### PR TITLE
fix: 修正ColPicker多列选择器v-model类型提示使用Record<string, any>[]实际上的数据是一维数组的问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-col-picker/wd-col-picker.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-col-picker/wd-col-picker.vue
@@ -101,7 +101,7 @@ interface Props {
   customViewClass?: string
   customLabelClass?: string
   customValueClass?: string
-  modelValue: Array<Record<string, any>>
+  modelValue: Array<string | number>
   columns: Array<Array<Record<string, any>>>
   label?: string
   labelWidth?: string
@@ -163,13 +163,13 @@ const props = withDefaults(defineProps<Props>(), {
 const pickerShow = ref<boolean>(false)
 const currentCol = ref<number>(0)
 const selectList = ref<Record<string, any>[]>([])
-const pickerColSelected = ref<Record<string, any>[]>([])
+const pickerColSelected = ref<(string | number)[]>([])
 const selectShowList = ref<Record<string, any>[]>([])
 const loading = ref<boolean>(false)
 const showValue = ref<string>('')
 const isChange = ref<boolean>(false)
 const lastSelectList = ref<Record<string, any>[]>([])
-const lastPickerColSelected = ref<Record<string, any>[]>([])
+const lastPickerColSelected = ref<(string | number)[]>([])
 const lineStyle = ref<string>('')
 const scrollLeft = ref<number>(0)
 const inited = ref<boolean>(false)


### PR DESCRIPTION
实际选中后v-model的值为一维数组
![image](https://github.com/Moonofweisheng/wot-design-uni/assets/14084550/c2a9f103-7f45-44ab-8aa3-5d990a7bc1bd)
![image](https://github.com/Moonofweisheng/wot-design-uni/assets/14084550/912cf119-4114-4490-9255-2e87cbf156f3)
