### PR TITLE
fix: 🐛 修复Sticky在h5和App端缓慢拖动时存在几率始终固定在顶部的问题

### DIFF
--- a/src/pages/tabs/Index.vue
+++ b/src/pages/tabs/Index.vue
@@ -7,7 +7,7 @@
           <wd-tab :title="`标签${item}`">
             <view class="content">
               内容{{ tab1 + 1 }}
-              <wd-button @click="tab1 < 3 ? tab1++ : (tab1 = 0)">下一个</wd-button>
+              <view><wd-button @click="tab1 < 3 ? tab1++ : (tab1 = 0)">下一个</wd-button></view>
             </view>
           </wd-tab>
         </block>
@@ -53,21 +53,21 @@
       </wd-tabs>
     </demo-block>
 
-    <demo-block title="手势滑动" transparent>
-      <wd-tabs v-model="tab5" swipeable @change="handleChange">
-        <block v-for="item in 4" :key="item">
-          <wd-tab :title="`标签${item}`">
-            <view class="content">内容{{ tab5 + 1 }}</view>
-          </wd-tab>
-        </block>
-      </wd-tabs>
-    </demo-block>
-
     <demo-block title="切换动画" transparent>
       <wd-tabs v-model="tab8" animated @change="handleChange">
         <block v-for="item in 4" :key="item">
           <wd-tab :title="`标签${item}`">
             <view class="content">内容{{ tab8 + 1 }}</view>
+          </wd-tab>
+        </block>
+      </wd-tabs>
+    </demo-block>
+
+    <demo-block title="手势滑动" transparent>
+      <wd-tabs v-model="tab5" swipeable animated @change="handleChange">
+        <block v-for="item in 4" :key="item">
+          <wd-tab :title="`标签${item}`">
+            <view class="content">内容{{ tab5 + 1 }}</view>
           </wd-tab>
         </block>
       </wd-tabs>

--- a/src/uni_modules/wot-design-uni/components/wd-sticky-box/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-sticky-box/types.ts
@@ -1,0 +1,20 @@
+/*
+ * @Author: weisheng
+ * @Date: 2024-04-08 22:34:01
+ * @LastEditTime: 2024-06-01 16:04:56
+ * @LastEditors: weisheng
+ * @Description:
+ * @FilePath: /wot-design-uni/src/uni_modules/wot-design-uni/components/wd-sticky-box/types.ts
+ * 记得注释
+ */
+import type { ComponentInternalInstance, InjectionKey } from 'vue'
+
+export type stickyBoxProvide = {
+  boxStyle: {
+    height: number // 高度
+    width: number // 宽度
+  }
+  observerForChild: (child: ComponentInternalInstance) => void // 监听子组件
+}
+
+export const STICKY_BOX_KEY: InjectionKey<stickyBoxProvide> = Symbol('wd-sticky-box')

--- a/src/uni_modules/wot-design-uni/components/wd-sticky-box/wd-sticky-box.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-sticky-box/wd-sticky-box.vue
@@ -1,7 +1,7 @@
 <template>
   <view style="position: relative">
     <view :class="`wd-sticky-box ${props.customClass}`" :style="customStyle" :id="styckyBoxId">
-      <wd-resize @resize="resizeHandler">
+      <wd-resize @resize="handleResize">
         <slot />
       </wd-resize>
     </view>
@@ -20,38 +20,43 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import { getCurrentInstance, onBeforeMount, provide, ref } from 'vue'
+import { getCurrentInstance, onBeforeMount, reactive, ref } from 'vue'
 import { getRect, uuid } from '../common/util'
 import { baseProps } from '../common/props'
+import { STICKY_BOX_KEY } from './types'
+import { useChildren } from '../composables/useChildren'
 
 const props = defineProps(baseProps)
 
 const styckyBoxId = ref<string>(`wd-sticky-box${uuid()}`)
 
 const observerMap = ref<Map<any, any>>(new Map())
-const height = ref<number>(0)
-const width = ref<number>(0)
 
-const stickyList: any[] = [] // 子元素sticky列表
+const boxStyle = reactive({
+  height: 0,
+  width: 0
+})
 
 const { proxy } = getCurrentInstance() as any
-const instance = getCurrentInstance() as any
 
-provide('box-height', height)
-provide('box-width', width)
-provide('observerForChild', observerForChild)
+const { children: stickyList, linkChildren } = useChildren(STICKY_BOX_KEY)
+linkChildren({
+  boxStyle: boxStyle,
+  observerForChild
+})
 
 onBeforeMount(() => {
   observerMap.value = new Map()
 })
 
 /**
- * @description wd-sticky-box 尺寸发生变化时，重新监听所有的viewport
+ * 容器大小变化后重新监听sticky组件与box组件的交叉状态
+ * @param detail
  */
-function resizeHandler(detail: any) {
+function handleResize(detail: any) {
   // 相对的容器大小改变后，同步设置 wd-sticky-box 的大小
-  width.value = detail.width
-  height.value = detail.height
+  boxStyle.width = detail.width
+  boxStyle.height = detail.height
   // wd-sticky-box 大小变化时，重新监听所有吸顶元素
   const temp = observerMap.value
   observerMap.value = new Map()
@@ -67,8 +72,8 @@ function resizeHandler(detail: any) {
   temp.clear()
 }
 /**
- * @description 删除 wd-sticky 废弃的监听器
- * @param child
+ * 删除对指定sticky的监听
+ * @param child 指定的子组件
  */
 function deleteObserver(child: any) {
   const observer = observerMap.value.get(child.$.uid)
@@ -77,63 +82,70 @@ function deleteObserver(child: any) {
   observerMap.value.delete(child.$.uid)
 }
 /**
- * @description 为 wd-sticky 创建监听器
- * @param child
+ * 针对指定sticky添加监听
+ * @param child 指定的子组件
  */
 function createObserver(child: any) {
-  const observer = uni.createIntersectionObserver(instance)
+  const observer = uni.createIntersectionObserver(proxy, { thresholds: [0, 0.5] })
   observerMap.value.set(child.$.uid, observer)
   return observer
 }
 /**
- * @description 为单个 wd-sticky 监听 viewport
- * @param child sticky
+ * 监听子组件
+ * @param child 子组件
  */
 function observerForChild(child: any) {
-  const hasChild = stickyList.find((sticky) => {
-    return sticky.$.uid === child.$.uid
-  })
-  if (!hasChild) {
-    stickyList.push(child)
-  }
   deleteObserver(child)
   const observer = createObserver(child)
-
   const exposed = child.$.exposed
-  const offset = exposed.height.value + exposed.offsetTop
+  let offset = exposed.stickyState.height + exposed.offsetTop
+  // #ifdef H5
+  // H5端，导航栏为普通元素，需要将组件移动到导航栏的下边沿
+  // H5的导航栏高度为44px
+  offset = offset + 44
+  // #endif
 
-  // 如果 wd-sticky 比 wd-sticky-box还大，"相对吸顶"无任何意义,此时强制吸顶元素回归其占位符
-  if (height.value <= exposed.height.value) {
+  if (boxStyle.height <= exposed.stickyState.height) {
     exposed.setPosition(false, 'absolute', 0)
   }
   observer.relativeToViewport({ top: -offset }).observe(`#${styckyBoxId.value}`, (result) => {
-    scrollHandler(exposed, result)
+    handleRelativeTo(exposed, result)
   })
+  // 当子组件默认处于边界外且永远不会进入边界内时，需要手动调用一次
   getRect(`#${styckyBoxId.value}`, false, proxy)
     .then((res) => {
-      // 当 wd-sticky-box 位于 viewport 外部时不会触发 observe，此时根据位置手动修复位置。
-      if (Number(res.bottom) <= offset) scrollHandler(exposed, { boundingClientRect: res })
+      // #ifdef H5
+      // H5端，查询节点信息未计算导航栏高度
+      res.bottom = Number(res.bottom) + 44
+      // #endif
+      if (Number(res.bottom) <= offset) handleRelativeTo(exposed, { boundingClientRect: res })
     })
     .catch((res) => {
       console.log(res)
     })
 }
 /**
- * @description 为子节点监听 viewport，处理子节点的相对吸顶逻辑
+ *  监听容器组件
  * @param {Object} exposed wd-sticky实例暴露出的事件
- * @param {Object} boundingClientRect 目标节点各个边在viewport中的坐标
+ * @param {Object} boundingClientRect 边界信息
  */
-function scrollHandler(exposed: any, { boundingClientRect }: any) {
-  const offset = exposed.height.value + exposed.offsetTop
-  if (boundingClientRect.bottom <= offset) {
-    // 父元素即将被吸顶元素遮盖，将吸顶元素固定到父元素底部
-    exposed.setPosition(true, 'absolute', boundingClientRect.height - exposed.height.value)
-  } else if (boundingClientRect.top <= offset && boundingClientRect.bottom > offset) {
-    // wd-sticky 已经完全呈现了 viewport 中了，
-    // 此时没有必要再相对 wd-sticky-box 吸顶了
-    if (exposed.state.value === 'normal') return
-    // 顶元素开始遮盖不住父元素了，将吸顶元素恢复到吸顶模式
-    exposed.setPosition(false, 'fixed', exposed.offsetTop)
+function handleRelativeTo(exposed: any, { boundingClientRect }: any) {
+  let childOffsetTop = exposed.offsetTop
+  // #ifdef H5
+  // H5端，导航栏为普通元素，需要将组件移动到导航栏的下边沿
+  // H5的导航栏高度为44px
+  childOffsetTop = childOffsetTop + 44
+  // #endif
+  const offset = exposed.stickyState.height + childOffsetTop
+  let isAbsolute = boundingClientRect.bottom <= offset
+  // #ifdef H5 || APP-PLUS
+  isAbsolute = boundingClientRect.bottom < offset
+  // #endif
+  if (isAbsolute) {
+    exposed.setPosition(true, 'absolute', boundingClientRect.height - exposed.stickyState.height)
+  } else if (boundingClientRect.top <= offset && !isAbsolute) {
+    if (exposed.stickyState.state === 'normal') return
+    exposed.setPosition(false, 'fixed', childOffsetTop)
   }
 }
 </script>

--- a/src/uni_modules/wot-design-uni/components/wd-sticky/wd-sticky.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-sticky/wd-sticky.vue
@@ -1,13 +1,8 @@
 <template>
   <view :style="`${rootStyle};display: inline-block;`">
-    <!--强制设置高宽，防止元素坍塌-->
-    <!--在使用 wd-sticky-box 时，某些情况下 wd-sticky__container 的 'position：absolute' 需要相对于 wd-sticky-box-->
     <view :class="`wd-sticky ${customClass}`" :style="stickyStyle" :id="styckyId">
-      <!--吸顶容器-->
       <view class="wd-sticky__container" :style="containerStyle">
-        <!--监听元素尺寸变化-->
-        <wd-resize @resize="resizeHandler" custom-style="display: inline-block;">
-          <!--需要吸顶的内容-->
+        <wd-resize @resize="handleResize" custom-style="display: inline-block;">
           <slot />
         </wd-resize>
       </view>
@@ -27,56 +22,57 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import { type Ref, computed, getCurrentInstance, inject, ref } from 'vue'
+import { computed, getCurrentInstance, reactive, ref, type CSSProperties } from 'vue'
 import { addUnit, getRect, objToStyle, requestAnimationFrame, uuid } from '../common/util'
 import { stickyProps } from './types'
+import { useParent } from '../composables/useParent'
+import { STICKY_BOX_KEY } from '../wd-sticky-box/types'
 
 const props = defineProps(stickyProps)
 const styckyId = ref<string>(`wd-sticky${uuid()}`)
-
-const openBox = ref<boolean>(false)
-const position = ref<string>('absolute')
-const top = ref<number>(0)
-const height = ref<number>(0)
-const width = ref<number>(0)
 const observerList = ref<UniApp.IntersectionObserver[]>([])
-const state = ref<string>('')
 
-const boxHeight: Ref<number> = inject('box-height', null) || ref(0)
-// eslint-disable-next-line @typescript-eslint/ban-types
-const observerForChild: Function | null = inject('observerForChild', null)
+const stickyState = reactive({
+  position: 'absolute',
+  boxLeaved: false,
+  top: 0,
+  height: 0,
+  width: 0,
+  state: ''
+})
+
+const { parent: stickyBox } = useParent(STICKY_BOX_KEY)
 
 const { proxy } = getCurrentInstance() as any
-const instance = getCurrentInstance() as any
 
 const rootStyle = computed(() => {
-  const style: Record<string, string | number> = {
+  const style: CSSProperties = {
     'z-index': props.zIndex,
-    height: addUnit(height.value),
-    width: addUnit(width.value)
+    height: addUnit(stickyState.height),
+    width: addUnit(stickyState.width)
   }
-  if (!openBox.value) {
+  if (!stickyState.boxLeaved) {
     style['position'] = 'relative'
   }
   return `${objToStyle(style)};${props.customStyle}`
 })
 
 const stickyStyle = computed(() => {
-  const style: Record<string, string | number> = {
+  const style: CSSProperties = {
     'z-index': props.zIndex,
-    height: addUnit(height.value),
-    width: addUnit(width.value)
+    height: addUnit(stickyState.height),
+    width: addUnit(stickyState.width)
   }
-  if (!openBox.value) {
+  if (!stickyState.boxLeaved) {
     style['position'] = 'relative'
   }
   return `${objToStyle(style)};`
 })
 
 const containerStyle = computed(() => {
-  const style: Record<string, string | number> = {
-    position: position.value,
-    top: addUnit(top.value)
+  const style: CSSProperties = {
+    position: stickyState.position as 'static' | 'relative' | 'absolute' | 'sticky' | 'fixed',
+    top: addUnit(stickyState.top)
   }
   return objToStyle(style)
 })
@@ -93,7 +89,7 @@ const innerOffsetTop = computed(() => {
 })
 
 /**
- * @description 清除无用的 viewport 观察者
+ * 清除对当前组件的监听
  */
 function clearObserver() {
   while (observerList.value.length !== 0) {
@@ -101,94 +97,92 @@ function clearObserver() {
   }
 }
 /**
- * @description 创建新的 viewport 观察者
+ * 添加对当前组件的监听
  */
 function createObserver() {
-  const observer = uni.createIntersectionObserver(instance)
+  const observer = uni.createIntersectionObserver(proxy, { thresholds: [0, 0.5] })
   observerList.value.push(observer)
   return observer
 }
 /**
- * @description 监听到吸顶元素尺寸大小变化时，立即重新模拟吸顶
+ *  当前内容高度发生变化时重置监听
  */
-function resizeHandler(detail: any) {
-  // 当吸顶内容处于absolute、fixed时，为了防止父容器坍塌，需要手动设置父容器高宽。
-  width.value = detail.width
-  height.value = detail.height
-  // // 如果和 wd-sticky-box 配套使用，吸顶逻辑交由 wd-sticky-box 进行处理
+function handleResize(detail: any) {
+  stickyState.width = detail.width
+  stickyState.height = detail.height
   requestAnimationFrame(() => {
     observerContentScroll()
-    if (!observerForChild) return
-    observerForChild(proxy)
+    if (!stickyBox || !stickyBox.observerForChild) return
+    stickyBox.observerForChild(proxy)
   })
 }
 /**
- * @description 模拟吸顶逻辑
+ *  监听吸顶元素滚动事件
  */
 function observerContentScroll() {
-  // 视图在 render tree 中未呈现，吸顶无任何意义。
-  if (height.value === 0 && width.value === 0) return
-  const offset = innerOffsetTop.value + height.value
+  if (stickyState.height === 0 && stickyState.width === 0) return
+  const offset = innerOffsetTop.value + stickyState.height
   clearObserver()
   createObserver()
     .relativeToViewport({
-      top: -offset // viewport上边界往下拉
+      top: -offset
     })
     .observe(`#${styckyId.value}`, (result) => {
-      scrollHandler(result)
+      handleRelativeTo(result)
     })
   getRect(`#${styckyId.value}`, false, proxy).then((res) => {
-    // 当 wd-sticky 位于 viewport 外部时不会触发 observe，此时根据位置手动修复位置。
-    if (Number(res.bottom) <= offset) scrollHandler({ boundingClientRect: res })
+    // #ifdef H5
+    // H5端，查询节点信息未计算导航栏高度
+    res.bottom = Number(res.bottom) + 44
+    // #endif
+    if (Number(res.bottom) <= offset) handleRelativeTo({ boundingClientRect: res })
   })
 }
 /**
  * @description 根据位置进行吸顶
  */
-function scrollHandler({ boundingClientRect }: any) {
+function handleRelativeTo({ boundingClientRect }: any) {
   // sticky 高度大于或等于 wd-sticky-box，使用 wd-sticky-box 无任何意义
-  if (observerForChild && height.value >= boxHeight.value) {
-    position.value = 'absolute'
-    top.value = 0
+  if (stickyBox && stickyState.height >= stickyBox.boxStyle.height) {
+    stickyState.position = 'absolute'
+    stickyState.top = 0
     return
   }
-  // boundingClientRect : 目标节点各个边在 viewport 中的坐标
-  if (boundingClientRect.top <= innerOffsetTop.value) {
-    state.value = 'sticky'
-    // 开始吸顶，固定到顶部
-    openBox.value = false
-    position.value = 'fixed'
-    top.value = innerOffsetTop.value
-  } else if (boundingClientRect.top > innerOffsetTop.value) {
-    state.value = 'normal'
-    // 完全展示，结束吸顶
-    openBox.value = false
-    position.value = 'absolute'
-    top.value = 0
+
+  let isStycky = boundingClientRect.top <= innerOffsetTop.value
+  // #ifdef H5 || APP-PLUS
+  isStycky = boundingClientRect.top < innerOffsetTop.value
+  // #endif
+
+  if (isStycky) {
+    stickyState.state = 'sticky'
+    stickyState.boxLeaved = false
+    stickyState.position = 'fixed'
+    stickyState.top = innerOffsetTop.value
+  } else {
+    stickyState.state = 'normal'
+    stickyState.boxLeaved = false
+    stickyState.position = 'absolute'
+    stickyState.top = 0
   }
 }
 
 /**
  * 设置位置
- * @param setOpenBox
+ * @param setboxLeaved
  * @param setPosition
  * @param setTop
  */
-function setPosition(setOpenBox: boolean, setPosition: string, setTop: number) {
-  openBox.value = setOpenBox
-  position.value = setPosition
-  top.value = setTop
+function setPosition(boxLeaved: boolean, position: string, top: number) {
+  stickyState.boxLeaved = boxLeaved
+  stickyState.position = position
+  stickyState.top = top
 }
 
 defineExpose({
   setPosition,
-  openBox: openBox,
-  position: position,
-  top: top,
-  height: height,
-  width: width,
-  state: state,
-  offsetTop: innerOffsetTop.value
+  stickyState,
+  offsetTop: props.offsetTop
 })
 </script>
 <style lang="scss" scoped>


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [x] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
Sticky组件在h5和App端缓慢拖动时存在几率始终固定在顶部。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充