### PR TITLE
refactor: ♻️  重构组件内部使用loading、icon时指定size为px的逻辑改为使用custom-clsss覆写

### DIFF
--- a/src/uni_modules/wot-design-uni/components/common/abstracts/variable.scss
+++ b/src/uni_modules/wot-design-uni/components/common/abstracts/variable.scss
@@ -93,6 +93,7 @@ $-size-side-padding: var(--wot-size-side-padding, 15px) !default; // 屏幕两�
 /* action-sheet */
 $-action-sheet-weight: var(--wot-action-sheet-weight, 500) !default; // 面板字重
 $-action-sheet-radius: var(--wot-action-sheet-radius, 16px) !default; // 面板圆角大小
+$-action-sheet-loading-size: var(--wot-action-sheet-loading-size, 20px) !default; // loading动画尺寸
 $-action-sheet-action-height: var(--wot-action-sheet-action-height, 48px) !default; // 单条菜单高度
 $-action-sheet-color: var(--wot-action-sheet-color, rgba(0, 0, 0, 0.85)) !default; // 选项名称颜色
 $-action-sheet-fs: var(--wot-action-sheet-fs, $-fs-title) !default; // 选项名称字号
@@ -292,6 +293,8 @@ $-divider-fs: var(--wot-divider-fs, 14px) !default; // 字体大小
 $-drop-menu-height: var(--wot-drop-menu-height, 48px) !default; // 展示选中项的高度
 $-drop-menu-color: var(--wot-drop-menu-color, $-color-content) !default; // 展示选中项的颜色
 $-drop-menu-fs: var(--wot-drop-menu-fs, $-fs-content) !default; // 展示选中项的字号
+$-drop-menu-arrow-fs: var(--wot-drop-menu-arrow-fs, $-fs-content) !default; // 箭头图标大小
+
 $-drop-menu-side-padding: var(--wot-drop-menu-side-padding, $-size-side-padding) !default; // 两边留白间距
 $-drop-menu-disabled-color: var(--wot-drop-menu-disabled-color, rgba(0, 0, 0, 0.25)) !default; // 禁用颜色
 $-drop-menu-item-height: var(--wot-drop-menu-item-height, 48px) !default; // 选项高度
@@ -359,7 +362,6 @@ $-textarea-clear-color: var(--wot-textarea-clear-color, #585858) !default; // �
 $-textarea-count-color: var(--wot-textarea-count-color, #bfbfbf) !default; // 计数文字颜色
 $-textarea-count-current-color: var(--wot-textarea-count-current-color, #262626) !default; // 当前长度颜色
 $-textarea-bg: var(--wot-textarea-bg, $-color-white) !default; // 默认背景颜色
-
 $-textarea-cell-border-color: var(--wot-textarea-cell-border-color, $-color-border-light) !default; // cell 类型边框颜色
 $-textarea-cell-padding: var(--wot-textarea-cell-padding, 10px) !default; // cell 容器padding
 $-textarea-cell-padding-large: var(--wot-textarea-cell-padding-large, 12px) !default; // large类型cell容器padding
@@ -374,6 +376,10 @@ $-loadmore-height: var(--wot-loadmore-height, 48px) !default; // 高度
 $-loadmore-color: var(--wot-loadmore-color, rgba(0, 0, 0, 0.45)) !default; // 颜色
 $-loadmore-fs: var(--wot-loadmore-fs, 14px) !default; // 字号
 $-loadmore-error-color: var(--wot-loadmore-error-color, $-color-theme) !default; // 点击重试颜色
+$-loadmore-refresh-fs: var(--wot-loadmore-refresh-fs, $-fs-title) !default; // refresh图标字号
+$-loadmore-loading-size: var(--wot-loadmore-loading-size, $-fs-title) !default; // loading尺寸
+
+
 
 /* message-box */
 $-message-box-width: var(--wot-message-box-width, 300px) !default; // 宽度
@@ -419,6 +425,8 @@ $-pagination-nav-color: var(--wot-pagination-nav-color, rgba(0, 0, 0, 0.85)) !de
 $-pagination-nav-content-fs: var(--wot-pagination-nav-content-fs, 12px) !default;
 $-pagination-nav-sepatator-padding: var(--wot-pagination-nav-sepatator-padding, 0 4px) !default;
 $-pagination-nav-current-color: var(--wot-pagination-nav-current-color, $-color-theme) !default;
+$-pagination-icon-size: var(--wot-pagination-icon-size, $-fs-content) !default;
+
 
 /* picker */
 $-picker-toolbar-height: var(--wot-picker-toolbar-height, 54px) !default; // toolbar 操作条的高度
@@ -531,6 +539,8 @@ $-search-input-padding: var(--wot-search-input-padding, 0 32px 0 42px) !default;
 $-search-input-fs: var(--wot-search-input-fs, $-fs-content) !default; // 输入框字号
 $-search-input-color: var(--wot-search-input-color, #262626) !default; // 输入框文字颜色
 $-search-icon-color: var(--wot-search-icon-color, $-color-icon) !default; // 图标颜色
+$-search-icon-size: var(--wot-search-icon-size, 18px) !default; // 图标大小
+$-search-clear-icon-size: var(--wot-search-clear-icon-size, $-fs-title) !default; // 清除图标大小
 $-search-placeholder-color: var(--wot-search-placeholder-color, #bfbfbf) !default; // placeholder 颜色
 $-search-cancel-padding: var(--wot-search-cancel-padding, 0 $-search-side-padding 0 10px) !default; // 取消按钮间距
 $-search-cancel-fs: var(--wot-search-cancel-fs, $-fs-title) !default; // 取消按钮字号
@@ -592,6 +602,7 @@ $-tabs-nav-bg: var(--wot-tabs-nav-bg, $-color-white) !default; // 背景颜色
 $-tabs-nav-active-color: var(--wot-tabs-nav-active-color, $-color-theme) !default; // 头部高亮颜色
 $-tabs-nav-disabled-color: var(--wot-tabs-nav-disabled-color, rgba(0, 0, 0, 0.25)) !default; // 头部禁用颜色
 $-tabs-nav-line-height: var(--wot-tabs-nav-line-height, 3px) !default; // 高亮边框高度
+$-tabs-nav-line-width: var(--wot-tabs-nav-line-width, 19px) !default; // 高亮边框宽度
 $-tabs-nav-line-bg-color: var(--wot-tabs-nav-line-bg-color, $-color-theme) !default; // 底部条颜色
 $-tabs-nav-map-fs: var(--wot-tabs-nav-map-fs, $-fs-content) !default; // map 类型按钮字号
 $-tabs-nav-map-color: var(--wot-tabs-nav-map-color, rgba(0, 0, 0, 0.85)) !default; // map 类型按钮文字颜色
@@ -706,12 +717,12 @@ $-upload-close-icon-color: var(--wot-upload-close-icon-color, rgba(0, 0, 0, 0.65
 $-upload-progress-fs: var(--wot-upload-progress-fs, 14px) !default; // 进度文字字号
 $-upload-file-fs: var(--wot-upload-file-fs, 12px) !default; // 文件名字号
 $-upload-file-color: var(--wot-upload-file-color, $-color-secondary) !default; // 文件名字颜色
-
-
 $-upload-preview-name-fs: var(--wot-upload-preview-name-fs, 12px) !default; // 预览图片名字号
 $-upload-preview-icon-size: var(--wot-upload-preview-icon-size, 24px) !default; // 预览内部图标尺寸
 $-upload-preview-name-bg: var(--wot-upload-preview-name-bg, rgba(0, 0, 0, 0.6)) !default; // 预览文件名背景色
 $-upload-preview-name-height: var(--wot-upload-preview-name-height, 22px) !default; // 预览文件名背景高度
+$-upload-cover-icon-size: var(--wot-upload-cover-icon-size, 22px) !default; // 视频/文件图标尺寸
+
 
 /* curtain */
 $-curtain-content-radius: var(--wot-curtain-content-radius, 24px) !default; // 内容圆角
@@ -780,6 +791,8 @@ $-tabbar-item-title-font-size: var(--wot-tabbar-item-title-font-size, 10px) !def
 $-tabbar-item-title-line-height: var(--wot-tabbar-item-title-line-height, initial) !default; // tabbar选项标题文字行高
 $-tabbar-inactive-color: var(--wot-tabbar-inactive-color, $-color-title) !default; // 标题文字和图标颜色
 $-tabbar-active-color: var(--wot-tabbar-active-color, $-color-theme) !default; // 选中文字和图标颜色
+$-tabbar-item-icon-size: var(--wot-tabbar-item-icon-size, 20px) !default; // tabbar选项图标大小
+
 
 
 /* navbar */
@@ -799,6 +812,9 @@ $-navbar-capsule-border-color: var(--wot-navbar-capsule-border-color, #e7e7e7) !
 $-navbar-capsule-border-radius: var(--wot-navbar-capsule-border-radius, 16px) !default;
 $-navbar-capsule-width: var(--wot-navbar-capsule-width, 88px) !default;
 $-navbar-capsule-height: var(--wot-navbar-capsule-height, 32px) !default;
+$-navbar-capsule-icon-size: var(--wot-navbar-capsule-icon-size, 20px) !default; // navbar capsule图标大小
+
+
 
 /* table */
 $-table-color: var(--wot-table-color, $-font-gray-1) !default; // 表格字体颜色
@@ -830,7 +846,7 @@ $-sidebar-active-border-height: var(--wot-sidebar-active-border-height, 16px) !d
 $-fab-trigger-height: var(--wot-fab-trigger-height, 56px) !default;
 $-fab-trigger-width: var(--wot-fab-trigger-width, 56px) !default;
 $-fab-actions-padding: var(--wot-actions-padding, 12px) !default;
-
+$-fab-icon-fs: var(--wot-fab-icon-fs, 20px) !default;
 
 /* count-down */
 $-count-down-text-color: var(--wot-count-down-text-color, $-color-gray-8) !default;
@@ -854,6 +870,8 @@ $-number-keyboard-title-font-size: var(--wot-number-keyboard-title-font-size, 16
 $-number-keyboard-close-padding: var(--wot-number-keyboard-title-font-size, 0 16px) !default;
 $-number-keyboard-close-color: var(--wot-number-keyboard-close-color, $-color-theme) !default;
 $-number-keyboard-close-font-size: var(--wot-number-keyboard-close-font-size, 14px) !default;
+$-number-keyboard-icon-size: var(--wot-number-keyboard-icon-size, 22px) !default;
+
 
 /* passwod-input */
 $-password-input-height: var(--wot-password-input-height, 50px);
@@ -880,6 +898,7 @@ $-form-item-error-message-line-height: var(--wot-form-item-error-message-line-he
 
 /* backtop */
 $-backtop-bg: var(--wot-backtop-bg, #e1e1e1) !default;
+$-backtop-icon-size: var(--wot-backtop-icon-size, 20px) !default;
 
 /* index-bar */
 $-index-bar-index-font-size: var(--wot-index-bar-index-font-size, $-fs-aid) !default;
@@ -895,3 +914,7 @@ $-text-success-color: var(--wot-text-success-color, $-color-success) !default;
 $-video-preview-bg: var(--wot-video-preview-bg, rgba(0, 0, 0, 0.8)) !default; // 背景色
 $-video-preview-close-color: var(--wot-video-preview-close-color, #fff) !default; // 图标颜色
 $-video-preview-close-font-size: var(--wot-video-preview-close-font-size, 20px) !default; // 图标大小
+
+/* img-cropper */
+$-img-cropper-icon-size: var(--wot-img-cropper-icon-size, $-fs-big) !default; // 图标大小
+$-img-cropper-icon-color: var(--wot-img-cropper-icon-color, #fff) !default; // 图标颜色

--- a/src/uni_modules/wot-design-uni/components/wd-action-sheet/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-action-sheet/index.scss
@@ -98,6 +98,11 @@
       line-height: initial;
     }
   }
+  
+  @include edeep(action-loading){
+    width: $-action-sheet-loading-size;
+    height: $-action-sheet-loading-size;
+  }
 
   @include e(name) {
     display: inline-block;

--- a/src/uni_modules/wot-design-uni/components/wd-action-sheet/wd-action-sheet.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-action-sheet/wd-action-sheet.vue
@@ -38,7 +38,7 @@
             :style="`color: ${action.color}`"
             @click="select(rowIndex, 'action')"
           >
-            <wd-loading v-if="action.loading" size="20px" />
+            <wd-loading custom-class="`wd-action-sheet__action-loading" v-if="action.loading" />
             <view v-else class="wd-action-sheet__name">{{ action.name }}</view>
             <view v-if="!action.loading && action.subname" class="wd-action-sheet__subname">{{ action.subname }}</view>
           </button>

--- a/src/uni_modules/wot-design-uni/components/wd-backtop/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-backtop/index.scss
@@ -11,6 +11,10 @@
   align-items: center;
   color: $-color-gray-8;
 
+  @include edeep(backicon) {
+    font-size: $-backtop-icon-size;
+  }
+
   @include when(circle) {
     border-radius: 50%;
   }

--- a/src/uni_modules/wot-design-uni/components/wd-backtop/wd-backtop.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-backtop/wd-backtop.vue
@@ -6,7 +6,7 @@
       @click="handleBacktop"
     >
       <slot v-if="$slots.default"></slot>
-      <wd-icon v-else name="backtop" size="20px" :custom-style="iconStyle" />
+      <wd-icon v-else custom-class="wd-backtop__backicon" name="backtop" :custom-style="iconStyle" />
     </view>
   </wd-transition>
 </template>

--- a/src/uni_modules/wot-design-uni/components/wd-checkbox/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-checkbox/index.scss
@@ -111,8 +111,6 @@
     display: inline-block;
     font-size: $-checkbox-icon-size;
     margin-right: 4px;
-    height: $-checkbox-icon-size;
-    width: $-checkbox-icon-size;
     vertical-align: middle;
   }
 

--- a/src/uni_modules/wot-design-uni/components/wd-checkbox/wd-checkbox.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-checkbox/wd-checkbox.vue
@@ -14,7 +14,7 @@
       :class="`wd-checkbox__shape ${innerShape === 'square' ? 'is-square' : ''} ${customShapeClass}`"
       :style="isChecked && !innerDisabled && innerCheckedColor ? 'color :' + innerCheckedColor : ''"
     >
-      <wd-icon custom-class="wd-checkbox__check" name="check-bold" size="14px" />
+      <wd-icon custom-class="wd-checkbox__check" name="check-bold" />
     </view>
     <!--shape为button时只保留wd-checkbox__label-->
     <view
@@ -22,7 +22,7 @@
       :style="isChecked && innerShape === 'button' && !innerDisabled && innerCheckedColor ? 'color:' + innerCheckedColor : ''"
     >
       <!--button选中时展示的icon-->
-      <wd-icon v-if="innerShape === 'button' && isChecked" custom-class="wd-checkbox__btn-check" name="check-bold" size="14px" />
+      <wd-icon v-if="innerShape === 'button' && isChecked" custom-class="wd-checkbox__btn-check" name="check-bold" />
       <!--文案-->
       <view class="wd-checkbox__txt" :style="maxWidth ? 'max-width:' + maxWidth : ''">
         <slot></slot>

--- a/src/uni_modules/wot-design-uni/components/wd-col-picker/wd-col-picker.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-col-picker/wd-col-picker.vue
@@ -43,7 +43,7 @@
         <scroll-view :scroll-x="true" scroll-with-animation :scroll-left="scrollLeft">
           <view class="wd-col-picker__selected-container">
             <view
-              v-for="(select, colIndex) in selectList"
+              v-for="(_, colIndex) in selectList"
               :key="colIndex"
               :class="`wd-col-picker__selected-item  ${colIndex === currentCol && 'is-selected'}`"
               @click="handleColClick(colIndex)"

--- a/src/uni_modules/wot-design-uni/components/wd-config-provider/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-config-provider/types.ts
@@ -83,6 +83,7 @@ export type baseThemeVars = {
 export type actionSheetThemeVars = {
   actionSheetWeight?: string
   actionSheetRadius?: string
+  actionSheetLoadingSize?: string
   actionSheetActionHeight?: string
   actionSheetColor?: string
   actionSheetFs?: string
@@ -289,6 +290,8 @@ export type dropMenuThemeVars = {
   dropMenuHeight?: string
   dropMenuColor?: string
   dropMenuFs?: string
+  dropMenuArrowFs?: string
+
   dropMenuSidePadding?: string
   dropMenuDisabledColor?: string
   dropMenuItemHeight?: string
@@ -359,7 +362,6 @@ export type textareaThemeVars = {
   textareaCountColor?: string
   textareaCountCurrentColor?: string
   textareaBg?: string
-
   textareaCellBorderColor?: string
   textareaCellPadding?: string
   textareaCellPaddingLarge?: string
@@ -375,6 +377,8 @@ export type loadmoreThemeVars = {
   loadmoreColor?: string
   loadmoreFs?: string
   loadmoreErrorColor?: string
+  loadmoreRefreshFs?: string
+  loadmoreLoadingSize?: string
 }
 
 export type messageBoxThemeVars = {
@@ -423,6 +427,7 @@ export type paginationThemeVars = {
   paginationNavContentFs?: string
   paginationNavSepatatorPadding?: string
   paginationNavCurrentColor?: string
+  paginationIconSize?: string
 }
 
 export type pickerThemeVars = {
@@ -542,6 +547,8 @@ export type searchThemeVars = {
   searchInputFs?: string
   searchInputColor?: string
   searchIconColor?: string
+  searchIconSize?: string
+  searchClearIconSize?: string
   searchPlaceholderColor?: string
   searchCancelPadding?: string
   searchCancelFs?: string
@@ -607,6 +614,7 @@ export type tabsThemeVars = {
   tabsNavActiveColor?: string
   tabsNavDisabledColor?: string
   tabsNavLineHeight?: string
+  tabsNavLineWidth?: string
   tabsNavLineBgColor?: string
   tabsNavMapFs?: string
   tabsNavMapColor?: string
@@ -730,11 +738,11 @@ export type uploadThemeVars = {
   uploadProgressFs?: string
   uploadFileFs?: string
   uploadFileColor?: string
-
   uploadPreviewNameFs?: string
   uploadPreviewIconSize?: string
   uploadPreviewNameBg?: string
   uploadPreviewNameHeight?: string
+  uploadCoverIconSize?: string
 }
 
 export type curtainThemeVars = {
@@ -811,6 +819,7 @@ export type tabbarItemThemeVars = {
   tabbarItemTitleLineHeight?: string
   tabbarInactiveColor?: string
   tabbarActiveColor?: string
+  tabbarItemIconSize?: string
 }
 
 export type navbarThemeVars = {
@@ -831,6 +840,7 @@ export type navbarCapsuleThemeVars = {
   navbarCapsuleBorderRadius?: string
   navbarCapsuleWidth?: string
   navbarCapsuleHeight?: string
+  navbarCapsuleIconSize?: string
 }
 
 export type tableThemeVars = {
@@ -866,6 +876,7 @@ export type fabThemeVars = {
   fabTriggerHeight?: string
   fabTriggerWidth?: string
   fabActionsPadding?: string
+  fabIconFs?: string
 }
 
 export type countDownThemeVars = {
@@ -891,6 +902,7 @@ export type numberKeyboardThemeVars = {
   numberKeyboardClosePadding?: string
   numberKeyboardCloseColor?: string
   numberKeyboardCloseFontSize?: string
+  numberKeyboardIconSize?: string
 }
 
 export type passwodInputThemeVars = {
@@ -920,6 +932,7 @@ export type formItemThemeVars = {
 
 export type backtopThemeVars = {
   backtopBg?: string
+  backtopIconSize?: string
 }
 
 export type indexBarThemeVars = {
@@ -938,6 +951,11 @@ export type videoPreviewThemeVars = {
   videoPreviewBg?: string
   videoPreviewCloseColor?: string
   videoPreviewCloseFontSize?: string
+}
+
+export type imgCropperThemeVars = {
+  imgCropperIconSize?: string
+  imgCropperIconColor?: string
 }
 
 export type ConfigProviderThemeVars = baseThemeVars &
@@ -1000,4 +1018,5 @@ export type ConfigProviderThemeVars = baseThemeVars &
   backtopThemeVars &
   indexBarThemeVars &
   textThemeVars &
-  videoPreviewThemeVars
+  videoPreviewThemeVars &
+  imgCropperThemeVars

--- a/src/uni_modules/wot-design-uni/components/wd-curtain/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-curtain/index.scss
@@ -33,6 +33,7 @@
     top: 10px;
     right: 10px;
     color: $-curtain-content-close-color;
+    font-size: $-curtain-content-close-fs;
     -webkit-tap-highlight-color: transparent;
     &.top {
       margin: 0 0 0 -18px;

--- a/src/uni_modules/wot-design-uni/components/wd-curtain/wd-curtain.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-curtain/wd-curtain.vue
@@ -19,7 +19,7 @@
     >
       <view class="wd-curtain__content">
         <image :src="src" class="wd-curtain__content-img" :style="imgStyle" @click="clickImage" @error="imgErr" @load="imgLoad"></image>
-        <wd-icon name="close-outline" size="24px" :custom-class="`wd-curtain__content-close ${closePosition}`" @click="close" />
+        <wd-icon name="close-outline" :custom-class="`wd-curtain__content-close ${closePosition}`" @click="close" />
       </view>
     </wd-popup>
   </view>

--- a/src/uni_modules/wot-design-uni/components/wd-drop-menu/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-drop-menu/index.scss
@@ -84,5 +84,6 @@
     right: -4px;
     transition: transform 0.3s;
     transform: scale(0.6);
+    font-size: $-drop-menu-arrow-fs;
   }
 }

--- a/src/uni_modules/wot-design-uni/components/wd-drop-menu/wd-drop-menu.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-drop-menu/wd-drop-menu.vue
@@ -12,7 +12,7 @@
         >
           <view class="wd-drop-menu__item-title">
             <view class="wd-drop-menu__item-title-text">{{ getDisplayTitle(child) }}</view>
-            <wd-icon name="arrow-down" size="14px" custom-class="wd-drop-menu__arrow" />
+            <wd-icon name="arrow-down" custom-class="wd-drop-menu__arrow" />
           </view>
         </view>
       </view>

--- a/src/uni_modules/wot-design-uni/components/wd-fab/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-fab/index.scss
@@ -111,6 +111,6 @@
   }
 
   @include edeep(icon) {
-    font-size: 20px;
+    font-size: $-fab-icon-fs;
   }
 }

--- a/src/uni_modules/wot-design-uni/components/wd-img-cropper/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-img-cropper/index.scss
@@ -9,11 +9,13 @@
   width: 100vw;
   height: 100vh;
   z-index: 1;
+
   // 裁剪框包裹器
   @include e(wrapper) {
     position: relative;
     background: rgba(0, 0, 0, 0.45);
   }
+
   @include e(cut) {
     z-index: 9;
     position: absolute;
@@ -30,21 +32,26 @@
       // 拖动中背景蒙层为0 拖动结束为0.85
       background-color: rgba(0, 0, 0, 0.85);
       transition: background 0.2s;
+
       @include when(hightlight) {
         background-color: rgba(0, 0, 0, 0);
       }
     }
+
     .wd-img-cropper__cut--bottom,
     .wd-img-cropper__cut--right {
       flex: auto;
     }
+
     @include m(middle) {
       display: flex;
     }
+
     @include m(body) {
       // 若需要变化窗体大小，支持控制窗体的大小来控制下方所有对应的展示
       background-color: transparent;
       position: relative;
+
       // 节选框的窗体最外部边缘线
       &::before {
         content: "";
@@ -59,6 +66,7 @@
 
       // 结算框对角尺寸
       $border-size: 2px;
+
       // 节选框的四个角
       .is-left-top,
       .is-left-bottom,
@@ -71,6 +79,7 @@
           height: 20px;
           background-color: #fff;
         }
+
         &::after {
           content: "";
           position: absolute;
@@ -79,28 +88,36 @@
           background-color: #fff;
         }
       }
+
       .is-left-top {
+
         &::before,
         &::after {
           left: -$border-size;
           top: -$border-size;
         }
       }
+
       .is-left-bottom {
+
         &::before,
         &::after {
           left: -$border-size;
           bottom: -$border-size;
         }
       }
+
       .is-right-top {
+
         &::before,
         &::after {
           right: -$border-size;
           top: -$border-size;
         }
       }
+
       .is-right-bottom {
+
         &::before,
         &::after {
           right: -$border-size;
@@ -118,8 +135,10 @@
         top: 0;
         display: flex;
       }
+
       .is-gridlines-x {
         justify-content: center;
+
         &::before {
           content: "";
           display: inline-block;
@@ -131,9 +150,11 @@
           transform: scale(0.5) translate(0, -50%);
         }
       }
+
       // 内部网格线 - y轴
       .is-gridlines-y {
         align-items: center;
+
         &::after {
           content: "";
           flex-shrink: 0;
@@ -148,6 +169,7 @@
       }
     }
   }
+
   @include e(img) {
     z-index: 2;
     top: 0;
@@ -158,6 +180,7 @@
     backface-visibility: hidden;
     transform-origin: center;
   }
+
   @include e(canvas) {
     position: fixed;
     background: white;
@@ -167,6 +190,7 @@
     top: -200%;
     pointer-events: none;
   }
+
   @include e(footer) {
     position: fixed;
     z-index: 10;
@@ -174,6 +198,7 @@
     width: 100%;
     height: 15vh;
     text-align: center;
+
     @include m(button) {
       position: relative;
       text-align: left;
@@ -181,11 +206,13 @@
       padding-top: 4vh;
       // line-height: 32px;
       box-sizing: border-box;
+
       .is-cancel {
         display: inline-block;
         color: #fff;
         font-size: 16px;
       }
+
       .is-confirm {
         position: absolute;
         right: 0;
@@ -195,5 +222,10 @@
         font-size: 16px;
       }
     }
+  }
+
+  @include edeep(rotate) {
+    font-size: $-img-cropper-icon-size;
+    color: $-img-cropper-icon-color;
   }
 }

--- a/src/uni_modules/wot-design-uni/components/wd-img-cropper/wd-img-cropper.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-img-cropper/wd-img-cropper.vue
@@ -56,7 +56,7 @@
     />
     <!-- 下方按钮 -->
     <view class="wd-img-cropper__footer">
-      <wd-icon v-if="!disabledRotate" name="rotate" size="24px" color="#fff" data-eventsync="true" @click="handleRotate"></wd-icon>
+      <wd-icon custom-class="wd-img-cropper__rotate" v-if="!disabledRotate" name="rotate" @click="handleRotate"></wd-icon>
       <view class="wd-img-cropper__footer--button">
         <view class="is-cancel" @click="handleCancel">{{ cancelButtonText || translate('cancel') }}</view>
         <wd-button size="small" :custom-style="buttonStyle" @click="handleConfirm">{{ confirmButtonText || translate('confirm') }}</wd-button>

--- a/src/uni_modules/wot-design-uni/components/wd-loadmore/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-loadmore/index.scss
@@ -17,6 +17,8 @@
     display: inline-block;
     margin-right: 8px;
     vertical-align:  middle;
+    width: $-loadmore-loading-size;
+    height: $-loadmore-loading-size;
   }
   @include e(text) {
     display: inline-block;
@@ -32,5 +34,6 @@
     display: inline-block;
     color: $-loadmore-error-color;
     vertical-align: middle;
+    font-size: $-loadmore-refresh-fs;
   }
 }

--- a/src/uni_modules/wot-design-uni/components/wd-loadmore/wd-loadmore.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-loadmore/wd-loadmore.vue
@@ -8,11 +8,11 @@
       <block v-else>
         <text class="wd-loadmore__text">{{ translate('error') }}</text>
         <text class="wd-loadmore__text is-light">{{ translate('retry') }}</text>
-        <wd-icon name="refresh" size="16px" custom-class="wd-loadmore__refresh" />
+        <wd-icon name="refresh" custom-class="wd-loadmore__refresh" />
       </block>
     </block>
     <block v-if="state === 'loading'">
-      <wd-loading size="16px" custom-class="wd-loadmore__loading" />
+      <wd-loading custom-class="wd-loadmore__loading" />
       <text class="wd-loadmore__text">{{ loadingText || translate('loading') }}</text>
     </block>
   </view>

--- a/src/uni_modules/wot-design-uni/components/wd-navbar-capsule/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-navbar-capsule/index.scss
@@ -61,5 +61,6 @@
     flex: 1;
     position: relative;
     color: $-navbar-desc-font-color;
+    font-size: $-navbar-capsule-icon-size;
   }
 }

--- a/src/uni_modules/wot-design-uni/components/wd-navbar-capsule/wd-navbar-capsule.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-navbar-capsule/wd-navbar-capsule.vue
@@ -1,7 +1,7 @@
 <template>
   <view class="wd-navbar-capsule">
-    <wd-icon @click="handleBack" size="20px" name="chevron-left" custom-class="wd-navbar-capsule__icon" />
-    <wd-icon @click="handleBackHome" size="20px" name="home" custom-class="wd-navbar-capsule__icon" />
+    <wd-icon @click="handleBack" name="chevron-left" custom-class="wd-navbar-capsule__icon" />
+    <wd-icon @click="handleBackHome" name="home" custom-class="wd-navbar-capsule__icon" />
   </view>
 </template>
 <script lang="ts">

--- a/src/uni_modules/wot-design-uni/components/wd-navbar/wd-navbar.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-navbar/wd-navbar.vue
@@ -13,7 +13,7 @@
           @click="handleClickLeft"
           v-else-if="!$slots.left"
         >
-          <wd-icon v-if="leftArrow" size="24px" name="arrow-left" custom-class="wd-navbar__arrow" />
+          <wd-icon v-if="leftArrow" name="arrow-left" custom-class="wd-navbar__arrow" />
           <view v-if="leftText" class="wd-navbar__text">{{ leftText }}</view>
         </view>
 

--- a/src/uni_modules/wot-design-uni/components/wd-notice-bar/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-notice-bar/index.scss
@@ -23,18 +23,12 @@
   }
   @include edeep(prefix) {
     padding-right: 4px;
-    width: $-notice-bar-prefix-size;
-    height: $-notice-bar-prefix-size;
-    line-height: $-notice-bar-prefix-size;
+    font-size: $-notice-bar-prefix-size;
   }
-
-
 
   @include edeep(suffix) {
     text-align: center;
-    width: $-notice-bar-close-size;
-    height: $-notice-bar-close-size;
-    line-height: $-notice-bar-close-size;
+    font-size: $-notice-bar-close-size;
     display: inline-block;
     background-color: $-notice-bar-close-bg;
     color: $-notice-bar-close-color;

--- a/src/uni_modules/wot-design-uni/components/wd-notice-bar/wd-notice-bar.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-notice-bar/wd-notice-bar.vue
@@ -1,6 +1,6 @@
 <template>
   <view v-if="show" :class="`wd-notice-bar ${customClass} ${noticeBarClass}`" :style="rootStyle">
-    <wd-icon v-if="prefix" custom-class="wd-notice-bar__prefix" size="18px" :name="prefix"></wd-icon>
+    <wd-icon v-if="prefix" custom-class="wd-notice-bar__prefix" :name="prefix"></wd-icon>
     <slot v-else name="prefix"></slot>
     <view class="wd-notice-bar__wrap">
       <view class="wd-notice-bar__content" :style="animation" @transitionend="animationEnd" @click="handleClick">
@@ -11,7 +11,7 @@
         <slot v-else>{{ currentText }}</slot>
       </view>
     </view>
-    <wd-icon v-if="closable" custom-class="wd-notice-bar__suffix" size="18px" name="close-bold" @click="handleClose"></wd-icon>
+    <wd-icon v-if="closable" custom-class="wd-notice-bar__suffix" name="close-bold" @click="handleClose"></wd-icon>
     <slot v-else name="suffix"></slot>
   </view>
 </template>

--- a/src/uni_modules/wot-design-uni/components/wd-number-keyboard/key/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-number-keyboard/key/index.scss
@@ -13,7 +13,7 @@
     @include m(active) {
       background-color: $-dark-background4;
     }
- 
+
   }
 }
 
@@ -73,4 +73,9 @@
   @include edeep(loading-icon) {
     color: $-number-keyboard-button-text-color;
   }
+
+  @include edeep(icon) {
+    font-size: $-number-keyboard-icon-size;
+  }
+
 }

--- a/src/uni_modules/wot-design-uni/components/wd-number-keyboard/key/index.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-number-keyboard/key/index.vue
@@ -1,18 +1,18 @@
 <template>
   <view :class="`wd-key-wrapper ${wider ? 'wd-key-wrapper--wider' : ''}`" @touchstart="onTouchStart" @touchmove="onTouchMove" @touchend="onTouchEnd">
     <view :class="keyClass">
-      <wd-loading custom-class="wd-key--loading-icon" v-if="props.loading" />
+      <wd-loading custom-class="wd-key__loading-icon" v-if="props.loading" />
       <template v-if="type === 'delete'">
         <template v-if="text">
           {{ text }}
         </template>
-        <wd-icon v-else name="keyboard-delete" size="22px"></wd-icon>
+        <wd-icon v-else custom-class="wd-key__icon" name="keyboard-delete" size="22px"></wd-icon>
       </template>
       <template v-else-if="type === 'extra'">
         <template v-if="text">
           {{ text }}
         </template>
-        <wd-icon v-else name="keyboard-collapse" size="22px"></wd-icon>
+        <wd-icon v-else custom-class="wd-key__icon" name="keyboard-collapse" size="22px"></wd-icon>
       </template>
       <template v-else>{{ text }}</template>
     </view>

--- a/src/uni_modules/wot-design-uni/components/wd-pagination/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-pagination/index.scss
@@ -13,6 +13,11 @@
 @include b(pager) {
   user-select: none;
   background-color: #fff;
+
+  @include edeep(icon) {
+    font-size: $-pagination-icon-size;
+  }
+
   @include e(content) {
     display: flex;
     justify-content: flex-start;

--- a/src/uni_modules/wot-design-uni/components/wd-pagination/wd-pagination.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-pagination/wd-pagination.vue
@@ -5,8 +5,7 @@
         <text v-if="!showIcon">{{ prevText || translate('prev') }}</text>
         <wd-icon
           v-else
-          size="14px"
-          :custom-class="`wd-pager__left ${modelValue <= 1 ? 'wd-pager__nav--disabled' : 'wd-pager__nav--active'}`"
+          :custom-class="`wd-pager__left wd-pager__icon ${modelValue <= 1 ? 'wd-pager__nav--disabled' : 'wd-pager__nav--active'}`"
           name="arrow-right"
         ></wd-icon>
       </wd-button>
@@ -26,8 +25,7 @@
         <text v-if="!showIcon">{{ nextText || translate('next') }}</text>
         <wd-icon
           v-else
-          size="14px"
-          :custom-class="modelValue >= totalPageNum ? 'wd-pager__nav--disabled' : 'wd-pager__nav--active'"
+          :custom-class="`wd-pager__icon ${modelValue >= totalPageNum ? 'wd-pager__nav--disabled' : 'wd-pager__nav--active'}`"
           name="arrow-right"
         ></wd-icon>
       </wd-button>

--- a/src/uni_modules/wot-design-uni/components/wd-search/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-search/index.scss
@@ -99,19 +99,15 @@
   @include edeep(search-icon) {
     margin-right: 8px;
     color: $-search-icon-color;
-    font-size: $-search-input-fs;
-    height: $-search-input-height;
+    font-size: $-search-icon-size;
   }
   @include edeep(search-left-icon) {
     position: absolute;
-    display: inline-block;
-    height: $-search-input-height;
-    line-height: $-search-input-height;
+    font-size: $-search-icon-size;
     top: 50%;
     left: 16px;
     transform: translateY(-50%);
     color: $-search-icon-color;
-    font-size: $-search-input-fs;
   }
   @include e(placeholder-txt) {
     color: $-search-placeholder-color;
@@ -125,6 +121,7 @@
   }
   @include edeep(clear-icon) {
     vertical-align: middle;
+    font-size: $-search-clear-icon-size;
   }
   @include e(cancel) {
     padding: $-search-cancel-padding;

--- a/src/uni_modules/wot-design-uni/components/wd-search/wd-search.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-search/wd-search.vue
@@ -6,11 +6,11 @@
       <slot name="prefix"></slot>
       <view class="wd-search__field">
         <view v-if="!placeholderLeft" :style="coverStyle" class="wd-search__cover" @click="closeCover">
-          <wd-icon name="search" size="18px" custom-class="wd-search__search-icon"></wd-icon>
+          <wd-icon name="search" custom-class="wd-search__search-icon"></wd-icon>
           <text class="wd-search__placeholder-txt">{{ placeholder || translate('search') }}</text>
         </view>
         <!--icon:search-->
-        <wd-icon v-if="showInput || str || placeholderLeft" name="search" size="18px" custom-class="wd-search__search-left-icon"></wd-icon>
+        <wd-icon v-if="showInput || str || placeholderLeft" name="search" custom-class="wd-search__search-left-icon"></wd-icon>
         <!--搜索框-->
         <input
           v-if="showInput || str || placeholderLeft"
@@ -28,7 +28,7 @@
           :focus="isFocused"
         />
         <!--icon:clear-->
-        <wd-icon v-if="str" custom-class="wd-search__clear wd-search__clear-icon" name="error-fill" size="16px" @click="clearSearch" />
+        <wd-icon v-if="str" custom-class="wd-search__clear wd-search__clear-icon" name="error-fill" @click="clearSearch" />
       </view>
     </view>
     <!--the button behind input,care for hideCancel without displaying-->

--- a/src/uni_modules/wot-design-uni/components/wd-sidebar-item/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-sidebar-item/index.scss
@@ -93,15 +93,4 @@
     margin-right: 2px;
   }
 
-  // @include e(line) {
-  //   width: 6rpx;
-  //   height: 28rpx;
-  //   position: absolute;
-  //   left: 0;
-  //   top: 50%;
-  //   transform: translateY(-50%);
-  //   background: $-sidebar-active-color;
-  //   border-radius: 8rpx;
-  // }
-
 }

--- a/src/uni_modules/wot-design-uni/components/wd-sidebar-item/wd-sidebar-item.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-sidebar-item/wd-sidebar-item.vue
@@ -8,7 +8,7 @@
   >
     <slot name="icon"></slot>
     <template v-if="!$slots.icon && icon">
-      <wd-icon custom-class="wd-sidebar-item__icon" :name="icon" size="20px"></wd-icon>
+      <wd-icon custom-class="wd-sidebar-item__icon" :name="icon"></wd-icon>
     </template>
     <wd-badge v-bind="customBadgeProps" custom-class="wd-sidebar-item__badge">
       {{ label }}

--- a/src/uni_modules/wot-design-uni/components/wd-tabbar-item/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-tabbar-item/index.scss
@@ -47,5 +47,9 @@
     font-size: $-tabbar-item-title-font-size;
     line-height: $-tabbar-item-title-line-height;
   }
+
+  @include edeep(body-icon) {
+    font-size: $-tabbar-item-icon-size;
+  }
   
 }

--- a/src/uni_modules/wot-design-uni/components/wd-tabbar-item/wd-tabbar-item.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-tabbar-item/wd-tabbar-item.vue
@@ -4,7 +4,11 @@
       <view class="wd-tabbar-item__body">
         <slot name="icon" :active="active"></slot>
         <template v-if="!$slots.icon && icon">
-          <wd-icon :name="icon" size="20px" :custom-style="textStyle" :custom-class="active ? 'is-active' : 'is-inactive'"></wd-icon>
+          <wd-icon
+            :name="icon"
+            :custom-style="textStyle"
+            :custom-class="`wd-tabbar-item__body-icon ${active ? 'is-active' : 'is-inactive'}`"
+          ></wd-icon>
         </template>
         <text v-if="title" :style="textStyle" :class="`wd-tabbar-item__body-title ${active ? 'is-active' : 'is-inactive'}`">
           {{ title }}

--- a/src/uni_modules/wot-design-uni/components/wd-tabs/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/index.scss
@@ -113,10 +113,11 @@
     position: absolute;
     bottom: 4px;
     left: 0;
-    height: $-tabs-nav-line-height;
-    background: $-tabs-nav-line-bg-color;
     z-index: 1;
-    border-radius: 1.5px;
+    height: $-tabs-nav-line-height;
+    width: $-tabs-nav-line-width;
+    background: $-tabs-nav-line-bg-color;
+    border-radius: calc($-tabs-nav-line-height / 2);
   }
 
   @include e(container) {

--- a/src/uni_modules/wot-design-uni/components/wd-tabs/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/types.ts
@@ -1,5 +1,5 @@
 import { type ExtractPropTypes, type InjectionKey } from 'vue'
-import { baseProps, makeBooleanProp, makeNumberProp, makeNumericProp, makeStringProp } from '../common/props'
+import { baseProps, makeBooleanProp, makeNumberProp, makeNumericProp, makeStringProp, numericProp } from '../common/props'
 
 export type TabsProvide = {
   state: {
@@ -38,11 +38,11 @@ export const tabsProps = {
   /**
    * 底部条宽度，单位像素
    */
-  lineWidth: makeNumberProp(19),
+  lineWidth: numericProp,
   /**
    * 底部条高度，单位像素
    */
-  lineHeight: makeNumberProp(3),
+  lineHeight: numericProp,
   /**
    * 颜色
    */

--- a/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
@@ -9,7 +9,7 @@
           <!--头部导航容器-->
           <view class="wd-tabs__nav wd-tabs__nav--sticky">
             <view class="wd-tabs__nav--wrap">
-              <scroll-view :scroll-x="slidableNum < items.length" scroll-with-animation :scroll-left="scrollLeft">
+              <scroll-view :scroll-x="slidableNum < items.length" scroll-with-animation :scroll-left="state.scrollLeft">
                 <view class="wd-tabs__nav-container">
                   <!--nav列表-->
                   <view
@@ -22,21 +22,21 @@
                     {{ item.title }}
                   </view>
                   <!--下划线-->
-                  <view class="wd-tabs__line" :style="lineStyle"></view>
+                  <view class="wd-tabs__line" :style="state.lineStyle"></view>
                 </view>
               </scroll-view>
             </view>
             <!--map表-->
             <view class="wd-tabs__map" v-if="mapNum < items.length && mapNum !== 0">
-              <view :class="`wd-tabs__map-btn  ${animating ? 'is-open' : ''}`" @click="toggleMap">
-                <view :class="`wd-tabs__map-arrow  ${animating ? 'is-open' : ''}`">
+              <view :class="`wd-tabs__map-btn  ${state.animating ? 'is-open' : ''}`" @click="toggleMap">
+                <view :class="`wd-tabs__map-arrow  ${state.animating ? 'is-open' : ''}`">
                   <wd-icon name="arrow-down" />
                 </view>
               </view>
-              <view class="wd-tabs__map-header" :style="`${mapShow ? '' : 'display:none;'}  ${animating ? 'opacity:1;' : ''}`">
+              <view class="wd-tabs__map-header" :style="`${state.mapShow ? '' : 'display:none;'}  ${state.animating ? 'opacity:1;' : ''}`">
                 {{ translate('all') }}
               </view>
-              <view :class="`wd-tabs__map-body  ${animating ? 'is-open' : ''}`" :style="mapShow ? '' : 'display:none'">
+              <view :class="`wd-tabs__map-body  ${state.animating ? 'is-open' : ''}`" :style="state.mapShow ? '' : 'display:none'">
                 <view class="wd-tabs__map-nav-item" v-for="(item, index) in items" :key="index" @click="handleSelect(index)">
                   <view
                     :class="`wd-tabs__map-nav-btn ${state.activeIndex === index ? 'is-active' : ''}  ${item.disabled ? 'is-disabled' : ''}`"
@@ -66,7 +66,11 @@
         </view>
 
         <!--map表的阴影浮层-->
-        <view class="wd-tabs__mask" :style="`${mapShow ? '' : 'display:none;'} ${animating ? 'opacity:1;' : ''}`" @click="toggleMap"></view>
+        <view
+          class="wd-tabs__mask"
+          :style="`${state.mapShow ? '' : 'display:none;'} ${state.animating ? 'opacity:1;' : ''}`"
+          @click="toggleMap"
+        ></view>
       </view>
     </wd-sticky-box>
   </template>
@@ -76,7 +80,7 @@
       <!--头部导航容器-->
       <view class="wd-tabs__nav">
         <view class="wd-tabs__nav--wrap">
-          <scroll-view :scroll-x="slidableNum < items.length" scroll-with-animation :scroll-left="scrollLeft">
+          <scroll-view :scroll-x="slidableNum < items.length" scroll-with-animation :scroll-left="state.scrollLeft">
             <view class="wd-tabs__nav-container">
               <!--nav列表-->
               <view
@@ -89,21 +93,21 @@
                 {{ item.title }}
               </view>
               <!--下划线-->
-              <view class="wd-tabs__line" :style="lineStyle"></view>
+              <view class="wd-tabs__line" :style="state.lineStyle"></view>
             </view>
           </scroll-view>
         </view>
         <!--map表-->
         <view class="wd-tabs__map" v-if="mapNum < items.length && mapNum !== 0">
           <view class="wd-tabs__map-btn" @click="toggleMap">
-            <view :class="`wd-tabs__map-arrow ${animating ? 'is-open' : ''}`">
+            <view :class="`wd-tabs__map-arrow ${state.animating ? 'is-open' : ''}`">
               <wd-icon name="arrow-down" />
             </view>
           </view>
-          <view class="wd-tabs__map-header" :style="`${mapShow ? '' : 'display:none;'}  ${animating ? 'opacity:1;' : ''}`">
+          <view class="wd-tabs__map-header" :style="`${state.mapShow ? '' : 'display:none;'}  ${state.animating ? 'opacity:1;' : ''}`">
             {{ translate('all') }}
           </view>
-          <view :class="`wd-tabs__map-body ${animating ? 'is-open' : ''}`" :style="mapShow ? '' : 'display:none'">
+          <view :class="`wd-tabs__map-body ${state.animating ? 'is-open' : ''}`" :style="state.mapShow ? '' : 'display:none'">
             <view class="wd-tabs__map-nav-item" v-for="(item, index) in items" :key="index" @click="handleSelect(index)">
               <view :class="`wd-tabs__map-nav-btn ${state.activeIndex === index ? 'is-active' : ''}  ${item.disabled ? 'is-disabled' : ''}`">
                 {{ item.title }}
@@ -121,7 +125,7 @@
       </view>
 
       <!--map表的阴影浮层-->
-      <view class="wd-tabs__mask" :style="`${mapShow ? '' : 'display:none;'}  ${animating ? 'opacity:1' : ''}`" @click="toggleMap"></view>
+      <view class="wd-tabs__mask" :style="`${state.mapShow ? '' : 'display:none;'}  ${state.animating ? 'opacity:1' : ''}`" @click="toggleMap"></view>
     </view>
   </template>
 </template>
@@ -136,8 +140,8 @@ export default {
 }
 </script>
 <script lang="ts" setup>
-import { computed, getCurrentInstance, onMounted, ref, watch, nextTick, reactive } from 'vue'
-import { checkNumRange, debounce, getRect, isDef, isNumber, isString, objToStyle } from '../common/util'
+import { computed, getCurrentInstance, onMounted, ref, watch, nextTick, reactive, type CSSProperties } from 'vue'
+import { addUnit, checkNumRange, debounce, getRect, isDef, isNumber, isString, objToStyle } from '../common/util'
 import { useTouch } from '../composables/useTouch'
 import { TABS_KEY, tabsProps } from './types'
 import { useChildren } from '../composables/useChildren'
@@ -151,20 +155,16 @@ const emit = defineEmits(['change', 'disabled', 'click', 'update:modelValue'])
 
 const { translate } = useTranslate('tabs')
 
-// 选中值的索引，默认第一个
-const state = reactive({ activeIndex: 0 })
-// navBar的下划线样式
-const lineStyle = ref<string>('')
+const state = reactive({
+  activeIndex: 0, // 选中值的索引，默认第一个
+  lineStyle: 'display:none;', // 激活项边框线样式
+  inited: false, // 是否初始化
+  animating: false, // 是否动画中
+  mapShow: false, // map的开关
+  scrollLeft: 0 // scroll-view偏移量
+})
 
 // map的开关
-const mapShow = ref<boolean>(false)
-// scroll-view偏移量
-const scrollLeft = ref<number>(0)
-
-// 是否动画中
-const animating = ref<boolean>(false)
-
-const inited = ref<boolean>(false)
 
 const { children, linkChildren } = useChildren(TABS_KEY)
 linkChildren({ state })
@@ -253,7 +253,7 @@ watch(
 watch(
   () => children.length,
   () => {
-    if (inited.value) {
+    if (state.inited) {
       nextTick(() => {
         setActive(props.modelValue)
       })
@@ -276,7 +276,7 @@ watch(
 )
 
 onMounted(() => {
-  inited.value = true
+  state.inited = true
   nextTick(() => {
     setActive(props.modelValue, true)
   })
@@ -287,15 +287,15 @@ onMounted(() => {
  */
 function toggleMap() {
   // 必须保证display和transition不在同一个帧
-  if (mapShow.value) {
-    animating.value = false
+  if (state.mapShow) {
+    state.animating = false
     setTimeout(() => {
-      mapShow.value = false
+      state.mapShow = false
     }, 300)
   } else {
-    mapShow.value = true
+    state.mapShow = true
     setTimeout(() => {
-      animating.value = true
+      state.animating = true
     }, 100)
   }
 }
@@ -305,32 +305,32 @@ function toggleMap() {
  * @param {Boolean} animation 是否伴随动画
  */
 function updateLineStyle(animation: boolean = true) {
-  if (!inited.value) return
+  if (!state.inited) return
   const { lineWidth, lineHeight } = props
   getRect($item, true, proxy).then((rects) => {
-    const rect = rects[state.activeIndex]
-    const width = lineWidth
-    let left = rects.slice(0, state.activeIndex).reduce((prev, curr) => prev + Number(curr.width), 0)
-    left += (Number(rect.width) - width) / 2
-    const transition = animation ? 'transition: width 300ms ease, transform 300ms ease;' : ''
+    const lineStyle: CSSProperties = {}
 
-    const lineStyleTemp = `
-            height: ${lineHeight}px;
-            width: ${width}px;
-            transform: translateX(${left}px);
-            ${transition}
-          `
-    // 防止重复绘制
-    if (lineStyle.value !== lineStyleTemp) {
-      lineStyle.value = lineStyleTemp
+    if (isDef(lineWidth)) {
+      lineStyle.width = addUnit(lineWidth)
     }
+    if (isDef(lineHeight)) {
+      lineStyle.height = addUnit(lineHeight)
+      lineStyle.borderRadius = `calc(${addUnit(lineHeight)} / 2)`
+    }
+    const rect = rects[state.activeIndex]
+    let left = rects.slice(0, state.activeIndex).reduce((prev, curr) => prev + Number(curr.width), 0) + Number(rect.width) / 2
+    lineStyle.transform = `translateX(${left}px) translateX(-50%)`
+    if (animation) {
+      lineStyle.transition = 'width 300ms ease, transform 300ms ease'
+    }
+    state.lineStyle = objToStyle(lineStyle)
   })
 }
 /**
  * @description 通过控制tab的active来展示选定的tab
  */
 function setActiveTab() {
-  if (!inited.value) return
+  if (!state.inited) return
   if (items.value[state.activeIndex].name !== props.modelValue) {
     emit('change', {
       index: state.activeIndex,
@@ -343,7 +343,7 @@ function setActiveTab() {
  * @description scroll-view滑动到active的tab_nav
  */
 function scrollIntoView() {
-  if (!inited.value) return
+  if (!state.inited) return
   Promise.all([getRect($item, true, proxy), getRect($container, false, proxy)]).then(([navItemsRects, navRect]) => {
     // 选中元素
     const selectItem = navItemsRects[state.activeIndex]
@@ -351,10 +351,10 @@ function scrollIntoView() {
     const offsetLeft = (navItemsRects as any).slice(0, state.activeIndex).reduce((prev: any, curr: any) => prev + curr.width, 0)
     // scroll-view滑动到selectItem的偏移量
     const left = offsetLeft - ((navRect as any).width - Number(selectItem.width)) / 2
-    if (left === scrollLeft.value) {
-      scrollLeft.value = left + Math.random() / 10000
+    if (left === state.scrollLeft) {
+      state.scrollLeft = left + Math.random() / 10000
     } else {
-      scrollLeft.value = left
+      state.scrollLeft = left
     }
   })
 }
@@ -372,7 +372,7 @@ function handleSelect(index: number) {
     })
     return
   }
-  mapShow.value && toggleMap()
+  state.mapShow && toggleMap()
   setActive(index)
   emit('click', {
     index,

--- a/src/uni_modules/wot-design-uni/components/wd-upload/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-upload/index.scss
@@ -93,6 +93,10 @@
     background-color: $-upload-evoke-bg;
   }
 
+  @include e(video-icon, file-icon) {
+    font-size: $-upload-cover-icon-size;
+  }
+
   @include e(file-name, video-name) {
     width: 100%;
     font-size: $-upload-file-fs;

--- a/src/uni_modules/wot-design-uni/components/wd-upload/wd-upload.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-upload/wd-upload.vue
@@ -12,7 +12,7 @@
           </view>
           <view v-else class="wd-upload__video" @click="onPreviewVideo(file)">
             <!-- #ifdef APP-PLUS || MP-DINGTALK -->
-            <wd-icon name="video" size="22px"></wd-icon>
+            <wd-icon custom-class="wd-upload__video-icon" name="video"></wd-icon>
             <!-- #endif -->
             <!-- #ifndef APP-PLUS -->
             <!-- #ifndef MP-DINGTALK -->
@@ -40,7 +40,7 @@
         </template>
 
         <view v-else class="wd-upload__file" @click="onPreviewFile(file)">
-          <wd-icon name="file" size="22px"></wd-icon>
+          <wd-icon name="file" custom-class="wd-upload__file-icon"></wd-icon>
           <view class="wd-upload__file-name">{{ file.name || file.url }}</view>
         </view>
       </view>


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [x] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
#190 #145 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
***现状***
组件库内部出于通用性的考虑使用px作为单位，关于大屏设备的视频，例如平板更加推崇大屏显示更多内容的设计，而非大屏显示内容更大。不过存在一些场景，如某些Iot设备，实际比例与手机一致只不过更大，此时就需要使用rpx单位来兼容这些设备。  

***解决方案***。

调整组件库内容内部`icon`、`loading`、`image`等组件size属性的使用，在组件库内部尽量使用class设置组件的尺寸，以搭配`postcss`工具实现将组件库中`px`转成`rpx`。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充