### PR TITLE
feat: ✨ SelectPicker单选支持确认按钮可隐藏

### DIFF
--- a/docs/component/select-picker.md
+++ b/docs/component/select-picker.md
@@ -341,6 +341,7 @@ function handleConfirm({ value, selectedItems }) {
 | filter-placeholder     | 搜索框占位符                                                                                             | string                            | -                | 搜索     | -    |
 | ellipsis               | 是否超出隐藏                                                                                             | boolean                           | -                | false    | -    |
 | scroll-into-view       | 重新打开是否滚动到选中项                                                                                 | boolean                           | -                | true    | 0.1.34    |
+| show-confirm-btn | 确认按钮是否显示（单选生效） | boolean |  | true | 1.2.7 |
 | prop | 表单域 `model` 字段名，在使用表单校验功能的情况下，该属性是必填的 | string | - | - | - |
 | rules | 表单验证规则，结合`wd-form`组件使用	 | `FormItemRule []`	 | - | `[]` | - |
 

--- a/src/pages/selectPicker/Index.vue
+++ b/src/pages/selectPicker/Index.vue
@@ -17,6 +17,14 @@
         <wd-select-picker label="必填" required v-model="value12" :columns="columns1" @confirm="handleConfirm12" />
         <wd-select-picker label="可搜索" filterable v-model="value13" :columns="columns1" @confirm="handleConfirm13" />
         <wd-select-picker label="单选可搜索" filterable v-model="value18" type="radio" :columns="columns1" @confirm="handleConfirm13" />
+        <wd-select-picker
+          label="单选取消确认按钮"
+          type="radio"
+          :show-confirm-btn="false"
+          v-model="value19"
+          :columns="columns1"
+          @confirm="handleConfirm2"
+        />
       </wd-cell-group>
     </view>
     <demo-block title="label不传" transparent>
@@ -126,6 +134,7 @@ const value15 = ref<string[]>(['101'])
 const value16 = ref<string[]>(['103'])
 const value17 = ref<string[]>(['102'])
 const value18 = ref<string>('102')
+const value19 = ref<string>('101')
 
 const customShow = ref<string>('奢侈品')
 

--- a/src/uni_modules/wot-design-uni/components/wd-select-picker/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-select-picker/types.ts
@@ -81,7 +81,9 @@ export const selectPickerProps = {
   /** 自定义标签样式类 */
   customLabelClass: makeStringProp(''),
   /** 自定义值样式类 */
-  customValueClass: makeStringProp('')
+  customValueClass: makeStringProp(''),
+  /** 确认按钮是否显示（单选才生效） */
+  showConfirmBtn: makeBooleanProp(true)
 }
 export type SelectPickerProps = ExtractPropTypes<typeof selectPickerProps>
 

--- a/src/uni_modules/wot-design-uni/components/wd-select-picker/wd-select-picker.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-select-picker/wd-select-picker.vue
@@ -97,7 +97,7 @@
         </view>
       </scroll-view>
       <!-- 确认按钮 -->
-      <view class="wd-select-picker__footer">
+      <view v-if="showConfirmBtn" class="wd-select-picker__footer">
         <wd-button block size="large" @click="onConfirm" :disabled="loading">{{ confirmButtonText || translate('confirm') }}</wd-button>
       </view>
     </wd-action-sheet>
@@ -319,6 +319,9 @@ function valueFormat(value: string | number | boolean | (string | number | boole
 function handleChange({ value }: { value: string | number | boolean | (string | number | boolean)[] }) {
   selectList.value = value
   emit('change', { value })
+  if (props.type === 'radio' && !props.showConfirmBtn) {
+    onConfirm()
+  }
 }
 
 function close() {
@@ -411,6 +414,10 @@ function formatFilterColumns(columns: Record<string, any>[], filterVal: string) 
     filterColumns.value = formatFilterColumns
   })
 }
+
+const showConfirmBtn = computed(() => {
+  return (props.type === 'radio' && props.showConfirmBtn) || props.type === 'checkbox'
+})
 
 defineExpose<SelectPickerExpose>({
   close,


### PR DESCRIPTION
✅ Closes: #206

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充