### PR TITLE
fix: 🐛 修复Textarea的placeholder无法设置空字符串问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-textarea/wd-textarea.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-textarea/wd-textarea.vue
@@ -17,7 +17,7 @@
         :class="`wd-textarea__inner ${customTextareaClass}`"
         v-model="inputValue"
         :show-count="false"
-        :placeholder="placeholder || translate('placeholder')"
+        :placeholder="placeholder ?? translate('placeholder')"
         :disabled="disabled"
         :maxlength="maxlength"
         :focus="isFocus"

--- a/src/uni_modules/wot-design-uni/components/wd-textarea/wd-textarea.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-textarea/wd-textarea.vue
@@ -17,7 +17,7 @@
         :class="`wd-textarea__inner ${customTextareaClass}`"
         v-model="inputValue"
         :show-count="false"
-        :placeholder="placeholder ?? translate('placeholder')"
+        :placeholder="placeholderValue"
         :disabled="disabled"
         :maxlength="maxlength"
         :focus="isFocus"
@@ -72,7 +72,7 @@ export default {
 
 <script lang="ts" setup>
 import { computed, onBeforeMount, ref, watch } from 'vue'
-import { objToStyle, requestAnimationFrame } from '../common/util'
+import { objToStyle, requestAnimationFrame, isDef } from '../common/util'
 import { useCell } from '../composables/useCell'
 import { FORM_KEY, type FormItemRule } from '../wd-form/types'
 import { useParent } from '../composables/useParent'
@@ -95,6 +95,10 @@ const emit = defineEmits([
   'clickprefixicon',
   'click'
 ])
+
+const placeholderValue = computed(() => {
+  return isDef(props.placeholder) ? props.placeholder : translate('placeholder')
+})
 
 const showClear = ref<boolean>(false)
 const showWordCount = ref<boolean>(false)


### PR DESCRIPTION
✅ Closes: #471

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

#471

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

更改判断方式，不再过滤空字符串

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新特性**
	- 修改了 `wd-textarea` 组件的占位符处理逻辑，确保有效的空字符串保留，而仅在占位符为 `null` 或 `undefined` 时回退到翻译函数，从而提升了用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->