### PR TITLE
fix: 🐛 适配微信小程序css样式选择器命名规范（wd-img）

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-img/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-img/index.scss
@@ -5,7 +5,7 @@
   position: relative;
   display: inline-block;
 
-  .image {
+  .wd-img__image {
     display: block;
     width: 100%;
     height: 100%;

--- a/src/uni_modules/wot-design-uni/components/wd-img/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-img/index.scss
@@ -5,7 +5,7 @@
   position: relative;
   display: inline-block;
 
-  image {
+  .image {
     display: block;
     width: 100%;
     height: 100%;

--- a/src/uni_modules/wot-design-uni/components/wd-img/wd-img.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-img/wd-img.vue
@@ -9,7 +9,7 @@
 -->
 <template>
   <view :class="rootClass" @click="handleClick" :style="rootStyle">
-    <image :class="customImage" class="image" :src="src" :mode="mode" :lazy-load="lazyLoad" @load="handleLoad" @error="handleError" />
+    <image :class="`wd-img__image ${customImage}`" :src="src" :mode="mode" :lazy-load="lazyLoad" @load="handleLoad" @error="handleError" />
   </view>
 </template>
 <script lang="ts">

--- a/src/uni_modules/wot-design-uni/components/wd-img/wd-img.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-img/wd-img.vue
@@ -9,7 +9,7 @@
 -->
 <template>
   <view :class="rootClass" @click="handleClick" :style="rootStyle">
-    <image :class="customImage" :src="src" :mode="mode" :lazy-load="lazyLoad" @load="handleLoad" @error="handleError" />
+    <image :class="customImage" class="image" :src="src" :mode="mode" :lazy-load="lazyLoad" @load="handleLoad" @error="handleError" />
   </view>
 </template>
 <script lang="ts">


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充