### PR TITLE
refactor: ♻️  重构tabbar-item、grid-item和sidebar-item透传badge属性的逻辑

### DIFF
--- a/src/uni_modules/wot-design-uni/components/common/util.ts
+++ b/src/uni_modules/wot-design-uni/components/common/util.ts
@@ -650,3 +650,14 @@ export const isDate = (val: unknown): val is Date => Object.prototype.toString.c
  * 判断环境是否是H5
  */
 export const isH5 = process.env.UNI_PLATFORM === 'h5'
+
+/**
+ * 从对象中移除值为undefined的字段
+ * @param obj - 输入的对象
+ * @returns 处理后的新对象
+ */
+export function removeUndefinedFields(obj: Record<string, any>): Record<string, any> {
+  const newObj: Record<string, any> = { ...obj } // 创建输入对象的副本
+  Object.keys(newObj).forEach((key) => newObj[key] === undefined && delete newObj[key]) // 遍历对象的键，删除值为undefined的字段
+  return newObj // 返回处理后的新对象
+}

--- a/src/uni_modules/wot-design-uni/components/common/util.ts
+++ b/src/uni_modules/wot-design-uni/components/common/util.ts
@@ -1,5 +1,7 @@
 import { AbortablePromise } from './AbortablePromise'
 
+type NotUndefined<T> = T extends undefined ? never : T
+
 /**
  * 生成uuid
  * @returns string
@@ -348,6 +350,14 @@ export function isBoolean(value: any): value is boolean {
   return typeof value === 'boolean'
 }
 
+export function isUndefined(value): value is undefined {
+  return typeof value === 'undefined'
+}
+
+export function isNotUndefined<T>(value: T): value is NotUndefined<T> {
+  return !isUndefined(value)
+}
+
 /**
  * 检查给定的值是否为奇数
  * @param value 要检查的值
@@ -652,12 +662,21 @@ export const isDate = (val: unknown): val is Date => Object.prototype.toString.c
 export const isH5 = process.env.UNI_PLATFORM === 'h5'
 
 /**
- * 从对象中移除值为undefined的字段
- * @param obj - 输入的对象
- * @returns 处理后的新对象
+ * 剔除对象中的某些属性
+ * @param obj
+ * @param predicate
+ * @returns
  */
-export function removeUndefinedFields(obj: Record<string, any>): Record<string, any> {
-  const newObj: Record<string, any> = { ...obj } // 创建输入对象的副本
-  Object.keys(newObj).forEach((key) => newObj[key] === undefined && delete newObj[key]) // 遍历对象的键，删除值为undefined的字段
-  return newObj // 返回处理后的新对象
+export function omitBy<O extends Record<string, any>>(obj: O, predicate: (value: any, key: keyof O) => boolean): Partial<O> {
+  const newObj = {}
+
+  const keys = Object.keys(obj)
+
+  for (const item in keys) {
+    if (!predicate(obj[item], item)) {
+      newObj[item] = obj[item]
+    }
+  }
+
+  return newObj
 }

--- a/src/uni_modules/wot-design-uni/components/wd-grid-item/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-grid-item/types.ts
@@ -49,7 +49,10 @@ export const gridItemProps = {
   /**
    * 是否显示图标右上角小红点
    */
-  isDot: Boolean,
+  isDot: {
+    type: Boolean,
+    default: undefined
+  },
   /**
    * 图标右上角显示的 badge 类型，可选值：primary / success / warning / danger / info
    */

--- a/src/uni_modules/wot-design-uni/components/wd-grid-item/wd-grid-item.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-grid-item/wd-grid-item.vue
@@ -32,7 +32,7 @@ export default {
 import { onMounted, ref, watch, computed } from 'vue'
 import { useParent } from '../composables/useParent'
 import { GRID_KEY } from '../wd-grid/types'
-import { deepAssign, isDef, removeUndefinedFields } from '../common/util'
+import { deepAssign, isDef, isUndefined, omitBy } from '../common/util'
 import { gridItemProps } from './types'
 import type { BadgeProps } from '../wd-badge/types'
 
@@ -57,13 +57,16 @@ const childCount = computed(() => {
 
 const customBadgeProps = computed(() => {
   const badgeProps: Partial<BadgeProps> = deepAssign(
-    isDef(props.badgeProps) ? removeUndefinedFields(props.badgeProps) : {},
-    removeUndefinedFields({
-      max: props.max,
-      isDot: props.isDot,
-      modelValue: props.value,
-      type: props.type
-    })
+    isDef(props.badgeProps) ? omitBy(props.badgeProps, isUndefined) : {},
+    omitBy(
+      {
+        max: props.max,
+        isDot: props.isDot,
+        modelValue: props.value,
+        type: props.type
+      },
+      isUndefined
+    )
   )
   return badgeProps
 })

--- a/src/uni_modules/wot-design-uni/components/wd-grid-item/wd-grid-item.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-grid-item/wd-grid-item.vue
@@ -4,7 +4,7 @@
       <slot v-if="useSlot" />
       <block v-else>
         <view :style="'width:' + iconSize + '; height: ' + iconSize" class="wd-grid-item__wrapper">
-          <wd-badge custom-class="badge" :is-dot="isDot" :modelValue="value" :max="max" :type="type" v-bind="badgeProps">
+          <wd-badge custom-class="badge" v-bind="customBadgeProps">
             <template v-if="useIconSlot">
               <slot name="icon" />
             </template>
@@ -32,8 +32,9 @@ export default {
 import { onMounted, ref, watch, computed } from 'vue'
 import { useParent } from '../composables/useParent'
 import { GRID_KEY } from '../wd-grid/types'
-import { isDef } from '../common/util'
+import { deepAssign, isDef, removeUndefinedFields } from '../common/util'
 import { gridItemProps } from './types'
+import type { BadgeProps } from '../wd-badge/types'
 
 const props = defineProps(gridItemProps)
 const emit = defineEmits(['itemclick'])
@@ -52,6 +53,19 @@ const childCount = computed(() => {
   } else {
     return 0
   }
+})
+
+const customBadgeProps = computed(() => {
+  const badgeProps: Partial<BadgeProps> = deepAssign(
+    isDef(props.badgeProps) ? removeUndefinedFields(props.badgeProps) : {},
+    removeUndefinedFields({
+      max: props.max,
+      isDot: props.isDot,
+      modelValue: props.value,
+      type: props.type
+    })
+  )
+  return badgeProps
 })
 
 watch(

--- a/src/uni_modules/wot-design-uni/components/wd-sidebar-item/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-sidebar-item/types.ts
@@ -18,9 +18,12 @@ export const sidebarItemProps = {
   /** 图标 */
   icon: String,
   /** 是否点状徽标 */
-  isDot: Boolean,
+  isDot: {
+    type: Boolean,
+    default: undefined
+  },
   /** 徽标最大值 */
-  max: makeNumberProp(99),
+  max: Number,
   /** 是否禁用 */
   disabled: makeBooleanProp(false)
 }

--- a/src/uni_modules/wot-design-uni/components/wd-sidebar-item/wd-sidebar-item.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-sidebar-item/wd-sidebar-item.vue
@@ -33,7 +33,7 @@ import { useParent } from '../composables/useParent'
 import { SIDEBAR_KEY } from '../wd-sidebar/types'
 import { sidebarItemProps } from './types'
 import type { BadgeProps } from '../wd-badge/types'
-import { deepAssign, isDef, removeUndefinedFields } from '../common/util'
+import { deepAssign, isDef, isUndefined, omitBy } from '../common/util'
 
 const props = defineProps(sidebarItemProps)
 
@@ -41,12 +41,15 @@ const { parent: sidebar } = useParent(SIDEBAR_KEY)
 
 const customBadgeProps = computed(() => {
   const badgeProps: Partial<BadgeProps> = deepAssign(
-    isDef(props.badgeProps) ? removeUndefinedFields(props.badgeProps) : {},
-    removeUndefinedFields({
-      max: props.max,
-      isDot: props.isDot,
-      modelValue: props.badge
-    })
+    isDef(props.badgeProps) ? omitBy(props.badgeProps, isUndefined) : {},
+    omitBy(
+      {
+        max: props.max,
+        isDot: props.isDot,
+        modelValue: props.badge
+      },
+      isUndefined
+    )
   )
   if (!isDef(badgeProps.max)) {
     badgeProps.max = 99

--- a/src/uni_modules/wot-design-uni/components/wd-sidebar-item/wd-sidebar-item.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-sidebar-item/wd-sidebar-item.vue
@@ -10,7 +10,7 @@
     <template v-if="!$slots.icon && icon">
       <wd-icon custom-class="wd-sidebar-item__icon" :name="icon" size="20px"></wd-icon>
     </template>
-    <wd-badge :model-value="badge" :is-dot="isDot" :max="max" v-bind="badgeProps" custom-class="wd-sidebar-item__badge">
+    <wd-badge v-bind="customBadgeProps" custom-class="wd-sidebar-item__badge">
       {{ label }}
     </wd-badge>
   </view>
@@ -32,10 +32,27 @@ import { computed } from 'vue'
 import { useParent } from '../composables/useParent'
 import { SIDEBAR_KEY } from '../wd-sidebar/types'
 import { sidebarItemProps } from './types'
+import type { BadgeProps } from '../wd-badge/types'
+import { deepAssign, isDef, removeUndefinedFields } from '../common/util'
 
 const props = defineProps(sidebarItemProps)
 
 const { parent: sidebar } = useParent(SIDEBAR_KEY)
+
+const customBadgeProps = computed(() => {
+  const badgeProps: Partial<BadgeProps> = deepAssign(
+    isDef(props.badgeProps) ? removeUndefinedFields(props.badgeProps) : {},
+    removeUndefinedFields({
+      max: props.max,
+      isDot: props.isDot,
+      modelValue: props.badge
+    })
+  )
+  if (!isDef(badgeProps.max)) {
+    badgeProps.max = 99
+  }
+  return badgeProps
+})
 
 const active = computed(() => {
   let active: boolean = false

--- a/src/uni_modules/wot-design-uni/components/wd-tabbar-item/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-tabbar-item/types.ts
@@ -34,11 +34,14 @@ export const tabbarItemProps = {
   /**
    * 是否点状徽标
    */
-  isDot: Boolean,
+  isDot: {
+    type: Boolean,
+    default: undefined
+  },
   /**
    * 徽标最大值
    */
-  max: makeNumberProp(99),
+  max: Number,
   /**
    * 徽标属性，透传给 Badge 组件
    */

--- a/src/uni_modules/wot-design-uni/components/wd-tabbar-item/wd-tabbar-item.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-tabbar-item/wd-tabbar-item.vue
@@ -25,7 +25,7 @@ export default {
 </script>
 <script lang="ts" setup>
 import { type CSSProperties, computed } from 'vue'
-import { deepAssign, isDef, objToStyle, removeUndefinedFields } from '../common/util'
+import { deepAssign, isDef, isUndefined, objToStyle, omitBy } from '../common/util'
 import { useParent } from '../composables/useParent'
 import { TABBAR_KEY } from '../wd-tabbar/types'
 import { tabbarItemProps } from './types'
@@ -37,12 +37,15 @@ const { parent: tabbar, index } = useParent(TABBAR_KEY)
 
 const customBadgeProps = computed(() => {
   const badgeProps: Partial<BadgeProps> = deepAssign(
-    isDef(props.badgeProps) ? removeUndefinedFields(props.badgeProps) : {},
-    removeUndefinedFields({
-      max: props.max,
-      isDot: props.isDot,
-      modelValue: props.value
-    })
+    isDef(props.badgeProps) ? omitBy(props.badgeProps, isUndefined) : {},
+    omitBy(
+      {
+        max: props.max,
+        isDot: props.isDot,
+        modelValue: props.value
+      },
+      isUndefined
+    )
   )
   if (!isDef(badgeProps.max)) {
     badgeProps.max = 99

--- a/src/uni_modules/wot-design-uni/components/wd-tabbar-item/wd-tabbar-item.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-tabbar-item/wd-tabbar-item.vue
@@ -1,6 +1,6 @@
 <template>
   <view :class="`wd-tabbar-item ${customClass}`" :style="customStyle" @click="handleClick">
-    <wd-badge :modelValue="value" v-bind="badgeProps" :is-dot="isDot" :max="max">
+    <wd-badge v-bind="customBadgeProps">
       <view class="wd-tabbar-item__body">
         <slot name="icon" :active="active"></slot>
         <template v-if="!$slots.icon && icon">
@@ -25,14 +25,30 @@ export default {
 </script>
 <script lang="ts" setup>
 import { type CSSProperties, computed } from 'vue'
-import { isDef, objToStyle } from '../common/util'
+import { deepAssign, isDef, objToStyle, removeUndefinedFields } from '../common/util'
 import { useParent } from '../composables/useParent'
 import { TABBAR_KEY } from '../wd-tabbar/types'
 import { tabbarItemProps } from './types'
+import type { BadgeProps } from '../wd-badge/types'
 
 const props = defineProps(tabbarItemProps)
 
 const { parent: tabbar, index } = useParent(TABBAR_KEY)
+
+const customBadgeProps = computed(() => {
+  const badgeProps: Partial<BadgeProps> = deepAssign(
+    isDef(props.badgeProps) ? removeUndefinedFields(props.badgeProps) : {},
+    removeUndefinedFields({
+      max: props.max,
+      isDot: props.isDot,
+      modelValue: props.value
+    })
+  )
+  if (!isDef(badgeProps.max)) {
+    badgeProps.max = 99
+  }
+  return badgeProps
+})
 
 const textStyle = computed(() => {
   const style: CSSProperties = {}


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [x] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
TabbarItem、SidebarItem和GridItem使用badge用于显示徽标数量，暴露出的badgeProps受到之前提供的isDot属性的默认值影响，部分属性无法生效，做此调整。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充