### PR TITLE
支持通过css变量自定义主色来定制主题

### DIFF
--- a/docs/component/button.md
+++ b/docs/component/button.md
@@ -31,6 +31,15 @@
 <wd-button plain>主要按钮</wd-button>
 ```
 
+## 细边框幽灵按钮
+
+设置 `hairline` 属性。
+
+```html
+<wd-button plain hairline>主要按钮</wd-button>
+```
+
+
 ## 按钮大小
 
 设置 `size` ，支持 'small'、'medium'、'large'，默认为 'medium'。
@@ -88,8 +97,8 @@
 | type | 按钮类型 |	string | primary / success / info / warning / error / text / icon |	primary | - |
 | round	| 圆角按钮 | boolean | - |	true | - |
 | plain | 幽灵按钮 | boolean | - | false | - |
+| hairline| 是否细边框 | boolean | - | false | - |
 | loading | 加载中按钮 | boolean | - | false | - |
-| suck | 吸顶按钮 | boolean | - | false | - |
 | block | 块状按钮 | boolean | - | false | - |
 | size | 按钮尺寸 | string | small / medium / large | medium | - |
 | disabled | 禁用按钮 | boolean | - | false | - |

--- a/src/pages/button/Index.vue
+++ b/src/pages/button/Index.vue
@@ -22,6 +22,13 @@
         <wd-button type="warning" plain>警告按钮</wd-button>
         <wd-button type="error" plain>危险按钮</wd-button>
       </demo-block>
+      <demo-block title="细边框幽灵按钮">
+        <wd-button plain hairline>主要按钮</wd-button>
+        <wd-button type="success" plain hairline>成功按钮</wd-button>
+        <wd-button type="info" plain hairline>信息按钮</wd-button>
+        <wd-button type="warning" plain hairline>警告按钮</wd-button>
+        <wd-button type="error" plain hairline>危险按钮</wd-button>
+      </demo-block>
       <demo-block title="幽灵按钮禁用状态">
         <wd-button plain disabled>主要按钮</wd-button>
         <wd-button type="success" plain disabled>成功按钮</wd-button>

--- a/src/uni_modules/wot-design-uni/components/common/abstracts/_mixin.scss
+++ b/src/uni_modules/wot-design-uni/components/common/abstracts/_mixin.scss
@@ -169,8 +169,9 @@
   }
 }
 
-/* 0.5px 边框 */
+/* 0.5px 边框 指定方向*/
 @mixin halfPixelBorder($direction: "bottom", $left: 0, $color: $-color-border-light) {
+  position: relative;
   &::after {
     position: absolute;
     display: block;
@@ -189,6 +190,26 @@
     }
     transform: scaleY(0.5);
     background: $color;
+  }
+}
+
+
+/* 0.5px 边框 环绕 */
+@mixin halfPixelBorderSurround($color: $-color-border-light) {
+  position: relative;
+  &::after {
+    position: absolute;
+    display: block;
+    content: ' ';
+    pointer-events: none;
+    width: 200%;
+    height: 200%;
+    left: 0;
+    top: 0;
+    border: 1px solid $color;
+    transform: scale(0.5);
+    box-sizing: border-box;
+    transform-origin: left top;
   }
 }
 @mixin buttonClear {

--- a/src/uni_modules/wot-design-uni/components/common/abstracts/variable.scss
+++ b/src/uni_modules/wot-design-uni/components/common/abstracts/variable.scss
@@ -182,7 +182,7 @@ $-button-normal-disabled-color: var(--wot-button-normal-disabled-color, rgba(0, 
 $-button-plain-bg-color: var(--wot-button-plain-bg-color, $-color-white) !default; // 幽灵按钮背景色
 
 $-button-primary-color: var(--wot-button-primary-color, $-color-white) !default; // 主要按钮颜色
-$-button-primary-bg-color: var(--wot-button-primary-bg-color,$-color-theme) !default; // 主要按钮背景颜色
+$-button-primary-bg-color: var(--wot-button-primary-bg-color, $-color-theme) !default; // 主要按钮背景颜色
 $-button-primary-box-shadow-color: var(--wot-button-primary-box-shadow-color, rgba($-color-theme, 0.25)) !default; // 主要按钮阴影颜色
 
 $-button-success-color: var(--wot-button-success-color, $-color-white) !default; // 成功按钮文字颜色
@@ -321,7 +321,7 @@ $-drop-menu-item-color-active: var(--wot-drop-menu-item-color-active, $-color-th
 $-drop-menu-item-color-tip: var(--wot-drop-menu-item-color-tip, rgba(0, 0, 0, 0.45)) !default; // 提示文字颜色
 $-drop-menu-item-fs-tip: var(--wot-drop-menu-item-fs-tip, $-fs-secondary) !default; // 提示文字字号
 $-drop-menu-option-check-size: var(--wot-drop-menu-option-check-size, 20px) !default; // check 图标大小
-$-drop-menu-line-color: var(--wot-drop-menu-line-color, resultColor($open-linear, 315deg, $-color-theme, "dark""light", rgba(81, 124, 240, 1) rgba(118, 158, 245, 1), 0% 100%)) !default; // 下划线颜色
+$-drop-menu-line-color: var(--wot-drop-menu-line-color, $-color-theme) !default; // 下划线颜色
 $-drop-menu-line-height: var(--wot-drop-menu-line-height, 3px) !default; // 下划线高度
 
 /* input-number */
@@ -465,7 +465,7 @@ $-picker-region-separator-color: var(--wot-picker-region-separator-color, rgba(0
 $-picker-cell-arrow-size-large: var(--wot-picker-cell-arrow-size-large, $-cell-icon-size) !default; // cell 类型的大尺寸 右侧icon尺寸
 
 $-picker-region-color: var(--wot-picker-region-color, rgba(0, 0, 0, 0.45)) !default; // 区域选择文字颜色
-$-picker-region-bg-active-color: var(--wot-picker-region-bg-active-color, resultColor($open-linear, 315deg, $-color-theme, "dark""light""light", rgba(79, 124, 248, 1) rgba(102, 141, 248, 1) rgba(102, 141, 248, 1), 0% 100% 100%)) !default; // 区域选择激活选中背景颜色
+$-picker-region-bg-active-color: var(--wot-picker-region-bg-active-color, $-color-theme) !default; // 区域选择激活选中背景颜色
 
 $-picker-region-fs: var(--wot-picker-region-fs, 14px) !default; // 区域选择文字字号
 
@@ -569,7 +569,7 @@ $-sort-button-fs: var(--wot-sort-button-fs, $-fs-content) !default; // 字号
 $-sort-button-color: var(--wot-sort-button-color, $-color-content) !default; // 颜色
 $-sort-button-height: var(--wot-sort-button-height, 48px) !default; // 高度
 $-sort-button-line-height: var(--wot-sort-button-line-height, 3px) !default; // 下划线高度
-$-sort-button-line-color: var(--wot-sort-button-line-color, resultColor($open-linear, 315deg, $-color-theme, "dark""light", rgba(81, 124, 240, 1) rgba(118, 158, 245, 1), 0% 100%)) !default; // 下划线颜色
+$-sort-button-line-color: var(--wot-sort-button-line-color, $-color-theme) !default; // 下划线颜色
 
 /* steps */
 $-steps-icon-size: var(--wot-steps-icon-size, 22px) !default; // 图标尺寸
@@ -592,7 +592,7 @@ $-switch-width: var(--wot-switch-width, calc(1.8em + 4px)) !default; // 宽度
 $-switch-height: var(--wot-switch-height, calc(1em + 4px)) !default; // 高度
 $-switch-circle-size: var(--wot-switch-circle-size, 1em) !default; // 圆点大小
 $-switch-border-color: var(--wot-switch-border-color, #e5e5e5) !default; // 边框颜色选中状态背景颜色
-$-switch-active-color: var(--wot-switch-active-color, resultColor($open-linear, 315deg, $-color-theme, "light""dark", #4f7cf8 #668df8, 0% 100%)) !default; // 选中状态背景
+$-switch-active-color: var(--wot-switch-active-color, $-color-theme) !default; // 选中状态背景
 $-switch-active-shadow-color: var(--wot-switch-active-shadow-color, rgba(0, 83, 162, 0.5)) !default; // 选中状态shadow颜色
 $-switch-inactive-color: var(--wot-switch-inactive-color, resultColor($open-linear, 315deg, #dadada, "light""dark""dark", #f2f2f2 #dadada #668df8, 0% 100% 100%)) !default; // 非选中背景颜色
 $-switch-inactive-shadow-color: var(--wot-switch-inactive-shadow-color, rgba(155, 155, 155, 0.5)) !default; // 非选中状态shadow颜色
@@ -609,7 +609,7 @@ $-tabs-nav-bg: var(--wot-tabs-nav-bg, $-color-white) !default; // 背景颜色
 $-tabs-nav-active-color: var(--wot-tabs-nav-active-color, $-color-theme) !default; // 头部高亮颜色
 $-tabs-nav-disabled-color: var(--wot-tabs-nav-disabled-color, rgba(0, 0, 0, 0.25)) !default; // 头部禁用颜色
 $-tabs-nav-line-height: var(--wot-tabs-nav-line-height, 3px) !default; // 高亮边框高度
-$-tabs-nav-line-bg-color: var(--wot-tabs-nav-line-bg-color, resultColor($open-linear, 315deg, $-color-theme, "dark""light", rgba(81, 124, 240, 1) rgba(118, 158, 245, 1), 0% 100%)) !default; // 底部条颜色
+$-tabs-nav-line-bg-color: var(--wot-tabs-nav-line-bg-color, $-color-theme) !default; // 底部条颜色
 $-tabs-nav-map-fs: var(--wot-tabs-nav-map-fs, $-fs-content) !default; // map 类型按钮字号
 $-tabs-nav-map-color: var(--wot-tabs-nav-map-color, rgba(0, 0, 0, 0.85)) !default; // map 类型按钮文字颜色
 $-tabs-nav-map-arrow-color: var(--wot-tabs-nav-map-arrow-color, rgba(0, 0, 0, 0.65)) !default; // map 类型箭头颜色
@@ -624,14 +624,14 @@ $-tag-color: var(--wot-tag-color, $-color-white) !default; // 字体颜色
 $-tag-small-fs: var(--wot-tag-small-fs, $-fs-aid) !default; // 小尺寸字号
 $-tag-info-color: var(--wot-tag-info-color, #585858) !default; // info 颜色
 $-tag-primary-color: var(--wot-tag-primary-color, $-color-theme) !default; // 主颜色
-$-tag-danger-color: var(--wot-tag-danger-color, rgba(250, 67, 80, 1)) !default; // danger 颜色
-$-tag-warning-color: var(--wot-tag-warning-color, rgba(255, 144, 0, 1)) !default; // warning 颜色
-$-tag-success-color: var(--wot-tag-success-color, rgba(51, 187, 68, 1)) !default; // success 颜色
+$-tag-danger-color: var(--wot-tag-danger-color, $-color-danger) !default; // danger 颜色
+$-tag-warning-color: var(--wot-tag-warning-color, $-color-warning) !default; // warning 颜色
+$-tag-success-color: var(--wot-tag-success-color, $-color-success) !default; // success 颜色
 $-tag-info-bg: var(--wot-tag-info-bg, resultColor($open-linear, 49deg, $-color-black, "dark""light", #808080 #999999, 0% 100%)) !default; // info 背景颜色
-$-tag-primary-bg: var(--wot-tag-primary-bg, resultColor($open-linear, 49deg, $-color-theme, "dark""light", rgba(81, 124, 240, 1) rgba(118, 158, 245, 1), 0% 100%)) !default; // 主背景颜色
-$-tag-danger-bg: var(--wot-tag-danger-bg, resultColor($open-linear, 44deg, $-color-danger, "dark""light", rgba(230, 62, 70, 1) rgba(255, 64, 73, 1), 0% 100%)) !default; // danger 背景颜色
-$-tag-warning-bg: var(--wot-tag-warning-bg, resultColor($open-linear, 45deg, $-color-warning, "dark""light", rgba(230, 113, 55, 1) rgba(255, 151, 76, 1), 0% 100%)) !default; // warning 背景颜色
-$-tag-success-bg: var(--wot-tag-success-bg, resultColor($open-linear, 45deg, $-color-success, "dark""light", rgba(32, 176, 128, 1) rgba(43, 214, 157, 1), 0% 100%)) !default; // success 背景颜色
+$-tag-primary-bg: var(--wot-tag-primary-bg, $-color-theme) !default; // 主背景颜色
+$-tag-danger-bg: var(--wot-tag-danger-bg, $-color-danger) !default; // danger 背景颜色
+$-tag-warning-bg: var(--wot-tag-warning-bg, $-color-warning) !default; // warning 背景颜色
+$-tag-success-bg: var(--wot-tag-success-bg, $-color-success) !default; // success 背景颜色
 $-tag-round-color: var(--wot-tag-round-color, rgba(102, 102, 102, 1)) !default; // round 字体颜色
 $-tag-round-border-color: var(--wot-tag-round-border-color, rgba(225, 225, 225, 1)) !default; // round 边框颜色
 $-tag-round-radius: var(--wot-tag-round-radius, 12px) !default; // round 圆角大小

--- a/src/uni_modules/wot-design-uni/components/common/abstracts/variable.scss
+++ b/src/uni_modules/wot-design-uni/components/common/abstracts/variable.scss
@@ -148,14 +148,16 @@ $-badge-dot-size: var(--wot-badge-dot-size, 6px) !default; // dot 类型大小
 $-badge-border: var(--wot-badge-border, 2px solid $-badge-color) !default; // 边框样式
 
 /* button */
+$-button-disabled-opacity: var(--wot-button-disabled-opacity, 0.6) !default; // button禁用透明度
+
 $-button-small-height: var(--wot-button-small-height, 28px) !default; // 小型按钮高度
-$-button-small-padding: var(--wot-button-small-padding, 0 11px) !default; // 小型按钮padding
+$-button-small-padding: var(--wot-button-small-padding, 0 12px) !default; // 小型按钮padding
 $-button-small-fs: var(--wot-button-small-fs, $-fs-secondary) !default; // 小型按钮字号
 $-button-small-radius: var(--wot-button-small-radius, 2px) !default; // 小型按钮圆角大小
 $-button-small-loading: var(--wot-button-small-loading, 14px) !default; // 小型按钮loading图标大小
 
 $-button-medium-height: var(--wot-button-medium-height, 36px) !default; // 中型按钮高度
-$-button-medium-padding: var(--wot-button-medium-padding, 0 15px) !default; // 中型按钮padding
+$-button-medium-padding: var(--wot-button-medium-padding, 0 16px) !default; // 中型按钮padding
 $-button-medium-fs: var(--wot-button-medium-fs, $-fs-content) !default; // 中型按钮字号
 $-button-medium-radius: var(--wot-button-medium-radius, 4px) !default; // 中型按钮圆角大小
 $-button-medium-loading: var(--wot-button-medium-loading, 18px) !default; // 中型按钮loading图标大小
@@ -174,55 +176,35 @@ $-button-icon-color: var(--wot-button-icon-color, rgba(0, 0, 0, 0.65)) !default;
 $-button-icon-active-color: var(--wot-button-icon-active-color, $-color-icon-active) !default; // icon 类型按钮点击态颜色
 $-button-icon-disabled-color: var(--wot-button-icon-disabled-color, $-color-icon-disabled) !default; // icon 类型按钮禁用颜色
 
-$-button-normal-bg: var(--wot-button-normal-bg, $-color-white) !default; // 默认按钮禁用背景色
 $-button-normal-color: var(--wot-button-normal-color, $-color-title) !default; // 文字颜色
-$-button-normal-active-color: var(--wot-button-normal-active-color, $-color-black) !default; // 文字点击态颜色
-$-button-normal-active-bg: var(--wot-button-normal-active-bg, $-color-bg) !default; // 默认按钮点击态背景色
-$-button-normal-border-active-color: var(--wot-button-normal-border-active-color, rgba(0, 0, 0, 0.45)) !default; // 默认按钮点击态边框色
 $-button-normal-disabled-color: var(--wot-button-normal-disabled-color, rgba(0, 0, 0, 0.25)) !default; // 默认按钮禁用文字色
-$-button-normal-disabled-bg: var(--wot-button-normal-disabled-bg, $-color-white) !default; // 默认按钮禁用背景色
-$-button-normal-border-disabled-color: var(--wot-button-normal-border-disabled-color, $-color-bg) !default; // 默认按钮禁用边框色
-$-button-border-color: var(--wot-button-border-color, #595959) !default; // 默认按钮边框色
 
-$-button-primary-color: var(--wot-button-primary-color, $-color-theme) !default; // 主要按钮颜色
-$-button-primary-bg-color: var(--wot-button-primary-bg-color, resultColor($open-linear, 315deg, $-color-theme, "dark""light", #4f7cf8 #668df8, 0% 100%)) !default; // 主要按钮背景颜色
-$-button-primary-active-color: var(--wot-button-primary-active-color, resultColor($open-linear, 315deg, #2c69ed, "dark""light", #416bdf #4e79ee, 0% 100%)) !default; // 主要按钮点击态颜色
-$-button-primary-plain-active-bg-color: var(--wot-button-primary-plain-active-bg-color, #eff4fe) !default; // 主要按钮点击态颜色
-$-button-primary-disabled-color: var(--wot-button-primary-disabled-color, resultColor($open-linear, 315deg, rgba($-color-theme, 0.6), "dark""light", #8FADFF #9FB8FE, 0% 100%)) !default; // 主要按钮禁用颜色
-$-button-primary-plain-disabled-color: var(--wot-button-primary-plain-disabled-color, themeColor($-color-theme, "light", #9DB9F6)) !default; // 主要按钮点击态文字颜色
+$-button-plain-bg-color: var(--wot-button-plain-bg-color, $-color-white) !default; // 幽灵按钮背景色
+
+$-button-primary-color: var(--wot-button-primary-color, $-color-white) !default; // 主要按钮颜色
+$-button-primary-bg-color: var(--wot-button-primary-bg-color,$-color-theme) !default; // 主要按钮背景颜色
 $-button-primary-box-shadow-color: var(--wot-button-primary-box-shadow-color, rgba($-color-theme, 0.25)) !default; // 主要按钮阴影颜色
 
-$-button-success-color: var(--wot-button-success-color, $-color-success) !default; // 成功按钮颜色
-$-button-success-active-color: var(--wot-button-success-active-color, #2bab81) !default; // 成功按钮点击态颜色
-$-button-success-disabled-color: var(--wot-button-success-disabled-color, #89e4c6) !default; // 成功按钮禁用颜色
+$-button-success-color: var(--wot-button-success-color, $-color-white) !default; // 成功按钮文字颜色
+$-button-success-bg-color: var(--wot-button-success-bg-color, $-color-success) !default; // 成功按钮颜色
 $-button-success-box-shadow-color: var(--wot-button-success-box-shadow-color, rgba($-color-success, 0.25)) !default; // 主要按钮阴影颜色
 
-$-button-info-bg-color: var(--wot-button-info-bg-color, #F0F0F0) !default; // 信息按钮背景颜色
 $-button-info-color: var(--wot-button-info-color, $-color-title) !default; // 信息按钮颜色
-$-button-info-active-bg-color: var(--wot-button-info-active-bg-color, #E1E1E1) !default; // 信息按钮背景颜色
-$-button-info-active-color: var(--wot-button-info-active-color, rgba(0, 0, 0, 0.85)) !default; // 信息按钮点击态颜色
-$-button-info-disabled-bg-color: var(--wot-button-info-disabled-bg-color, #F0F0F0) !default; // 信息按钮禁用颜色
-$-button-info-disabled-color: var(--wot-button-info-disabled-color, rgba(0, 0, 0, 0.09)) !default; // 信息按钮禁用颜色
+$-button-info-bg-color: var(--wot-button-info-bg-color, #F0F0F0) !default; // 信息按钮背景颜色
 
 $-button-info-plain-border-color: var(--wot-button-info-plain-border-color, rgba(0, 0, 0, 0.45)) !default; // 信息按钮禁用颜色
-$-button-info-plain-bg-color: var(--wot-button-info-plain-bg-color, $-color-white) !default; // 信息按钮禁用颜色
-$-button-info-plain-disabled-bg-color: var(--wot-button-info-plain-disabled-bg-color, #F0F0F0) !default; // 信息按钮禁用颜色
-$-button-info-plain-active-color: var(--wot-button-info-plain-active-color, rgba(0, 0, 0, 0.45)) !default; // 信息按钮点击态颜色
-$-button-info-plain-active-bg-color: var(--wot-button-info-plain-active-bg-color, #F0F0F0) !default; // 信息按钮禁用颜色
 $-button-info-plain-normal-color: var(--wot-button-info-plain-normal-color, rgba(0, 0, 0, 0.85)) !default; // 信息幽灵按钮默认颜色
 
-$-button-warning-color: var(--wot-button-warning-color, $-color-warning) !default; // 警告按钮颜色
-$-button-warning-active-color: var(--wot-button-warning-active-color, #c57030) !default; // 警告按钮点击颜色
-$-button-warning-disabled-color: var(--wot-button-warning-disabled-color, #f6ba8d) !default; // 警告按钮禁用颜色
+$-button-warning-color: var(--wot-button-warning-color, $-color-white) !default; // 警告按钮字体颜色
+$-button-warning-bg-color: var(--wot-button-warning-bg-color, $-color-warning) !default; // 警告按钮背景颜色
 $-button-warning-box-shadow-color: var(--wot-button-warning-box-shadow-color, rgba($-color-warning, 0.25)) !default; // 主要按钮阴影颜色
 
-$-button-error-color: var(--wot-button-error-color, $-color-danger) !default; // 错误按钮颜色
-$-button-error-active-color: var(--wot-button-error-active-color, #cd3742) !default; // 错误按钮点击颜色
-$-button-error-disabled-color: var(--wot-button-error-disabled-color, #fc929a) !default; // 错误按钮禁用颜色
+$-button-error-color: var(--wot-button-error-color, $-color-white) !default; // 错误按钮颜色
+$-button-error-bg-color: var(--wot-button-error-bg-color, $-color-danger) !default; // 错误按钮背景颜色
 $-button-error-box-shadow-color: var(--wot-button-error-box-shadow-color, rgba($-color-danger, 0.25)) !default; // 主要按钮阴影颜色
 
-$-button-suck-height: var(--wot-button-suck-height, 50px) !default; // suck 类型按钮高度
-$-button-suck-active-color: var(--wot-button-suck-active-color, $-button-primary-plain-active-bg-color) !default; // 错误按钮禁用颜色
+$-button-text-hover-opacity: var(--wot-button-text-hover-opacity, 0.7) !default; // 文字button激活时透明度
+
 
 /* cell */
 $-cell-padding: var(--wot-cell-padding, $-size-side-padding) !default; // cell 左右padding距离

--- a/src/uni_modules/wot-design-uni/components/wd-button/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-button/index.scss
@@ -1,117 +1,21 @@
 @import './../common/abstracts/_mixin.scss';
 @import './../common/abstracts/variable.scss';
 
-@mixin button-type-style($color, $normal, $active, $disabled, $disabledcolor) {
-  background: $normal;
-  color: $color;
-  font-weight: $-fw-medium;
-
-  &::after {
-    border-color: $normal;
-  }
-  &.wd-button--active {
-    background: $active;
-  }
-  @include when(disabled) {
-    &.wd-button--active {
-      background: $disabled;
-      color: $disabledcolor;
-    }
-
-    background: $disabled;
-    color: $disabledcolor;
-
-    &::after {
-      border-color: $disabled;
-    }
-  }
-  @include when(loading) {
-    &,
-    &.wd-button--active {
-      color: $color;
-      background: $normal;
-    }
-    &::after {
-      border-color: $normal;
-    }
-  }
-  @include when(suck) {
-    border-radius: 0;
-  }
-}
-
-@mixin button-plain-style($color, $normal, $active, $disabled) {
-  color: $color;
-  background: transparent;
-
-  &::after {
-    border-color: $normal;
-  }
-  &.wd-button--active {
-    color: $active;
-    background: transparent;
-
-    &::after {
-      border-color: $active;
-    }
-  }
-  @include when(disabled) {
-    color: $disabled;
-    background: transparent;
-
-    &::after {
-      border-color: $disabled;
-    }
-    &.wd-button--active {
-      background: transparent;
-
-      &::after {
-        border-color: $disabled;
-      }
-    }
-  }
-  @include when(loading) {
-    &,
-    &.wd-button--active {
-      color: $color;
-      background: transparent;
-
-      &::after {
-        border-color: $normal;
-      }
-    }
-  }
-}
 
 .wot-theme-dark {
   @include b(button) {
     @include when(info) {
-      @include button-type-style($-dark-color,
-        $-dark-background4,
-        $-dark-background5,
-        $-dark-background7,
-        $-dark-color3);
+      background: $-dark-background4;
+      color: $-dark-color3;
     }
 
     @include when(plain) {
+      background: transparent;
 
       @include when(info) {
-        @include button-plain-style($-dark-color, $-dark-background5, $-dark-color, $-dark-color-gray);
-      }
-
-      @include when(primary) {
-
-        &.wd-button--active {
-          background: transparent;
-          color: themeColor($-color-theme, "light", #9DB9F6);
-        }
-
-        @include when(disabled) {
-          background-color: transparent;
-
-          &.wd-button--active {
-            background-color: transparent;
-          }
+        color: $-dark-color;
+        &::after {
+          border-color: $-dark-background5;
         }
       }
     }
@@ -126,17 +30,9 @@
     @include when(icon) {
       color: $-dark-color;
 
-      &.wd-button--active {
-        background: $-dark-background4;
-      }
-
       @include when(disabled) {
         color: $-dark-color-gray;
         background: transparent;
-
-        &.wd-button--active {
-          background: transparent;
-        }
       }
 
     }
@@ -159,32 +55,30 @@
   user-select: none;
   font-weight: normal;
 
-  &::after {
-    display: none;
-  }
-  &.wd-button--active {
-    color: $-button-normal-active-color;
-    background: $-button-normal-active-bg;
 
-    &::after {
-      border-color: $-button-normal-border-active-color;
+  &::before {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 100%;
+    height: 100%;
+    background: $-color-black;
+    border: inherit;
+    border-color: $-color-black;
+    border-radius: inherit;
+    transform: translate(-50%, -50%);
+    opacity: 0;
+    content: ' ';
+  }
+
+  @include m(active) {
+    &:active::before {
+      opacity: 0.15;
     }
   }
+
   @include when(disabled) {
-    color: $-button-normal-disabled-color;
-    background: $-button-normal-disabled-bg;
-
-    &::after {
-      border-color: $-button-normal-border-disabled-color;
-    }
-    &.wd-button--active {
-      color: $-button-normal-disabled-color;
-      background: $-button-normal-disabled-bg;
-
-      &::after {
-        border-color: $-button-normal-border-disabled-color;
-      }
-    }
+    opacity: $-button-disabled-opacity;
   }
 
   @include e(loading) {
@@ -192,49 +86,39 @@
     animation: wd-rotate 0.8s linear infinite;
     animation-duration: 2s;
   }
+
   @include e(loading-svg) {
     width: 100%;
     height: 100%;
     background-size: cover;
     background-repeat: no-repeat;
   }
-  @include when(loading) {
-    &.wd-button--active {
-      color: $-button-normal-color;
-      background: transparent;
 
-      &::after {
-        border-color: $-button-border-color;
-      }
-    }
-  }
+  @include when(loading) {}
 
   @include when(primary) {
-    @include button-type-style(
-      $-color-white,
-      $-button-primary-bg-color,
-      $-button-primary-active-color,
-      $-button-primary-disabled-color,
-      $-color-white
-    );
+    background: $-button-primary-bg-color;
+    color: $-button-primary-color;
   }
+
   @include when(success) {
-    @include button-type-style($-color-white, $-button-success-color, $-button-success-active-color, $-button-success-disabled-color, $-color-white);
+    background: $-button-success-bg-color;
+    color: $-button-success-color;
   }
+
   @include when(info) {
-    @include button-type-style(
-      $-button-info-color,
-      $-button-info-bg-color,
-      $-button-info-active-bg-color,
-      $-button-info-disabled-bg-color,
-      $-button-info-disabled-color
-    );
+    background: $-button-info-bg-color;
+    color: $-button-info-color;
   }
+
   @include when(warning) {
-    @include button-type-style($-color-white, $-button-warning-color, $-button-warning-active-color, $-button-warning-disabled-color, $-color-white);
+    background: $-button-warning-bg-color;
+    color: $-button-warning-color;
   }
+
   @include when(error) {
-    @include button-type-style($-color-white, $-button-error-color, $-button-error-active-color, $-button-error-disabled-color, $-color-white);
+    background: $-button-error-bg-color;
+    color: $-button-error-color;
   }
 
   @include when(small) {
@@ -243,14 +127,6 @@
     border-radius: $-button-small-radius;
     font-size: $-button-small-fs;
     font-weight: normal;
-
-    @include when(round) {
-      border-radius: calc($-button-small-height / 2);
-
-      &::after {
-        border-radius: $-button-small-height;
-      }
-    }
 
     .wd-button__loading {
       width: $-button-small-loading;
@@ -264,9 +140,6 @@
     border-radius: $-button-medium-radius;
     font-size: $-button-medium-fs;
 
-    &::after {
-      border-radius: calc($-button-medium-radius * 2);
-    }
     @include when(primary) {
       box-shadow: $-button-medium-box-shadow-size $-button-primary-box-shadow-color;
     }
@@ -288,20 +161,16 @@
     }
 
     @include when(round) {
-      min-width: 118px;
-      border-radius: calc($-button-medium-height / 2);
+      min-width: 120px;
 
-      &::after {
-        border-radius: $-button-medium-height;
-      }
       @include when(icon) {
         min-width: 0;
         border-radius: 50%;
       }
 
       @include when(text) {
-        min-width: 0;
         border-radius: 0;
+        min-width: 0;
       }
     }
 
@@ -310,6 +179,7 @@
       height: $-button-medium-loading;
     }
   }
+
   @include when(large) {
     height: $-button-large-height;
     padding: $-button-large-padding;
@@ -317,8 +187,9 @@
     font-size: $-button-large-fs;
 
     &::after {
-      border-radius: calc($-button-large-radius * 2);
+      border-radius: $-button-large-radius;
     }
+
     &:not(.is-plain) {
       @include when(primary) {
         box-shadow: $-button-large-box-shadow-size $-button-primary-box-shadow-color;
@@ -337,36 +208,44 @@
       }
     }
 
-    @include when(round) {
-      border-radius: calc($-button-large-height / 2);
 
-      &::after {
-        border-radius: $-button-large-height;
-      }
-      @include when(icon) {
-        border-radius: 50%;
-      }
-      @include when(text) {
-        border-radius: 0;
-      }
-    }
     .wd-button__loading {
       width: $-button-large-loading;
       height: $-button-large-loading;
     }
   }
 
+
+  @include when(round) {
+    border-radius: 999px;
+
+    &::after {
+      border-radius: 999px;
+    }
+
+    &::before {
+      border-radius: 999px;
+    }
+  }
+
   @include when(text) {
-    color: $-button-primary-color;
+    color: $-button-primary-bg-color;
+    min-width: 0;
     padding: 4px 0;
 
     &::after {
       display: none;
     }
+
     &.wd-button--active {
-      color: $-button-primary-active-color;
-      background: transparent;
+      opacity: $-button-text-hover-opacity;
+
+      &:active::before {
+        display: none;
+      }
+
     }
+
     @include when(disabled) {
       color: $-button-normal-disabled-color;
       background: transparent;
@@ -374,93 +253,47 @@
   }
 
   @include when(plain) {
-    background: $-color-white;
+    background: $-button-plain-bg-color;
 
-    &::after {
-      position: absolute;
-      display: block;
-      content: '';
-      width: 200%;
-      height: 200%;
-      left: 0;
-      top: 0;
-      border: 1px solid $-button-border-color;
-      box-sizing: border-box;
-      transform: scale(0.5);
-      transform-origin: left top;
-    }
     @include when(primary) {
-      @include button-plain-style($-button-primary-color, $-button-primary-color, $-button-primary-active-color, $-button-primary-disabled-color);
-      &.wd-button--active {
-        background-color: $-button-primary-plain-active-bg-color;
-      }
-      @include when(disabled) {
-        &.wd-button--active {
-          background-color: $-button-primary-plain-active-bg-color;
-        }
-        opacity: 1;
-        background-color: $-button-primary-plain-active-bg-color;
-        color: $-button-primary-plain-disabled-color;
-      }
+      color: $-button-primary-bg-color;
+      border: 1px solid $-button-primary-bg-color;
     }
+
     @include when(success) {
-      @include button-plain-style($-button-success-color, $-button-success-color, $-button-success-active-color, $-button-success-disabled-color);
+      color: $-button-success-bg-color;
+      border: 1px solid $-button-success-bg-color;
     }
+
     @include when(info) {
-      @include button-plain-style($-button-info-plain-normal-color, $-button-info-bg-color, $-button-info-active-color, $-button-info-disabled-color);
-      &::after {
-        border-color: $-button-info-plain-border-color;
-      }
-      &.wd-button--active {
-        background-color: $-button-info-plain-active-bg-color;
-
-        &::after {
-          border-color: $-button-info-plain-active-color;
-        }
-      }
-      @include when(disabled) {
-        &,
-        &.wd-button--active {
-          background-color: $-button-info-plain-disabled-bg-color;
-
-          &::after {
-            border-color: $-button-info-plain-disabled-bg-color;
-          }
-        }
-      }
-      @include when(loading) {
-        &::after,
-        &.wd-button--active::after {
-          border-color: $-button-info-plain-border-color;
-        }
-      }
+      color: $-button-info-plain-normal-color;
+      border: 1px solid $-button-info-plain-border-color;
     }
+
     @include when(warning) {
-      @include button-plain-style($-button-warning-color, $-button-warning-color, $-button-warning-active-color, $-button-warning-disabled-color);
+      color: $-button-warning-bg-color;
+      border: 1px solid $-button-warning-bg-color;
     }
+
     @include when(error) {
-      @include button-plain-style($-button-error-color, $-button-error-color, $-button-error-active-color, $-button-error-disabled-color);
-    }
-    @include when(suck) {
-      &.wd-button--active {
-        background: $-button-suck-active-color;
-      }
-      @include when(disabled) {
-        background: $-color-white;
-      }
+      color: $-button-error-bg-color;
+      border: 1px solid $-button-error-bg-color;
     }
   }
 
-  @include when(suck) {
-    display: flex;
-    font-size: $-button-large-fs;
-    height: $-button-suck-height;
-    border-radius: 0;
+  @include when(hairline) {
+    &.is-plain {
+      border-width: 0;
+      border-radius: 0;
+      @include halfPixelBorderSurround();
 
-    &::after {
-      display: none;
+      &::after {
+        border-color: inherit;
+      }
     }
+
   }
+
 
   @include when(block) {
     display: flex;
@@ -477,19 +310,14 @@
     &::after {
       display: none;
     }
-    &.wd-button--active {
-      background: $-button-icon-active-color;
-    }
-    :deep(.wd-button__icon){
+
+    :deep(.wd-button__icon) {
       margin-right: 0;
     }
+
     @include when(disabled) {
       color: $-button-icon-disabled-color;
       background: transparent;
-
-      &.wd-button--active {
-        background: transparent;
-      }
     }
   }
 
@@ -505,11 +333,13 @@
     white-space: nowrap;
   }
 }
+
 // 微信2.8.0以上版本加了较高层级的默认样式，需要重置掉
 .wd-button {
   min-height: auto;
   width: auto;
 }
+
 @keyframes wd-rotate {
   from {
     transform: rotate(0deg);

--- a/src/uni_modules/wot-design-uni/components/wd-button/wd-button.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-button/wd-button.vue
@@ -1,6 +1,6 @@
 <template>
   <button
-    hover-class="wd-button--active"
+    :hover-class="`${disabled || loading ? '' : 'wd-button--active'}`"
     :style="customStyle"
     :class="[
       'wd-button',
@@ -9,7 +9,7 @@
       plain ? 'is-plain' : '',
       disabled ? 'is-disabled' : '',
       round ? 'is-round' : '',
-      suck ? 'is-suck' : '',
+      hairline ? 'is-hairline' : '',
       block ? 'is-block' : '',
       loading ? 'is-loading' : '',
       customClass
@@ -74,7 +74,7 @@ interface Props {
   plain?: boolean
   disabled?: boolean
   round?: boolean
-  suck?: boolean
+  hairline?: boolean
   block?: boolean
   type?: ButtonType
   size?: ButtonSize
@@ -100,7 +100,7 @@ const props = withDefaults(defineProps<Props>(), {
   round: true,
   plain: false,
   loading: false,
-  suck: false,
+  hairline: false,
   block: false,
   disabled: false,
   customClass: '',


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
解决button、tabs等组件使用基于主色生成的渐变色作为背景色，此时不支持通过css变量实现主题的定制的问题。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充