### PR TITLE
docs: ✏️  允许文档组件列表折叠收起

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -188,6 +188,7 @@ export default defineConfig({
       '/component/': [
         {
           text: '基础',
+          collapsed: false,
           items: [
             {
               link: "/component/button",
@@ -222,6 +223,7 @@ export default defineConfig({
         {
 
           text: "导航",
+          collapsed: false,
           items: [{
             link: "/component/pagination",
             text: "Pagination 分页"
@@ -253,6 +255,7 @@ export default defineConfig({
         }, {
 
           text: "数据输入",
+          collapsed: false,
           items: [{
             link: "/component/calendar",
             text: "Calendar 日历选择器"
@@ -316,6 +319,7 @@ export default defineConfig({
           }]
         }, {
           text: "反馈",
+          collapsed: false,
           items: [{
             link: "/component/action-sheet",
             text: "ActionSheet 动作面板"
@@ -368,6 +372,7 @@ export default defineConfig({
         }, {
 
           text: "数据展示",
+          collapsed: false,
           items: [{
             link: "/component/badge",
             text: "Badge 徽标"


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

随着 `wot-uni-design` 组件数量增加，文档中组件列表太长，位置靠后的组件翻阅体验变差。因此将列表改为允许收起，方便开发者浏览。

> 本次改动不影响现有文档体验，默认全部列表依然展开。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充