### PR TITLE
fix: 修复 step 的 description 插槽不显示的bug

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-step/wd-step.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-step/wd-step.vue
@@ -25,7 +25,7 @@
         <text v-else>{{ currentTitle }}</text>
       </view>
       <view v-if="$slots.description || description" class="wd-step__description">
-        <slot v-if="$slots.description" />
+        <slot v-if="$slots.description" name="description"/>
         <text v-else>{{ description }}</text>
       </view>
     </view>


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

无

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

step 组件的 description 插槽设置了 v-if=“$slots.description” 但未设置 name，导致不显示。

解决方案：增加 name=“description ” 属性

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充