### PR TITLE
feat: 新增自定义确认按钮到 MessageBox 弹框

### DIFF
--- a/docs/component/message-box.md
+++ b/docs/component/message-box.md
@@ -60,6 +60,42 @@ function alert() {
 }
 ```
 
+
+## Alert 自定义确认按钮
+
+一般用于在微信小程序弹窗通过按钮授权等场景open-type,调用close方法手动关闭弹窗。
+
+```html
+<wd-message-box selector="wd-message-close">
+<view>
+  <view>自定义按钮</view>
+</view>
+<template #confirmButton>
+  <wd-button block @click="close()">自定义确定按钮</wd-button>
+</template>
+</wd-message-box>
+
+<wd-button @click="show">alert-自定义确定按钮</wd-button>
+```
+
+```typescript
+import { useMessage } from '@/uni_modules/wot-design-uni'
+const message2 = useMessage('wd-message-close')
+
+function show() {
+  message2.alert({
+    title: '提示',
+    showConfirmButton: false
+  })
+}
+
+function close() {
+  message2.close()
+}
+
+```
+
+
 ## Confirm 弹框
 
 用于提示用户操作。
@@ -85,40 +121,6 @@ function confirm() {
     .catch(() => {
       console.log('点击了取消按钮')
     })
-}
-
-```
-
-## Alert 弹框
-
-一般用于在微信小程序弹窗通过按钮授权等场景,调用close方法手动关闭弹窗。
-
-```html
-<wd-message-box selector="wd-message-close">
-<view>
-  <view>自定义按钮</view>
-</view>
-<template #confirmButton>
-  <wd-button block @click="close()">自定义确定按钮</wd-button>
-</template>
-</wd-message-box>
-<wd-button @click="show">alert-自定义确定按钮</wd-button>
-```
-
-```typescript
-import { useMessage } from '@/uni_modules/wot-design-uni'
-const message2 = useMessage('wd-message-close')
-
-function show() {
-  message2.alert({
-    title: '提示',
-    showConfirmButton: false,
-    showCancelButton: false
-  })
-}
-
-function close() {
-  message2.close()
 }
 
 ```
@@ -254,6 +256,7 @@ MessageBox.prompt(options)
 | title             | 标题                                                          | string          | -                        | -                | -        |
 | msg               | 消息文案                                                      | string          | -                        | -                | -        |
 | type              | 弹框类型                                                      | string          | alert / confirm / prompt | alert            | -        |
+| type              | 弹框类型                                                      | string          | alert / confirm / prompt | alert            | -        |
 | closeOnClickModal | 是否支持点击蒙层进行关闭，点击蒙层回调传入的 action 为'modal' | boolean         | -                        | true             | -        |
 | inputType         | 当 type 为 prompt 时，输入框类型                              | string          | -                        | text             | -        |
 | inputValue        | 当 type 为 prompt 时，输入框初始值                            | string / number | -                        | -                | -        |
@@ -261,6 +264,7 @@ MessageBox.prompt(options)
 | inputPattern      | 当 type 为 prompt 时，输入框正则校验，点击确定按钮时进行校验  | regex           | -                        | -                | -        |
 | inputValidate     | 当 type 为 prompt 时，输入框校验函数，点击确定按钮时进行校验  | function        | -                        | -                | -        |
 | inputError        | 当 type 为 prompt 时，输入框检验不通过时的错误提示文案        | string          | -                        | 输入的数据不合法 | -        |
+| showConfirmButton | type为alert时是否显示确认按钮                                                  | boolean          | -                        | true             | -        |
 | confirmButtonText | 确定按钮文案                                                  | string          | -                        | 确定             | -        |
 | cancelButtonText  | 取消按钮文案                                                  | string          | -                        | 取消             | -        |
 | selector          | 组件的 id                                                     | string          | -                        | #wd-message-box  | -        |

--- a/docs/component/message-box.md
+++ b/docs/component/message-box.md
@@ -89,6 +89,40 @@ function confirm() {
 
 ```
 
+## Alert 弹框
+
+一般用于在微信小程序弹窗通过按钮授权等场景,调用close方法手动关闭弹窗。
+
+```html
+<wd-message-box selector="wd-message-close">
+<view>
+  <view>自定义按钮</view>
+</view>
+<template #confirmButton>
+  <wd-button block @click="close()">自定义确定按钮</wd-button>
+</template>
+</wd-message-box>
+<wd-button @click="show">alert-自定义确定按钮</wd-button>
+```
+
+```typescript
+import { useMessage } from '@/uni_modules/wot-design-uni'
+const message2 = useMessage('wd-message-close')
+
+function show() {
+  message2.alert({
+    title: '提示',
+    showConfirmButton: false,
+    showCancelButton: false
+  })
+}
+
+function close() {
+  message2.close()
+}
+
+```
+
 ## Prompt 弹框
 
 prompt 会展示一个输入框，并可以进行输入校验。

--- a/src/pages/messageBox/Index.vue
+++ b/src/pages/messageBox/Index.vue
@@ -16,6 +16,18 @@
       <wd-button @click="confirm">confirm</wd-button>
     </demo-block>
 
+    <demo-block title="自定义确定按钮:一般用于在微信小程序弹窗通过按钮授权等场景,调用close方法手动关闭弹窗。">
+      <wd-message-box selector="wd-message-close">
+        <view>
+          <view>自定义按钮</view>
+        </view>
+        <template #confirmButton>
+          <wd-button block @click="close()">自定义确定按钮</wd-button>
+        </template>
+      </wd-message-box>
+      <wd-button @click="show">alert-自定义确定按钮</wd-button>
+    </demo-block>
+
     <demo-block title="prompt">
       <wd-button @click="prompt">prompt</wd-button>
     </demo-block>
@@ -42,6 +54,7 @@ const value1 = ref<string>('')
 const toast = useToast()
 const message = useMessage()
 const message1 = useMessage('wd-message-box-slot')
+const message2 = useMessage('wd-message-close')
 
 function alert() {
   message.alert('操作成功')
@@ -114,6 +127,18 @@ function withSlot() {
     .catch((error) => {
       console.log(error)
     })
+}
+
+function show() {
+  message2.alert({
+    title: '提示',
+    showConfirmButton: false,
+    showCancelButton: false
+  })
+}
+
+function close() {
+  message2.close()
 }
 </script>
 <style lang="scss" scoped>

--- a/src/pages/messageBox/Index.vue
+++ b/src/pages/messageBox/Index.vue
@@ -132,8 +132,7 @@ function withSlot() {
 function show() {
   message2.alert({
     title: '提示',
-    showConfirmButton: false,
-    showCancelButton: false
+    showConfirmButton: false
   })
 }
 

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/index.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/index.ts
@@ -21,6 +21,7 @@ export const messageDefaultOptionKey = '__MESSAGE_OPTION__'
 // 默认模板
 export const defaultOptions: MessageOptions = {
   title: '',
+  showConfirmButton: true,
   showCancelButton: false,
   show: false,
   closeOnClickModal: true,
@@ -75,9 +76,9 @@ export function useMessage(selector: string = ''): Message {
   const confirm = createMethod('confirm')
   // 打开Prompt 弹框
   const prompt = createMethod('prompt')
-
+  // 关闭弹窗
   const close = () => {
-    messageOption.value = { ...defaultOptions }
+    messageOption.value.show = false
   }
   return {
     show,

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/types.ts
@@ -24,6 +24,10 @@ export type MessageOptions = {
    * 是否展示取消按钮
    */
   showCancelButton?: boolean
+  /**
+   * 是否显示确认按钮
+   */
+  showConfirmButton?: boolean
 
   show?: boolean
   /**

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
@@ -35,7 +35,7 @@
             </wd-button>
           </template>
           <template v-else>
-            <slot name="confirmButton" @click="toggleModal('confirm')"></slot>
+            <slot name="confirmButton"></slot>
           </template>
         </view>
       </view>

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
@@ -29,9 +29,14 @@
           <wd-button type="info" block v-if="showCancelButton" custom-style="margin-right: 16px;" @click="toggleModal('cancel')">
             {{ cancelButtonText || translate('cancel') }}
           </wd-button>
-          <wd-button block @click="toggleModal('confirm')">
-            {{ confirmButtonText || translate('confirm') }}
-          </wd-button>
+          <template v-if="showConfirmButton">
+            <wd-button block @click="toggleModal('confirm')">
+              {{ confirmButtonText || translate('confirm') }}
+            </wd-button>
+          </template>
+          <template v-else>
+            <slot name="confirmButton" @click="toggleModal('confirm')"></slot>
+          </template>
         </view>
       </view>
     </wd-popup>
@@ -93,6 +98,10 @@ const title = ref<string>('')
  * 是否展示取消按钮
  */
 const showCancelButton = ref<boolean>(false)
+/**
+ * 是否显示确认按钮
+ */
+const showConfirmButton = ref<boolean>(true)
 /**
  * 是否支持点击蒙层进行关闭，点击蒙层回调传入的action为'modal'
  */
@@ -280,9 +289,11 @@ function inputValChange(value: string | number) {
  * @param option message选项值
  */
 function reset(option: MessageOptions) {
+  console.log(isDef(option.showConfirmButton))
   if (option) {
     title.value = isDef(option.title) ? option.title : ''
     showCancelButton.value = isDef(option.showCancelButton) ? option.showCancelButton : false
+    showConfirmButton.value = option.showConfirmButton!
     show.value = option.show!
     closeOnClickModal.value = option.closeOnClickModal!
     confirmButtonText.value = option.confirmButtonText!

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
@@ -289,7 +289,6 @@ function inputValChange(value: string | number) {
  * @param option message选项值
  */
 function reset(option: MessageOptions) {
-  console.log(isDef(option.showConfirmButton))
   if (option) {
     title.value = isDef(option.title) ? option.title : ''
     showCancelButton.value = isDef(option.showCancelButton) ? option.showCancelButton : false


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [x] 新特性提交
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
[1. 描述相关需求的来源，如相关的 issue 讨论链接。](https://github.com/Moonofweisheng/wot-design-uni/issues/399#issuecomment-2201787520)
-->

### 💡 需求背景和解决方案

<!--
自定义确定按钮:一般用于在微信小程序弹窗通过按钮授权等场景,调用close方法手动关闭弹窗。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充