### PR TITLE
fix: 修复双向滑块响应式丢失

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-slider/wd-slider.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-slider/wd-slider.vue
@@ -136,21 +136,21 @@ watch(
 
 watch(
   () => props.modelValue,
-  (newValue, oldValue) => {
+  (newValue) => {
     // 类型校验，支持所有值(除null、undefined。undefined建议统一写成void (0)防止全局undefined被覆盖)
     if (newValue === null || newValue === undefined) {
-      emit('update:modelValue', oldValue)
+      emit('update:modelValue', currentValue.value)
       console.warn('[wot design] warning(wd-slider): value can nott be null or undefined')
     } else if (isArray(newValue) && newValue.length !== 2) {
       console.warn('[wot design] warning(wd-slider): value must be dyadic array')
     } else if (!isNumber(newValue) && !isArray(newValue)) {
-      emit('update:modelValue', oldValue)
+      emit('update:modelValue', currentValue.value)
       console.warn('[wot design] warning(wd-slider): value must be dyadic array Or Number')
     }
-    currentValue.value = newValue
     // 动态传值后修改
     if (isArray(newValue)) {
-      if (oldValue && isArray(oldValue) && equal(newValue, oldValue)) return
+      if (currentValue.value && isArray(currentValue.value) && equal(newValue, currentValue.value)) return
+      currentValue.value = newValue
       showRight.value = true
       if (leftBarPercent.value <= rightBarPercent.value) {
         leftBarSlider(newValue[0])
@@ -160,7 +160,8 @@ watch(
         rightBarSlider(newValue[0])
       }
     } else {
-      if (newValue === oldValue) return
+      if (newValue === currentValue.value) return
+      currentValue.value = newValue
       leftBarSlider(newValue)
     }
   },


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
无issue
### 💡 需求背景和解决方案
当使用双向滑块时，通过v-model绑定数组后如`arr = [20, 40]`，则修改`arr[0]`后，组件UI无法更新，而后丢失响应式

不知道怎么贴出最小复现，下面的代码可以复现这个BUG
```vue
<template>
<div>
      <wd-button @click="value8[0] = 30">30</wd-button>
      <wd-button @click="value8 = [30, 50]">30-50</wd-button>
      {{ value8 }}
      <wd-slider v-model="value8" :min="10" :max="80" />
</div>
</template>
<script lang="ts" setup>
const value8 = ref<number[]>([20, 40])
</script>
```

点击第二个按钮组件会改变，但是点击第一个按钮（也就是单独修改数组中一项而不是整体改变）就会丢失响应式
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充