### PR TITLE
fix: 🐛 Correct the reference of wd-text to dayjs

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-text/wd-text.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-text/wd-text.vue
@@ -20,7 +20,7 @@ export default {
 <script lang="ts" setup>
 import { computed, ref, watch } from 'vue'
 import { isDef, objToStyle } from '../common/util'
-import { dayjs } from '@/uni_modules/wot-design-uni'
+import { dayjs } from '../common/dayjs'
 import { textProps } from './types'
 
 const props = defineProps(textProps)


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

#453 

### 💡 需求背景和解决方案

直接从 common 中修正 `dayjs` 引用，不依赖 `uni_modules`

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充