### PR TITLE
fix: 🐛 修复InputNumber步进器组件在初始化时未发生变化仍触发change的问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-input-number/wd-input-number.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-input-number/wd-input-number.vue
@@ -36,7 +36,7 @@ export default {
 
 <script lang="ts" setup>
 import { ref, watch } from 'vue'
-import { debounce, isDef } from '../common/util'
+import { debounce, isDef, isEqual } from '../common/util'
 import { inputNumberProps } from './types'
 
 const props = defineProps(inputNumberProps)
@@ -75,7 +75,9 @@ watch(
 function updateBoundary() {
   debounce(() => {
     const value = formatValue(inputValue.value)
-    setValue(value)
+    if (!isEqual(inputValue.value, value)) {
+      setValue(value)
+    }
     splitDisabled(value)
   }, 30)()
 }
@@ -161,13 +163,18 @@ function handleFocus(event: any) {
 
 function handleBlur() {
   const value = formatValue(inputValue.value)
-  setValue(value)
+  if (!isEqual(inputValue.value, value)) {
+    setValue(value)
+  }
   emit('blur', {
     value
   })
 }
 
 function dispatchChangeEvent(value: string | number, change: boolean = true) {
+  if (isEqual(inputValue.value, value)) {
+    return
+  }
   inputValue.value = value
   change && emit('update:modelValue', inputValue.value)
   change && emit('change', { value })


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
InputNumber步进器组件在初始化时未发生变化仍触发change事件  

解决方案：控制只有在值发生变化时才触发change

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充