### PR TITLE
fix: 修正upload组件使用自定义插槽时上传文件数量达到limit值后不自动隐藏上传按钮的问题，以及增加支持插槽外部容器的样式自定义

### DIFF
--- a/src/pages/upload/Index.vue
+++ b/src/pages/upload/Index.vue
@@ -37,7 +37,7 @@
       <wd-upload :file-list="fileList8" disabled :action="action" @change="handleChange8"></wd-upload>
     </demo-block>
     <demo-block title="自定义唤起上传样式">
-      <wd-upload :file-list="fileList9" :action="action" @change="handleChange9" use-default-slot>
+      <wd-upload :file-list="fileList9" :action="action" @change="handleChange9" :limit="1" use-default-slot>
         <wd-button>自定义唤起样式</wd-button>
       </wd-upload>
     </demo-block>

--- a/src/uni_modules/wot-design-uni/components/wd-upload/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-upload/types.ts
@@ -224,6 +224,7 @@ export const uploadProps = {
    */
   loadingSize: makeStringProp('24px'),
   customEvokeClass: makeStringProp(''),
+  customEvokeWrapperClass: makeStringProp(''),
   customPreviewClass: makeStringProp(''),
   /**
    * 预览图片的mode属性

--- a/src/uni_modules/wot-design-uni/components/wd-upload/wd-upload.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-upload/wd-upload.vue
@@ -23,7 +23,7 @@
       <wd-icon v-if="file.status !== 'loading' && !disabled" name="error-fill" custom-class="wd-upload__close" @click="removeFile(index)"></wd-icon>
     </view>
 
-    <view v-if="canUploadMoreFiles" @click="handleChoose">
+    <view v-if="canUploadMoreFiles" :class="['wd-upload__evoke-wrapper', customEvokeWrapperClass]" @click="handleChoose">
       <slot v-if="useDefaultSlot"></slot>
       <!-- 唤起项 -->
       <view v-if="!useDefaultSlot" :class="['wd-upload__evoke', disabled ? 'is-disabled' : '', customEvokeClass]">

--- a/src/uni_modules/wot-design-uni/components/wd-upload/wd-upload.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-upload/wd-upload.vue
@@ -23,13 +23,10 @@
       <wd-icon v-if="file.status !== 'loading' && !disabled" name="error-fill" custom-class="wd-upload__close" @click="removeFile(index)"></wd-icon>
     </view>
 
-    <view @click="handleChoose">
+    <view v-if="canUploadMoreFiles" @click="handleChoose">
       <slot v-if="useDefaultSlot"></slot>
       <!-- 唤起项 -->
-      <view
-        v-if="!useDefaultSlot && (!limit || uploadFiles.length < limit)"
-        :class="['wd-upload__evoke', disabled ? 'is-disabled' : '', customEvokeClass]"
-      >
+      <view v-if="!useDefaultSlot" :class="['wd-upload__evoke', disabled ? 'is-disabled' : '', customEvokeClass]">
         <!-- 唤起项图标 -->
         <wd-icon class="wd-upload__evoke-icon" name="fill-camera"></wd-icon>
         <!-- 有限制个数时确认是否展示限制个数 -->
@@ -51,7 +48,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { context, getType, isDef, isEqual, isFunction } from '../common/util'
 import { chooseFile } from './utils'
 import { useTranslate } from '../composables/useTranslate'
@@ -63,6 +60,8 @@ const emit = defineEmits(['fail', 'change', 'success', 'progress', 'oversize', '
 const { translate } = useTranslate('upload')
 
 const uploadFiles = ref<UploadFileItem[]>([])
+
+const canUploadMoreFiles = computed(() => !props.limit || uploadFiles.value.length < props.limit)
 
 watch(
   () => props.fileList,


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

### 💡 需求背景和解决方案

#### 问题一
在使用 wd-upload 组件的自定义插槽功能(use-default-slot)时，设置 limit 属性不生效，即上传文件的数量达到 limit 值后依旧显示上传按钮。

解决方案：将 limit 触发隐藏的逻辑提取到父组件，使得自定义插槽和默认内容都可隐藏
```js
const canUploadMoreFiles = computed(() => !props.limit || uploadFiles.value.length < props.limit)
```
```html
    <view v-if="canUploadMoreFiles" @click="handleChoose">
      <!-- 插槽内容 -->
      <slot v-if="useDefaultSlot"></slot>
      <!-- 唤起项 -->
      <view v-if="!useDefaultSlot" :class="['wd-upload__evoke', disabled ? 'is-disabled' : '', customEvokeClass]">
       ....默认内容
      </view>
    </view>
```

#### 问题二
wd-upload 组件的自定义插槽外部包裹了一个 view 用于监听点击事件的，但是这个 view 没有定义类名和支持自定义 class 的属性，因此在使用组件的时候没办法完全控制自定义插槽的父元素的宽度和高度等。

解决方案：增加 customEvokeWrapperClass 属性，用于自定义自定义插槽外层元素的类样式


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充