### PR TITLE
feat: segmented组件添加click事件

### DIFF
--- a/docs/component/segmented.md
+++ b/docs/component/segmented.md
@@ -120,6 +120,7 @@ const list1 = ref([
 | 事件名称 | 说明                       | 参数        | 最低版本 |
 | -------- | -------------------------- | ----------- | -------- |
 | change   | 选项切换时触发             | `SegmentedOption` | 0.1.23   |
+| click   | 选项点击时触发             | `SegmentedOption` | $LOWEST_VERSION$   |
 
 ## Slots
 

--- a/src/uni_modules/wot-design-uni/components/wd-segmented/wd-segmented.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-segmented/wd-segmented.vue
@@ -38,7 +38,7 @@ import { segmentedProps, type SegmentedInfo, type SegmentedOption } from './type
 const $item = '.wd-segmented__item'
 
 const props = defineProps(segmentedProps)
-const emit = defineEmits(['update:value', 'change'])
+const emit = defineEmits(['update:value', 'change', 'click'])
 
 const sectionItemInfo = reactive<SegmentedInfo>({
   width: 0,
@@ -130,6 +130,7 @@ function handleClick(option: string | number | SegmentedOption, index: number) {
   updateActiveStyle()
   emit('update:value', value)
   emit('change', isObj(option) ? option : { value })
+  emit('click', isObj(option) ? option : { value })
 }
 </script>
 


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
 需求背景：直接更新 value 值也会触发 change 事件，比如通过接口获取值给组件赋值，希望用户切换选项时才出发事件
 解决方案：增加 click 事件，用户点击时触发
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充