### PR TITLE
fix: 修复wd-calendar未抛出事件

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-calendar/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-calendar/types.ts
@@ -200,3 +200,10 @@ export type CalendarOnShortcutsClickOption = {
 }
 
 export type CalendarOnShortcutsClick = (option: CalendarOnShortcutsClickOption) => number | number[]
+
+export type CalendarExpose = {
+  /** 关闭时间选择器弹窗 */
+  close: () => void,
+  /** 打开时间选择器弹窗 */
+  open: () => void
+}

--- a/src/uni_modules/wot-design-uni/components/wd-calendar/wd-calendar.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-calendar/wd-calendar.vue
@@ -123,7 +123,7 @@ import { useCell } from '../composables/useCell'
 import { FORM_KEY, type FormItemRule } from '../wd-form/types'
 import { useParent } from '../composables/useParent'
 import { useTranslate } from '../composables/useTranslate'
-import { calendarProps } from './types'
+import { calendarProps, CalendarExpose } from './types'
 import type { CalendarType } from '../wd-calendar-view/types'
 const { translate } = useTranslate('calendar')
 
@@ -409,6 +409,11 @@ function handleShortcutClick(index: number) {
     handleConfirm()
   }
 }
+
+defineExpose<CalendarExpose>({
+  close,
+  open
+})
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
1. 关闭或者退出页面的时候需要调用api自动关闭当前没有关闭的选择器，经过源码驱动，发现事件没有抛出

解决方案
1. 通过vue的事件正常抛出

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x]TypeScript 定义已补充或无须补充