### PR TITLE
sidebar-item样式修正

### DIFF
--- a/docs/component/button.md
+++ b/docs/component/button.md
@@ -82,6 +82,14 @@
 <wd-button icon="edit-outline"></wd-button>
 ```
 
+## 在按钮中使用自定义图标
+
+设置 `icon-class-prefix` 属性，使用方法参考wd-icon中的`class-prefix`属性
+
+```html
+<wd-button type="icon" icon-class-prefix="my-icon" icon="extra"></wd-button>
+```
+
 ## 块状按钮
 
 设置 `block` 属性。
@@ -103,6 +111,7 @@
 | size | 按钮尺寸 | string | small / medium / large | medium | - |
 | disabled | 禁用按钮 | boolean | - | false | - |
 | icon | 图标类名 | string | - | - | - |
+| icon-class-prefix | 类名前缀，用于使用自定义图标 | string | - | - | - |
 | loading-color | 加载图标颜色 | string | - | - | - |
 | open-type | 微信开放能力 | string | - | - | - |
 | <s>form-type</s> | <s>用于 form 组件，点击分别会触发 form 组件的 submit/reset 事件</s>，该属性暂时不可用 | string | submit / reset | - | - |

--- a/src/uni_modules/wot-design-uni/components/wd-button/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-button/types.ts
@@ -48,6 +48,10 @@ export const buttonProps = {
    */
   icon: String,
   /**
+  * 自定义图标前缀
+  */
+  iconClassPrefix: String,
+  /**
    * 加载中按钮
    */
   loading: makeBooleanProp(false),

--- a/src/uni_modules/wot-design-uni/components/wd-button/wd-button.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-button/wd-button.vue
@@ -39,7 +39,7 @@
     <view v-if="loading" class="wd-button__loading">
       <view class="wd-button__loading-svg" :style="loadingStyle"></view>
     </view>
-    <wd-icon v-else-if="icon" custom-class="wd-button__icon" :name="icon"></wd-icon>
+    <wd-icon v-else-if="icon" custom-class="wd-button__icon" :name="icon" :class-prefix="iconClassPrefix"></wd-icon>
     <view class="wd-button__text"><slot /></view>
   </button>
 </template>

--- a/src/uni_modules/wot-design-uni/components/wd-sidebar-item/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-sidebar-item/index.scss
@@ -28,14 +28,14 @@
 
 @include b(sidebar-item) {
   display: flex;
+  gap:8rpx;
   align-items: center;
   justify-content: center;
   position: relative;
-  padding: 32rpx;
+  padding: 32rpx 24rpx;
   font-size: $-sidebar-font-size;
   color: $-sidebar-color;
   background: $-sidebar-bg;
-  min-height: $-sidebar-item-height;
   box-sizing: border-box;
   white-space: wrap;
   line-height: $-sidebar-item-line-height;
@@ -85,7 +85,18 @@
   }
 
   @include edeep(badge) {
+    flex: 1;
+    text-align: center;
     z-index: 2;
+  }
+  
+  @include edeep(badge-with-icon) {
+    flex: 1;
+    text-align: center;
+    z-index: 2;
+    overflow-wrap: break-word;
+    word-break: break-all;
+    max-width: 4ch;
   }
 
   @include edeep(icon) {

--- a/src/uni_modules/wot-design-uni/components/wd-sidebar-item/wd-sidebar-item.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-sidebar-item/wd-sidebar-item.vue
@@ -10,7 +10,7 @@
     <template v-if="!$slots.icon && icon">
       <wd-icon custom-class="wd-sidebar-item__icon" :name="icon" size="20px"></wd-icon>
     </template>
-    <wd-badge :model-value="badge" :is-dot="isDot" :max="max" v-bind="badgeProps" custom-class="wd-sidebar-item__badge">
+    <wd-badge :model-value="badge" :is-dot="isDot" :max="max" v-bind="badgeProps" :custom-class="($slots.icon || icon)?'wd-sidebar-item__badge-with-icon':'wd-sidebar-item__badge'">
       {{ label }}
     </wd-badge>
   </view>


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

修改前：
1、bar-item单行只能容纳3-4个汉字（视机型而定），当附带icon时，单行只能容纳两个汉字，且换行后样式不匹配。
2、side-bar-item数量超过10个时，定义的min-height: $-sidebar-item-height;会出现意想不到的情况，导致单个side-bar-item高度被挤压（图中第3，4个）
![无标题](https://github.com/Moonofweisheng/wot-design-uni/assets/64245796/6fc1a019-72be-445b-83e2-9430aec42f4c)


修改后：
1、减少左右paddding以保证可以容纳4个汉字
2、图标和文字采用flex布局，优化间隔
3、增加对是否使用icon的判断，使用icon时，强制2个汉字换行，以对齐每个baritem

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充