### PR TITLE
docs: ✏️ 修正upload组件文档错误

### DIFF
--- a/docs/component/upload.md
+++ b/docs/component/upload.md
@@ -25,7 +25,7 @@ const fileList = ref<any[]>([
 
 const action: string = 'https://ftf.jd.com/api/uploadImg'
 
-function handleChange({ files }) {
+function handleChange({ fileList: files }) {
   fileList.value = files
 }
 ```


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

只是个小错误所以没有提issue

### 💡 需求背景和解决方案
#### 需求背景
直接复制文档样例来用的人还是挺多的，这包括我在内。
我复制了upload的样例直接使用，发现每次第一次上传图片都不显示，事前添加的图片列表在点上传后也会消失。
添加调试信息如下
```typescript
const fileList = ref<any[]>([
  // {
  //   url: 'https://img12.360buyimg.com//n0/jfs/t1/29118/6/4823/55969/5c35c16bE7c262192/c9fdecec4b419355.jpg'
  // }
])

const action: string = 'https://ftf.jd.com/api/uploadImg'

function handleChange({ files }) {
  console.log('文件列表改变了: ')
  console.log('old: ', fileList.value)
  fileList.value = files
  console.log('new', fileList.value)
}
```
console输出：
![image](https://github.com/Moonofweisheng/wot-design-uni/assets/52315768/767c8c86-51de-4428-b35d-6695d5763231)
**可以确定是参数解构有问题
查看后面文档发现参数名其实是fileList！**
![image](https://github.com/Moonofweisheng/wot-design-uni/assets/52315768/609cc546-3d9d-496d-a1ff-3eda7cb20203)

#### 解决方案
添加别名解决：
```typescript
function handleChange({ fileList: files }) {
  console.log('文件列表改变了: ')
  console.log('old: ', fileList.value)
  fileList.value = files
  console.log('new', fileList.value)
}
```
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充