### PR TITLE
feat: ✨ img组件的mode属性增加类型`ImageMode`

### DIFF
--- a/docs/component/img.md
+++ b/docs/component/img.md
@@ -78,7 +78,7 @@ mode为小程序原生属性，参考[微信小程序image官方文档](https://
 | src | 图片链接 | string | - | - | - |
 | width | 宽度，默认单位为px | number / string | - | - | - |
 | height | 高度，默认单位为px | number / string | - | - | - |
-| mode | 填充模式 | string | 'top left' / 'top right' / 'bottom left' / 'bottom right' / 'right' / 'left' / 'center' / 'bottom' / 'top' / 'heightFix' / 'widthFix' / 'aspectFill' / 'aspectFit' / 'scaleToFill' | 'scaleToFill' | - |
+| mode | 填充模式 | ImageMode | 'top left' / 'top right' / 'bottom left' / 'bottom right' / 'right' / 'left' / 'center' / 'bottom' / 'top' / 'heightFix' / 'widthFix' / 'aspectFill' / 'aspectFit' / 'scaleToFill' | 'scaleToFill' | - |
 | round | 是否显示为圆形 | boolean | - | false | - |
 | radius | 圆角大小，默认单位为px | number / string | - | - | - |
 | enable-preview | 是否支持点击预览 | boolean | - | false | - |

--- a/src/pages/img/Index.vue
+++ b/src/pages/img/Index.vue
@@ -41,7 +41,9 @@
 <script lang="ts" setup>
 import { joy } from '../images/joy'
 import img from '../images/jd.png'
-const modes = [
+import type { ImageMode } from '@/uni_modules/wot-design-uni/components/wd-img/types'
+
+const modes: ImageMode[] = [
   'top left',
   'top right',
   'bottom left',

--- a/src/uni_modules/wot-design-uni/components/wd-img/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-img/types.ts
@@ -1,4 +1,19 @@
 import { baseProps, makeBooleanProp, makeStringProp, numericProp } from '../common/props'
+export type ImageMode =
+  | 'scaleToFill'
+  | 'aspectFit'
+  | 'aspectFill'
+  | 'widthFix'
+  | 'heightFix'
+  | 'top'
+  | 'bottom'
+  | 'center'
+  | 'left'
+  | 'right'
+  | 'top left'
+  | 'top right'
+  | 'bottom left'
+  | 'bottom right'
 
 export const imgProps = {
   ...baseProps,
@@ -14,7 +29,7 @@ export const imgProps = {
   /**
    * 填充模式：'top left' / 'top right' / 'bottom left' / 'bottom right' / 'right' / 'left' / 'center' / 'bottom' / 'top' / 'heightFix' / 'widthFix' / 'aspectFill' / 'aspectFit' / 'scaleToFill'
    */
-  mode: makeStringProp('scaleToFill'),
+  mode: makeStringProp<ImageMode>('scaleToFill'),
   /**
    * 是否懒加载
    */


### PR DESCRIPTION
mode有了类型后就不需要再去赋值mode了，直接类型提示+回车

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] TypeScript 定义更新



### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充