### PR TITLE
fix: 🐛 修复Button不同尺寸显示固定尺寸icon样式不协调的问题

### DIFF
--- a/src/pages/button/Index.vue
+++ b/src/pages/button/Index.vue
@@ -60,6 +60,10 @@
       <demo-block title="带图标的基本按钮">
         <wd-button icon="download">下载</wd-button>
         <wd-button icon="setting">设置</wd-button>
+        <wd-button icon="download" size="small">下载</wd-button>
+        <wd-button icon="setting" size="small">设置</wd-button>
+        <wd-button icon="download" size="large">下载</wd-button>
+        <wd-button icon="setting" size="large">设置</wd-button>
       </demo-block>
       <demo-block title="块状按钮，宽度100%">
         <wd-button block size="large">主要按钮</wd-button>

--- a/src/uni_modules/wot-design-uni/components/common/abstracts/variable.scss
+++ b/src/uni_modules/wot-design-uni/components/common/abstracts/variable.scss
@@ -152,7 +152,7 @@ $-button-large-radius: var(--wot-button-large-radius, 8px) !default; // 大型�
 $-button-large-loading: var(--wot-button-large-loading, 24px) !default; // 大小按钮loading图标大小
 $-button-large-box-shadow-size: var(--wot-button-large-box-shadow-size, 0px 4px 8px 0px) !default; // 大尺寸阴影尺寸
 
-$-button-icon-fs: var(--wot-button-icon-fs, 18px) !default; // 带图标的按钮的图标大小
+$-button-icon-fs: var(--wot-button-icon-fs, 1.18em) !default; // 带图标的按钮的图标大小
 $-button-icon-size: var(--wot-button-icon-size, 40px) !default; // icon 类型按钮尺寸
 $-button-icon-color: var(--wot-button-icon-color, rgba(0, 0, 0, 0.65)) !default; // icon 类型按钮颜色
 $-button-icon-disabled-color: var(--wot-button-icon-disabled-color, $-color-icon-disabled) !default; // icon 类型按钮禁用颜色

--- a/src/uni_modules/wot-design-uni/components/wd-button/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-button/index.scss
@@ -310,7 +310,6 @@
     height: $-button-icon-size;
     padding: 0;
     border-radius: 50%;
-    font-size: 0;
     color: $-button-icon-color;
 
     &::after {

--- a/src/uni_modules/wot-design-uni/components/wd-button/wd-button.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-button/wd-button.vue
@@ -39,7 +39,7 @@
     <view v-if="loading" class="wd-button__loading">
       <view class="wd-button__loading-svg" :style="loadingStyle"></view>
     </view>
-    <wd-icon v-if="icon" custom-class="wd-button__icon" :name="icon"></wd-icon>
+    <wd-icon v-else-if="icon" custom-class="wd-button__icon" :name="icon"></wd-icon>
     <view class="wd-button__text"><slot /></view>
   </button>
 </template>


### PR DESCRIPTION
✅ Closes: #235

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
#235 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充