### PR TITLE
fix: 修正README.md 中[贡献指南]链接错误，跳转失败的问题。

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@
 
 ## 贡献指南
 
-修改代码请阅读我们的 [贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/develop/.github/CONTRIBUTING.md)。
+修改代码请阅读我们的 [贡献指南](./.github/CONTRIBUTING.md)。
 
 使用过程中发现任何问题都可以提 [Issue](https://github.com/Moonofweisheng/wot-design-uni/issues) 给我们，当然，我们也非常欢迎你给我们发 [PR](https://github.com/Moonofweisheng/wot-design-uni/pulls)。
 


### PR DESCRIPTION
修改之前：
![image](https://github.com/Moonofweisheng/wot-design-uni/assets/61174105/7ac7deed-9b72-4562-935c-341bb3c961c1)

修改之后:
使用相对路径。
![image](https://github.com/Moonofweisheng/wot-design-uni/assets/61174105/a98b0744-9802-46b6-bf7c-832d59ea800c)

