### PR TITLE
fix: 🐛 wd-form针对多级对象校验，校验器无法获取到对应value值bug修复

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-form/wd-form.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-form/wd-form.vue
@@ -61,7 +61,7 @@ async function validate(prop?: string): Promise<{ valid: boolean; errors: ErrorM
           valid = false
           break
         }
-        if (rule.pattern && !rule.pattern.test(props.model[prop])) {
+        if (rule.pattern && !rule.pattern.test(value)) {
           errors.push({
             prop,
             message: rule.message
@@ -71,7 +71,7 @@ async function validate(prop?: string): Promise<{ valid: boolean; errors: ErrorM
         }
         const { validator, ...ruleWithoutValidator } = rule
         if (validator) {
-          const result = validator(props.model[prop], ruleWithoutValidator)
+          const result = validator(value, ruleWithoutValidator)
           if (isPromise(result)) {
             promises.push(
               result


### PR DESCRIPTION
当prop为多级嵌套结构时，正则或者自定义校验器时，无法获取对应的输入值

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充