### PR TITLE
perf: 不显示确认按钮的 alert 弹框

### DIFF
--- a/docs/component/message-box.md
+++ b/docs/component/message-box.md
@@ -41,6 +41,26 @@ function alert() {
 }
 ```
 
+不显示确认按钮的 alert 弹框。
+
+```html
+<wd-message-box />
+<wd-button @click="alertOnCancel">alert</wd-button>
+```
+
+```typescript
+import { useMessage } from '@/uni_modules/wot-design-uni'
+const message = useMessage()
+
+function alertOnCancel() {
+  message.alert({
+    msg: '不显示确认按钮',
+    title: '标题',
+    showConfirmButton: false,
+  })
+}
+```
+
 如果内容文案过长，弹框高度不再增加，而是展示滚动条。
 
 ```html

--- a/src/pages/messageBox/Index.vue
+++ b/src/pages/messageBox/Index.vue
@@ -12,6 +12,10 @@
       <wd-button @click="alertWithTitle">alert</wd-button>
     </demo-block>
 
+    <demo-block title="不显示确认按钮">
+      <wd-button @click="alertOnCancel">alert</wd-button>
+    </demo-block>
+
     <demo-block title="confirm">
       <wd-button @click="confirm">confirm</wd-button>
     </demo-block>
@@ -50,6 +54,14 @@ function alertWithTitle() {
   message.alert({
     msg: '提示文案',
     title: '标题'
+  })
+}
+
+function alertOnCancel() {
+  message.alert({
+    msg: '不显示确认按钮',
+    title: '标题',
+    showConfirmButton: false
   })
 }
 function confirm() {

--- a/src/uni_modules/wot-design-uni/components/common/abstracts/variable.scss
+++ b/src/uni_modules/wot-design-uni/components/common/abstracts/variable.scss
@@ -376,10 +376,11 @@ $-loadmore-fs: var(--wot-loadmore-fs, 14px) !default; // 字号
 $-loadmore-error-color: var(--wot-loadmore-error-color, $-color-theme) !default; // 点击重试颜色
 
 /* message-box */
+$-message-padding: var(--wot-message-padding, 24px) !default; // 主体padding
 $-message-box-width: var(--wot-message-box-width, 300px) !default; // 宽度
 $-message-box-bg: var(--wot-message-box-bg, $-color-white) !default; // 默认背景颜色
 $-message-box-radius: var(--wot-message-box-radius, 16px) !default; // 圆角大小
-$-message-box-padding: var(--wot-message-box-padding, 25px 24px 0) !default; // 主体内容padding
+$-message-box-padding: var(--wot-message-box-padding, 0 0 24px 0) !default; // 主体padding
 $-message-box-title-fs: var(--wot-message-box-title-fs, 16px) !default; // 标题字号
 $-message-box-title-color: var(--wot-message-box-title-color, rgba(0, 0, 0, 0.85)) !default; // 标题颜色
 $-message-box-content-fs: var(--wot-message-box-content-fs, 14px) !default; // 内容字号

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/index.scss
@@ -13,7 +13,6 @@
 
     @include e(content) {
       color: $-dark-color3;
-
       &::-webkit-scrollbar-thumb {
         background: $-dark-border-color;
       }
@@ -31,16 +30,17 @@
   overflow: hidden;
 
   @include e(container) {
+    padding: $-message-padding;
     width: $-message-box-width;
     box-sizing: border-box;
   }
 
   @include e(body) {
     background-color: $-message-box-bg;
-    padding: $-message-box-padding;
+    
 
     @include when(no-title) {
-      padding: 25px 24px 0px;
+      padding: 24px 24px 0px;
     }
   }
 
@@ -50,8 +50,7 @@
     color: $-message-box-title-color;
     line-height: 20px;
     font-weight: 500;
-    padding-top: 5px;
-    padding-bottom: 10px;
+    padding: $-message-box-padding;
   }
 
   @include e(content) {
@@ -61,7 +60,6 @@
     text-align: center;
     overflow: auto;
     line-height: 20px;
-
     &::-webkit-scrollbar {
       width: $-message-box-content-scrollbar-width;
     }
@@ -85,7 +83,7 @@
   }
 
   @include e(actions) {
-    padding: 24px;
+    padding: 24px 0 0 0;
   }
 
   @include e(flex) {

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/index.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/index.ts
@@ -22,6 +22,7 @@ export const messageDefaultOptionKey = '__MESSAGE_OPTION__'
 export const defaultOptions: MessageOptions = {
   title: '',
   showCancelButton: false,
+  showConfirmButton: true,
   show: false,
   closeOnClickModal: true,
   msg: '',

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/types.ts
@@ -25,6 +25,11 @@ export type MessageOptions = {
    */
   showCancelButton?: boolean
 
+  /**
+   * 是否显示确认按钮
+   */
+  showConfirmButton?: boolean
+
   show?: boolean
   /**
    * 是否支持点击蒙层进行关闭，点击蒙层回调传入的action为'modal'

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
@@ -25,7 +25,10 @@
             <slot>{{ msg }}</slot>
           </view>
         </view>
-        <view :class="`wd-message-box__actions ${showCancelButton ? 'wd-message-box__flex' : 'wd-message-box__block'}`">
+        <view
+          :class="`wd-message-box__actions ${showCancelButton ? 'wd-message-box__flex' : 'wd-message-box__block'}`"
+          v-if="!(type === 'alert' && showConfirmButton === false)"
+        >
           <wd-button type="info" block v-if="showCancelButton" custom-style="margin-right: 16px;" @click="toggleModal('cancel')">
             {{ cancelButtonText || translate('cancel') }}
           </wd-button>
@@ -93,6 +96,12 @@ const title = ref<string>('')
  * 是否展示取消按钮
  */
 const showCancelButton = ref<boolean>(false)
+
+/**
+ * 是否显示确认按钮
+ */
+const showConfirmButton = ref<boolean>(true)
+
 /**
  * 是否支持点击蒙层进行关闭，点击蒙层回调传入的action为'modal'
  */
@@ -283,6 +292,7 @@ function reset(option: MessageOptions) {
   if (option) {
     title.value = isDef(option.title) ? option.title : ''
     showCancelButton.value = isDef(option.showCancelButton) ? option.showCancelButton : false
+    showConfirmButton.value = isDef(option.showConfirmButton) ? option.showConfirmButton : true
     show.value = option.show!
     closeOnClickModal.value = option.closeOnClickModal!
     confirmButtonText.value = option.confirmButtonText!
@@ -306,5 +316,5 @@ function reset(option: MessageOptions) {
 </script>
 
 <style lang="scss" scoped>
-@import './index.scss';
+@import './index';
 </style>


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充