### PR TITLE
fix: 🐛 修复search组件suffix插槽无法使用的问题

### DIFF
--- a/docs/component/search.md
+++ b/docs/component/search.md
@@ -156,19 +156,19 @@ function changeSearchType({ item, index }) {
 
 ## Attributes
 
-| 参数             | 说明                                  | 类型            | 可选值 | 默认值 | 最低版本 |
-| ---------------- | ------------------------------------- | --------------- | ------ | ------ | -------- |
-| placeholder      | 搜索框占位文本                        | string          | -      | 搜索   | -        |
-| placeholder-left | placeholder 居左边                    | boolean         | -      | false  | -        |
-| cancel-txt       | 搜索框右侧文本                        | string          | -      | 取消   | -        |
-| light            | 搜索框亮色（白色）                    | boolean         | -      | false  | -        |
-| hide-cancel      | 是否隐藏右侧文本                      | boolean         | -      | false  | -        |
-| disabled         | 是否禁用搜索框                        | boolean         | -      | false  | -        |
-| maxlength        | 原生属性，设置最大长度。-1 表示无限制 | string / number | -      | -1     | -        |
-| v-model          | 输入框内容，双向绑定                  | string          | -      | -      | -        |
-| use-suffix-slot  | 是否使用输入框右侧插槽                | boolean         | -      | false  | -        |
-| focus            | 是否自动聚焦                      | boolean         | -      | false  | 0.1.63        |
-| focusWhenClear   | 是否在点击清除按钮时聚焦输入框       | boolean         | -      | false  | 0.1.63        |
+| 参数                | 说明                                                                                      | 类型            | 可选值 | 默认值 | 最低版本 |
+| ------------------- | ----------------------------------------------------------------------------------------- | --------------- | ------ | ------ | -------- |
+| placeholder         | 搜索框占位文本                                                                            | string          | -      | 搜索   | -        |
+| placeholder-left    | placeholder 居左边                                                                        | boolean         | -      | false  | -        |
+| cancel-txt          | 搜索框右侧文本                                                                            | string          | -      | 取消   | -        |
+| light               | 搜索框亮色（白色）                                                                        | boolean         | -      | false  | -        |
+| hide-cancel         | 是否隐藏右侧文本                                                                          | boolean         | -      | false  | -        |
+| disabled            | 是否禁用搜索框                                                                            | boolean         | -      | false  | -        |
+| maxlength           | 原生属性，设置最大长度。-1 表示无限制                                                     | string / number | -      | -1     | -        |
+| v-model             | 输入框内容，双向绑定                                                                      | string          | -      | -      | -        |
+| ~~use-suffix-slot~~ | ~~是否使用输入框右侧插槽~~**（已废弃，将在下一个 minor 版本被移除，直接使用插槽即可）** | boolean         | -      | false  | -        |
+| focus               | 是否自动聚焦                                                                              | boolean         | -      | false  | 0.1.63   |
+| focusWhenClear      | 是否在点击清除按钮时聚焦输入框                                                            | boolean         | -      | false  | 0.1.63   |
 
 ## Events
 
@@ -186,7 +186,7 @@ function changeSearchType({ item, index }) {
 | name   | 说明                 | 最低版本 |
 | ------ | -------------------- | -------- |
 | prefix | 输入框左侧自定义内容 | -        |
-| suffix | 输入框左侧自定义内容 | -        |
+| suffix | 输入框右侧自定义内容 | -        |
 
 ## 外部样式类
 

--- a/docs/component/swiper.md
+++ b/docs/component/swiper.md
@@ -184,12 +184,33 @@ function onChange(e) {
 }
 ```
 
+## 属性控制切换
+```html
+<wd-swiper :loop="isLoop" :autoplay="false" :list="swiperList" v-model:current="current" />
+<wd-gap />
+<wd-cell-group>
+  <wd-cell title="loop">
+    <wd-switch v-model="isLoop" size="24px" />
+  </wd-cell>
+  <wd-cell title="current" :value="current.toString()" />
+</wd-cell-group>
+<view style="display: flex; justify-content: space-between">
+  <wd-button @click="current--">prev</wd-button>
+  <wd-button type="success" @click="current++">next</wd-button>
+</view>
+```
+
+```javascript
+const current = ref<number>(0)
+const isLoop = ref(false)
+```
+
 ## Attributes
 
 | 参数                 | 说明                                                   | 类型                      | 可选值      | 默认值     | 最低版本 |
 | -------------------- | ------------------------------------------------------ | ------------------------- | ---------- | ---------- | -------- |
 | autoplay             | 是否自动播放                                           | `boolean`                   | -          | true       | 0.1.22   |
-| current              | 当前轮播在哪一项（下标）                               | `number`                    | -          | 0          | 0.1.22   |
+| v-model:current      | 控制当前轮播在哪一项（下标）                               | `number`                    | -          | 0          | 0.1.22   |
 | direction            | 轮播滑动方向                                           | `DirectionType`             | `horizontal, vertical`     | horizontal | 0.1.22   |
 | displayMultipleItems | 同时显示的滑块数量                                     | `number`                    | -          | 1          | 0.1.22   |
 | duration             | 滑动动画时长                                           | `number`                    | -          | 300        | 0.1.22   |
@@ -226,7 +247,7 @@ function onChange(e) {
 ### SwiperIndicatorProps
 
 | 参数                | 说明                       | 类型                   | 可选值                                                                   | 默认值     | 最低版本 |
-| ------------------- | -------------------------- | ---------------------- | ------------------------------------------------------------------------ | ---------- | -------- | 
+| ------------------- | -------------------------- | ---------------------- | ------------------------------------------------------------------------ | ---------- | -------- |
 | current             | 当前轮播在哪一项（下标）   | Number                 | -                                                                        | 0          | 0.1.22   |
 | direction           | 轮播滑动方向               | DirectionType          | `horizontal, vertical`                                                   | horizontal | 0.1.22   |
 | min-show-num        | 小于这个数字不会显示导航器 | Number                 | -                                                                        | 2          | 0.1.22   |
@@ -234,7 +255,7 @@ function onChange(e) {
 | show-controls       | 是否显示控制按钮           | Boolean                | -                                                                        | false      | 0.1.22   |
 | total               | 总共的项数                 | Number                 | -                                                                        | 0          | 0.1.22   |
 | type                | 导航器类型                 | SwiperIndicatorType   | `dots, dots-bar, fraction `                                        | dots       | 0.1.22   |
-| autoplay            | 是否自动播放               | boolean                | -                                                                        | true       | 0.1.22   | 
+| autoplay            | 是否自动播放               | boolean                | -                                                                        | true       | 0.1.22   |
 
 ## Events
 

--- a/src/pages/swiper/Index.vue
+++ b/src/pages/swiper/Index.vue
@@ -87,6 +87,22 @@
         </template>
       </wd-swiper>
     </demo-block>
+
+    <demo-block title="属性控制切换">
+      <wd-swiper :loop="isLoop" :autoplay="false" :list="swiperList" v-model:current="current" />
+      <wd-gap />
+      <wd-cell-group>
+        <wd-cell title="loop">
+          <wd-switch v-model="isLoop" size="24px" />
+        </wd-cell>
+        <wd-cell title="current" :value="current.toString()" />
+      </wd-cell-group>
+      <view style="display: flex; justify-content: space-between">
+        <wd-button @click="current--">prev</wd-button>
+
+        <wd-button type="success" @click="current++">next</wd-button>
+      </view>
+    </demo-block>
   </page-wraper>
 </template>
 <script lang="ts" setup>
@@ -99,6 +115,10 @@ const swiperList = ref([
   'https://img.yzcdn.cn/vant/cat.jpeg',
   'https://unpkg.com/wot-design-uni-assets/meng.jpg'
 ])
+
+const current = ref<number>(0)
+const isLoop = ref(false)
+
 function handleClick(e: any) {
   console.log(e)
 }

--- a/src/uni_modules/wot-design-uni/components/wd-search/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-search/types.ts
@@ -14,8 +14,9 @@ export const searchProps = {
    * 是否使用输入框右侧插槽
    * 类型: boolean
    * 默认值: false
+   * @deprecated 该属性已废弃，将在下一个minor版本被移除，直接使用插槽即可
    */
-  userSuffixSlot: makeBooleanProp(false),
+  useSuffixSlot: makeBooleanProp(false),
 
   /**
    * 搜索框占位文本

--- a/src/uni_modules/wot-design-uni/components/wd-search/wd-search.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-search/wd-search.vue
@@ -32,14 +32,13 @@
       </view>
     </view>
     <!--the button behind input,care for hideCancel without displaying-->
-    <block v-if="!hideCancel">
-      <!--有插槽就不用默认的按钮了-->
-      <slot v-if="userSuffixSlot" name="suffix"></slot>
+
+    <slot v-if="!hideCancel" name="suffix">
       <!--默认button-->
-      <view v-else class="wd-search__cancel" @click="handleCancel">
+      <view class="wd-search__cancel" @click="handleCancel">
         {{ cancelTxt || translate('cancel') }}
       </view>
-    </block>
+    </slot>
   </view>
 </template>
 

--- a/src/uni_modules/wot-design-uni/components/wd-swiper/wd-swiper.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-swiper/wd-swiper.vue
@@ -46,17 +46,29 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, onBeforeMount, ref } from 'vue'
+import { computed, watch, ref } from 'vue'
 import { addUnit, isObj } from '../common/util'
 import { swiperProps, type SwiperList } from './types'
 import type { SwiperNavProps } from '../wd-swiper-nav/types'
 
+const emit = defineEmits(['click', 'change', 'animationfinish', 'update:current'])
 const props = defineProps(swiperProps)
 const navCurrent = ref<number>(0) // 当前滑块
 
-onBeforeMount(() => {
-  navCurrent.value = props.current
-})
+watch(
+  () => props.current,
+  (val) => {
+    if (val < 0) {
+      props.loop ? goToEnd() : goToStart()
+    } else if (val >= props.list.length) {
+      props.loop ? goToStart() : goToEnd()
+    } else {
+      go(val)
+    }
+    emit('update:current', navCurrent.value)
+  },
+  { immediate: true }
+)
 
 const swiperIndicator = computed(() => {
   const { list, direction, indicatorPosition, indicator } = props
@@ -74,7 +86,17 @@ const swiperIndicator = computed(() => {
   return swiperIndicator
 })
 
-const emit = defineEmits(['click', 'change', 'animationfinish'])
+function go(index: number) {
+  navCurrent.value = index
+}
+
+function goToStart() {
+  navCurrent.value = 0
+}
+
+function goToEnd() {
+  navCurrent.value = props.list.length - 1
+}
 
 /**
  * 是否为当前滑块的前一个滑块


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x ] 日常 bug 修复
- [ ] 新特性提交
- [x ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [x ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [x] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
无

### 💡 需求背景和解决方案
本次修复Search组件的suffix插槽无法使用的问题，且use-suffix-slot属性是多余的，已标记为@deprecated，下一个中版本将移除该属性

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ x] 文档已补充或无须补充
- [ x] 代码演示已提供或无须提供
- [ x] TypeScript 定义已补充或无须补充