### PR TITLE
fix: 修复 textarea 组件同时使用 auto-height 和 no-border 属性时，no-border 属性不生效

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-textarea/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-textarea/index.scss
@@ -220,7 +220,7 @@
 
   @include e(placeholder) {
     color: $-input-placeholder-color;
-    
+
     &.is-error {
       color: $-input-error-color;
     }
@@ -268,12 +268,6 @@
     }
   }
 
-  @include when(no-border) {
-    &::after {
-      display: none;
-    }
-  }
-
   @include when(auto-height) {
     &:not(.is-cell) {
       padding: 5px 0;
@@ -281,6 +275,12 @@
 
     &::after {
       display: block;
+    }
+  }
+
+  @include when(no-border) {
+    &::after {
+      display: none;
     }
   }
 


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

1. [ issue 链接](https://github.com/Moonofweisheng/wot-design-uni/issues/447)。

### 💡 需求背景和解决方案

1. 解决 <wd-textarea auto-height no-border v-model="value"> 中 auto-height、 no-border 属性同时存在时 no-border 属性不生效的问题
2. 解决后如下所示
![Snipaste_2024-07-18_16-22-53](https://github.com/user-attachments/assets/831615fb-d2db-4f02-b2c0-c66448810c33)




### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充