### PR TITLE
refactor: ♻️ 重构table父子组件的数据交互

### DIFF
--- a/src/pages/table/Index.vue
+++ b/src/pages/table/Index.vue
@@ -1,35 +1,35 @@
 <template>
   <page-wraper>
     <demo-block title="基本用法">
-      <wd-table :data="dataList" @sort-method="doSort" height="328px" @row-click="handleRowClick">
+      <wd-table :data="dataList" @sort-method="handleSort" height="328px" @row-click="handleRowClick">
         <wd-table-col prop="name" label="姓名" align="center" width="50%"></wd-table-col>
         <wd-table-col prop="grade" label="分数" align="center" width="50%"></wd-table-col>
       </wd-table>
     </demo-block>
 
     <demo-block title="无边框">
-      <wd-table :data="dataList" @sort-method="doSort" height="328px" :border="false" @row-click="handleRowClick">
+      <wd-table :data="dataList" @sort-method="handleSort" height="328px" :border="false" @row-click="handleRowClick">
         <wd-table-col prop="name" label="姓名" align="center" width="50%"></wd-table-col>
         <wd-table-col prop="grade" label="分数" align="center" width="50%"></wd-table-col>
       </wd-table>
     </demo-block>
 
     <demo-block title="无斑马纹">
-      <wd-table :data="dataList" @sort-method="doSort" height="328px" :stripe="false" @row-click="handleRowClick">
+      <wd-table :data="dataList" @sort-method="handleSort" height="328px" :stripe="false" @row-click="handleRowClick">
         <wd-table-col prop="name" label="姓名" align="center" width="50%"></wd-table-col>
         <wd-table-col prop="grade" label="分数" align="center" width="50%"></wd-table-col>
       </wd-table>
     </demo-block>
 
     <demo-block title="不展示表头">
-      <wd-table :data="dataList" @sort-method="doSort" height="328px" :show-header="false" @row-click="handleRowClick">
+      <wd-table :data="dataList" @sort-method="handleSort" height="328px" :show-header="false" @row-click="handleRowClick">
         <wd-table-col prop="name" label="姓名" align="center" width="50%"></wd-table-col>
         <wd-table-col prop="grade" label="分数" align="center" width="50%"></wd-table-col>
       </wd-table>
     </demo-block>
 
     <demo-block title="固定列">
-      <wd-table :data="dataList" @sort-method="doSort" @row-click="handleRowClick" height="328px">
+      <wd-table :data="dataList" @sort-method="handleSort" @row-click="handleRowClick" height="328px">
         <wd-table-col prop="name" label="姓名" fixed :sortable="true" align="center"></wd-table-col>
         <wd-table-col prop="grade" label="分数" fixed :sortable="true" align="center"></wd-table-col>
         <wd-table-col prop="hobby" label="一言以蔽之" :sortable="true" :width="160"></wd-table-col>
@@ -40,7 +40,7 @@
     </demo-block>
 
     <demo-block title="显示索引">
-      <wd-table :data="dataList" height="328px" :index="{ align: 'center' }">
+      <wd-table :data="dataList" height="328px" @sort-method="handleSort" :index="{ align: 'center' }">
         <wd-table-col prop="name" label="姓名" :sortable="true" align="center"></wd-table-col>
         <wd-table-col prop="grade" label="分数" :sortable="true" align="center"></wd-table-col>
         <wd-table-col prop="hobby" label="一言以蔽之" :sortable="true" :width="160"></wd-table-col>
@@ -51,7 +51,7 @@
     </demo-block>
 
     <demo-block title="自定义列模板">
-      <wd-table :data="dataList" @sort-method="doSort" @row-click="handleRowClick" height="328px">
+      <wd-table :data="dataList" @sort-method="handleSort" @row-click="handleRowClick" height="328px">
         <wd-table-col prop="name" label="姓名" fixed :sortable="true" align="center"></wd-table-col>
         <wd-table-col prop="grade" label="分数" fixed :sortable="true" align="center">
           <template #value="{ row }">
@@ -71,6 +71,7 @@
   </page-wraper>
 </template>
 <script lang="ts" setup>
+import type { TableColumn } from '@/uni_modules/wot-design-uni/components/wd-table-col/types'
 import { ref } from 'vue'
 
 const dataList = ref<Record<string, any>[]>([
@@ -230,7 +231,7 @@ const dataList = ref<Record<string, any>[]>([
  * 排序
  * @param e
  */
-function doSort() {
+function handleSort(column: TableColumn) {
   dataList.value = dataList.value.reverse()
 }
 

--- a/src/uni_modules/wot-design-uni/components/wd-segmented/wd-segmented.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-segmented/wd-segmented.vue
@@ -80,7 +80,7 @@ onMounted(() => {
 })
 
 /**
- * @description 更新滑块偏移量
+ * 更新滑块偏移量
  *
  */
 function updateActiveStyle() {

--- a/src/uni_modules/wot-design-uni/components/wd-table-col/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-table-col/types.ts
@@ -11,7 +11,7 @@ export interface TableColumn {
   // 列对应字段标题
   label: string
   // 列宽度
-  width: string
+  width: string | number
   // 是否开启列排序
   sortable?: boolean
   // 列的对齐方式，可选值left,center,right

--- a/src/uni_modules/wot-design-uni/components/wd-table-col/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-table-col/types.ts
@@ -1,7 +1,7 @@
-import type { ExtractPropTypes } from 'vue'
+import type { ComponentPublicInstance, ExtractPropTypes } from 'vue'
 import { makeBooleanProp, makeNumericProp, makeRequiredProp, makeStringProp } from '../common/props'
 
-type AlignType = 'left' | 'center' | 'right' // 列的对齐方式
+export type AlignType = 'left' | 'center' | 'right' // 列的对齐方式
 
 export type SortDirection = 0 | 1 | -1 // 列的排序方向
 
@@ -50,3 +50,5 @@ export const tableColumnProps = {
 }
 
 export type TableColumnProps = ExtractPropTypes<typeof tableColumnProps>
+
+export type TableColumnInstance = ComponentPublicInstance<TableColumnProps>

--- a/src/uni_modules/wot-design-uni/components/wd-table-col/wd-table-col.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-table-col/wd-table-col.vue
@@ -1,6 +1,6 @@
 <template>
   <view
-    :class="`wd-table-col ${fixed ? 'wd-table-col--fixed' : ''} ${isLastFixed && isDef(parent.scrollLeft) && parent.scrollLeft ? 'is-shadow' : ''}`"
+    :class="`wd-table-col ${fixed ? 'wd-table-col--fixed' : ''} ${isLastFixed && isDef(table) && table.scrollLeft ? 'is-shadow' : ''}`"
     :style="columnStyle"
   >
     <view
@@ -10,7 +10,7 @@
       :style="cellStyle"
       @click="handleRowClick(index)"
     >
-      <slot name="value" v-if="$slots.value" :row="scope(index)" :index="index"></slot>
+      <slot name="value" v-if="$slots.value" :row="getScope(index)" :index="index"></slot>
       <text :class="`wd-table__value ${ellipsis ? 'is-ellipsis' : ''}`" v-else>{{ row }}</text>
     </view>
   </view>
@@ -27,31 +27,47 @@ export default {
 }
 </script>
 <script lang="ts" setup>
-import { type CSSProperties, computed, inject, onMounted } from 'vue'
-import { addUnit, isDef, objToStyle, isOdd } from '../common/util'
-import { tableColumnProps, type TableColumn } from './types'
+import { type CSSProperties, computed, ref, reactive } from 'vue'
+import { addUnit, isDef, objToStyle, isOdd, isFunction } from '../common/util'
+import { tableColumnProps, type SortDirection } from './types'
+import { useParent } from '../composables/useParent'
+import { TABLE_KEY } from '../wd-table/types'
 
 const props = defineProps(tableColumnProps)
 
-const parent = inject<any>('wdTable', { data: [] }) // table数据
+const { parent: table, index: columnIndex } = useParent(TABLE_KEY)
+
+const sortDirection = ref<SortDirection>(0) // 排序方向
 
 // 是否开启斑马纹
 const stripe = computed(() => {
-  return parent.stripe || false
+  if (isDef(table)) {
+    return table.stripe
+  } else {
+    return false
+  }
 })
 
 /**
  * 是否有边框
  */
 const border = computed(() => {
-  return parent.border || false
+  if (isDef(table)) {
+    return table.border
+  } else {
+    return false
+  }
 })
 
 /**
  * 是否超出省略
  */
 const ellipsis = computed(() => {
-  return parent.ellipsis || false
+  if (isDef(table)) {
+    return table.ellipsis
+  } else {
+    return false
+  }
 })
 
 /**
@@ -59,95 +75,50 @@ const ellipsis = computed(() => {
  */
 const isLastFixed = computed(() => {
   let isLastFixed: boolean = false
-  if (props.fixed && isDef(parent.columns)) {
-    const columns = parent.columns.filter((column: TableColumn) => {
-      return column.fixed
-    })
-    if (columns.length && columns[columns.length - 1].prop === props.prop) {
-      isLastFixed = true
-    }
+  if (props.fixed && isDef(table)) {
+    isLastFixed = table.getIsLastFixed(props)
   }
   return isLastFixed
 })
 
+/**
+ * 列样式
+ */
 const columnStyle = computed(() => {
-  const style: CSSProperties = {}
+  let style: CSSProperties = {}
   if (isDef(props.width)) {
-    // width存在且包含px则转成px
     style['width'] = addUnit(props.width)
   }
-  if (props.fixed) {
-    const columnIndex: number = parent.columns.findIndex((column: TableColumn) => {
-      return column.prop === props.prop
-    })
-    if (columnIndex > 0) {
-      let left: string | number = ''
-      parent.columns.forEach((column: TableColumn, index: number) => {
-        if (index < columnIndex) {
-          left = left ? `${left} + ${addUnit(column.width)}` : addUnit(column.width)
-        }
-      })
-      style['left'] = `calc(${left})`
-    } else {
-      style['left'] = 0
-    }
+  if (props.fixed && isDef(table) && isFunction(table.getFixedStyle)) {
+    style = table.getFixedStyle(columnIndex.value, style)
   }
-
-  return objToStyle(style)
+  return style
 })
 
+/**
+ * 单元格样式
+ */
 const cellStyle = computed(() => {
-  const rowHeight: string | number = parent.rowHeight || '80rpx' // 自定义行高
-  const style: CSSProperties = {}
+  let style: CSSProperties = {}
+  const rowHeight: string | number = isDef(table) ? table.rowHeight : '80rpx' // 自定义行高
   if (isDef(rowHeight)) {
-    // width存在且包含px则转成px
     style['height'] = addUnit(rowHeight)
   }
-  if (props.fixed) {
-    const columnIndex: number = parent.columns.findIndex((column: TableColumn) => {
-      return column.prop === props.prop
-    })
-    if (columnIndex > 0) {
-      let left: string | number = ''
-      parent.columns.forEach((column: TableColumn, index: number) => {
-        if (index < columnIndex) {
-          left = left ? `${left} + ${addUnit(column.width)}` : addUnit(column.width)
-        }
-      })
-      style['left'] = `calc(${left})`
-    } else {
-      style['left'] = 0
-    }
+  if (props.fixed && isDef(table) && isFunction(table.getFixedStyle)) {
+    style = table.getFixedStyle(columnIndex.value, style)
   }
   return objToStyle(style)
-})
-
-// 行完整数据
-const scope = computed(() => {
-  return (index: number) => {
-    return parent.data[index] || {}
-  }
 })
 
 // 列数据
 const column = computed(() => {
-  let column: any[] = parent.data.map((item: any) => {
+  if (!isDef(table)) {
+    return []
+  }
+  const column: any[] = table.data.map((item) => {
     return item[props.prop]
   })
   return column
-})
-
-onMounted(() => {
-  parent.setColumns &&
-    parent.setColumns({
-      prop: props.prop,
-      label: props.label,
-      width: props.width,
-      sortable: props.sortable,
-      fixed: props.fixed,
-      align: props.align,
-      sortDirection: 0
-    })
 })
 
 /**
@@ -155,8 +126,21 @@ onMounted(() => {
  * @param index 行下标
  */
 function handleRowClick(index: number) {
-  parent.setRowClick && parent.setRowClick(index)
+  if (!isDef(table)) {
+    return
+  }
+  isFunction(table.rowClick) && table.rowClick(index)
 }
+
+// 行数据
+function getScope(index: number) {
+  if (!isDef(table)) {
+    return {}
+  }
+  return table.data[index] || {}
+}
+
+defineExpose({ sortDirection: sortDirection })
 </script>
 
 <style lang="scss" scoped>

--- a/src/uni_modules/wot-design-uni/components/wd-table/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-table/types.ts
@@ -1,13 +1,13 @@
 /*
  * @Author: weisheng
  * @Date: 2024-03-15 11:36:12
- * @LastEditTime: 2024-03-18 15:36:59
+ * @LastEditTime: 2024-06-06 19:11:32
  * @LastEditors: weisheng
  * @Description:
  * @FilePath: \wot-design-uni\src\uni_modules\wot-design-uni\components\wd-table\types.ts
  * 记得注释
  */
-import type { ExtractPropTypes } from 'vue'
+import type { CSSProperties, ExtractPropTypes, InjectionKey } from 'vue'
 import { baseProps, makeBooleanProp, makeNumberProp, makeRequiredProp, makeStringProp } from '../common/props'
 import type { TableColumnProps } from '../wd-table-col/types'
 import type { PropType } from 'vue'
@@ -52,3 +52,12 @@ export const tableProps = {
 }
 
 export type TableProps = ExtractPropTypes<typeof tableProps>
+
+export type TableProvide = Omit<TableProps, 'index' | 'customStyle' | 'customClass'> & {
+  scrollLeft: number
+  rowClick: (index: number) => void
+  getIsLastFixed: (column: { fixed: boolean; prop: string }) => boolean
+  getFixedStyle: (index: number, style: CSSProperties) => CSSProperties
+}
+
+export const TABLE_KEY: InjectionKey<TableProvide> = Symbol('wd-table')

--- a/src/uni_modules/wot-design-uni/components/wd-table/wd-table.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-table/wd-table.vue
@@ -73,7 +73,7 @@ export default {
 <script lang="ts" setup>
 import { type CSSProperties, computed, watch, reactive, ref } from 'vue'
 import { addUnit, debounce, isDef, isObj, objToStyle, uuid } from '../common/util'
-import type { SortDirection, TableColumnInstance, TableColumnProps } from '../wd-table-col/types'
+import type { SortDirection, TableColumn, TableColumnInstance, TableColumnProps } from '../wd-table-col/types'
 import { TABLE_KEY, tableProps, type TableProvide } from './types'
 import WdTableCol from '../wd-table-col/wd-table-col.vue'
 import { useTranslate } from '../composables/useTranslate'
@@ -263,7 +263,23 @@ function handleSortChange(value: SortDirection, index: number) {
       col.$.exposed!.sortDirection.value = 0
     }
   })
-  emit('sort-method', children[index])
+  const column: TableColumn = {
+    // 列对应字段
+    prop: children[index].prop,
+    // 列对应字段标题
+    label: children[index].label,
+    // 列宽度
+    width: children[index].width,
+    // 是否开启列排序
+    sortable: children[index].sortable,
+    // 列的对齐方式，可选值left,center,right
+    align: children[index].align,
+    // 列的排序方向
+    sortDirection: value,
+    // 是否i固定列
+    fixed: children[index].fixed
+  }
+  emit('sort-method', column)
 }
 
 /**

--- a/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
@@ -423,8 +423,7 @@ function getActiveIndex(value: number | string) {
 defineExpose({
   setActive,
   scrollIntoView,
-  updateLineStyle,
-  children
+  updateLineStyle
 })
 </script>
 <style lang="scss" scoped>


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [x] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
重构table父子组件的数据交互

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充