### PR TITLE
feat(drop-menu): 支持自定义图标以及覆盖默认点击事件

### DIFF
--- a/docs/component/drop-menu.md
+++ b/docs/component/drop-menu.md
@@ -114,19 +114,30 @@ function handleOpened() {
 
 ## 自定义菜单图标
 
-可以通过 icon 设置菜单右侧图标，等同于 `<wd-icon />` 的 name 属性。通过 icon-size 设置图标尺寸，等同于 `<wd-icon />` 的 size 属性。
-
-可以通过 custom-click 来自定义菜单点击事件，不传则默认展开菜单。
+可以通过 `icon` 设置菜单右侧图标，等同于 `<wd-icon />` 的 `name` 属性。通过 `icon-size` 设置图标尺寸，等同于 `<wd-icon />` 的 `size` 属性。
 
 ```html
 <wd-drop-menu>
-  <wd-drop-menu-item title="地图" icon="location" icon-size="24px" :custom-click="handleClick" />
+  <wd-drop-menu-item title="地图" icon="location" icon-size="24px" />
+</wd-drop-menu>
+```
+
+## 自定义菜单点击事件
+
+可以通过 `before-toggle` 来自定义菜单点击事件，不传则默认展开菜单。
+
+```html
+<wd-drop-menu>
+  <wd-drop-menu-item title="延迟 0.5s 展开" :before-toggle="handleBeforeToggle" />
 </wd-drop-menu>
 ```
 
 ```typescript
-function handleClick() {
-  console.log('点击了地图')
+function handleBeforeToggle(showPop: boolean, toggle: () => void) {
+  console.log('当前菜单展开状态:', showPop)
+
+  // 异步展开（如果不需要展开则不调用 toggle 函数即可）
+  setTimeout(toggle, 500)
 }
 ```
 
@@ -170,7 +181,7 @@ function handleClick() {
 | title     | 菜单标题                                                               | string          | -      | -      | -        |
 | icon      | 菜单图标                                                           | string            | -       | arrow-down | -     |
 | icon-size | 菜单图标尺寸                                                        | string            | -       | 14px | _       |
-| custom-click | 菜单点击事件                                                     | function          | -       | -      | -      |
+| before-toggle | 在切换操作之前调用的函数，类型：`(showPop: boolean, toggle: () => void) => void`，其中 `showPop` 为当前菜单展开状态 | function          | -       | -      | -      |
 | value-key | 选项对象中，value 对应的 key                                           | string          | -      | value  | -        |
 | label-key | 选项对象中，展示的文本对应的 key                                       | string          | -      | label  | -        |
 | tip-key   | 选项对象中，选项说明对应的 key                                         | string          | -      | tip    | -        |

--- a/docs/component/drop-menu.md
+++ b/docs/component/drop-menu.md
@@ -112,6 +112,24 @@ function handleOpened() {
 </view>
 ```
 
+## 自定义菜单图标
+
+可以通过 icon 设置菜单右侧图标，等同于 `<wd-icon />` 的 name 属性。通过 icon-size 设置图标尺寸，等同于 `<wd-icon />` 的 size 属性。
+
+可以通过 custom-click 来自定义菜单点击事件，不传则默认展开菜单。
+
+```html
+<wd-drop-menu>
+  <wd-drop-menu-item title="地图" icon="location" icon-size="24px" :custom-click="handleClick" />
+</wd-drop-menu>
+```
+
+```typescript
+function handleClick() {
+  console.log('点击了地图')
+}
+```
+
 ## 向上展开
 
 将 `direction` 属性值设置为 `up`，菜单即可向上展开
@@ -150,6 +168,9 @@ function handleOpened() {
 | options   | 列表数据，对应数据结构 `[{text: '标题', value: '0', tip: '提示文字'}]` | array           | -      | -      | -        |
 | icon-name | 选中的图标名称(可选名称在 wd-icon 组件中)                              | string          | -      | check  | -        |
 | title     | 菜单标题                                                               | string          | -      | -      | -        |
+| icon      | 菜单图标                                                           | string            | -       | arrow-down | -     |
+| icon-size | 菜单图标尺寸                                                        | string            | -       | 14px | _       |
+| custom-click | 菜单点击事件                                                     | function          | -       | -      | -      |
 | value-key | 选项对象中，value 对应的 key                                           | string          | -      | value  | -        |
 | label-key | 选项对象中，展示的文本对应的 key                                       | string          | -      | label  | -        |
 | tip-key   | 选项对象中，选项说明对应的 key                                         | string          | -      | tip    | -        |

--- a/src/pages/dropMenu/Index.vue
+++ b/src/pages/dropMenu/Index.vue
@@ -34,7 +34,12 @@
       </demo-block>
       <demo-block title="自定义菜单图标" transparent>
         <wd-drop-menu>
-          <wd-drop-menu-item title="地图" icon="location" icon-size="24px" :custom-click="handleMapClick" />
+          <wd-drop-menu-item title="地图" icon="location" icon-size="24px" />
+        </wd-drop-menu>
+      </demo-block>
+      <demo-block title="自定义点击事件" transparent>
+        <wd-drop-menu>
+          <wd-drop-menu-item title="延迟 0.5s 展开" :before-toggle="handleBeforeToggle" />
         </wd-drop-menu>
       </demo-block>
       <demo-block title="向上弹出" transparent>
@@ -122,8 +127,11 @@ function confirm() {
   dropMenu.value.close()
 }
 
-function handleMapClick() {
-  console.log('点击了地图')
+function handleBeforeToggle(showPop: boolean, toggle: () => void) {
+  console.log('当前菜单展开状态:', showPop)
+
+  // 异步展开（如果不需要展开则不调用 toggle 函数即可）
+  setTimeout(toggle, 500)
 }
 </script>
 <style lang="scss" scoped>

--- a/src/pages/dropMenu/Index.vue
+++ b/src/pages/dropMenu/Index.vue
@@ -32,6 +32,11 @@
           </view>
         </view>
       </demo-block>
+      <demo-block title="自定义菜单图标" transparent>
+        <wd-drop-menu>
+          <wd-drop-menu-item title="地图" icon="location" icon-size="24px" :custom-click="handleMapClick" />
+        </wd-drop-menu>
+      </demo-block>
       <demo-block title="向上弹出" transparent>
         <wd-drop-menu direction="up">
           <wd-drop-menu-item v-model="value6" :options="option1" @change="handleChange6" />
@@ -115,6 +120,10 @@ function handleChange9({ value }: any) {
 
 function confirm() {
   dropMenu.value.close()
+}
+
+function handleMapClick() {
+  console.log('点击了地图')
 }
 </script>
 <style lang="scss" scoped>

--- a/src/uni_modules/wot-design-uni/components/wd-drop-menu-item/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-drop-menu-item/types.ts
@@ -32,6 +32,18 @@ export const dorpMenuItemProps = {
    */
   title: String,
   /**
+   * 菜单图标
+   */
+  icon: makeStringProp('arrow-down'),
+  /**
+   * 菜单图标大小
+   */
+  iconSize: makeStringProp('14px'),
+  /**
+   * 自定义点击事件
+   */
+  customClick: Function,
+  /**
    * 选项对象中，value 对应的 key
    */
   valueKey: makeStringProp('value'),

--- a/src/uni_modules/wot-design-uni/components/wd-drop-menu-item/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-drop-menu-item/types.ts
@@ -1,5 +1,7 @@
-import type { ComponentPublicInstance, ExtractPropTypes } from 'vue'
+import type { ComponentPublicInstance, ExtractPropTypes, PropType } from 'vue'
 import { baseProps, makeArrayProp, makeBooleanProp, makeStringProp } from '../common/props'
+
+export type DropMenuItemBeforeToggle = (showPop: boolean, toggle: () => void) => void
 
 export const dorpMenuItemProps = {
   ...baseProps,
@@ -40,9 +42,9 @@ export const dorpMenuItemProps = {
    */
   iconSize: makeStringProp('14px'),
   /**
-   * 自定义点击事件: (showPop: boolean, toggle: ()=>void)=>void
+   * 自定义点击事件
    */
-  beforeToggle: Function,
+  beforeToggle: Function as PropType<DropMenuItemBeforeToggle>,
   /**
    * 选项对象中，value 对应的 key
    */

--- a/src/uni_modules/wot-design-uni/components/wd-drop-menu-item/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-drop-menu-item/types.ts
@@ -40,9 +40,9 @@ export const dorpMenuItemProps = {
    */
   iconSize: makeStringProp('14px'),
   /**
-   * 自定义点击事件
+   * 自定义点击事件: (showPop: boolean, toggle: ()=>void)=>void
    */
-  customClick: Function,
+  beforeToggle: Function,
   /**
    * 选项对象中，value 对应的 key
    */

--- a/src/uni_modules/wot-design-uni/components/wd-drop-menu/wd-drop-menu.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-drop-menu/wd-drop-menu.vue
@@ -7,12 +7,12 @@
         <view
           v-for="(child, index) in children"
           :key="index"
-          @click="toggle(child)"
+          @click="handleItemClick(child)"
           :class="`wd-drop-menu__item ${child.disabled ? 'is-disabled' : ''} ${currentUid === child.$.uid ? 'is-active' : ''}`"
         >
           <view class="wd-drop-menu__item-title">
             <view class="wd-drop-menu__item-title-text">{{ getDisplayTitle(child) }}</view>
-            <wd-icon name="arrow-down" custom-class="wd-drop-menu__arrow" />
+            <wd-icon :name="child.icon" :size="child.iconSize" custom-class="wd-drop-menu__arrow" />
           </view>
         </view>
       </view>
@@ -88,6 +88,14 @@ function getDisplayTitle(child: any) {
     }
   }
   console.error('[wot-design] warning(wd-drop-menu-item): no value is matched in the options option.')
+}
+
+function handleItemClick(child: any) {
+  if (child.customClick) {
+    child.customClick()
+  } else {
+    toggle(child)
+  }
 }
 
 function toggle(child: any) {

--- a/src/uni_modules/wot-design-uni/components/wd-drop-menu/wd-drop-menu.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-drop-menu/wd-drop-menu.vue
@@ -91,8 +91,9 @@ function getDisplayTitle(child: any) {
 }
 
 function handleItemClick(child: any) {
-  if (child.customClick) {
-    child.customClick()
+  if (child.beforeToggle) {
+    const showPop = child.$.exposed!.getShowPop()
+    child.beforeToggle(showPop, () => toggle(child))
   } else {
     toggle(child)
   }


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

在开发中，可能会遇到一个下拉菜单栏里面包含一些非下拉菜单项（如下图），因此如果能提供自定义图标和自定义点击事件的话，能够简化开发。

<img width="479" alt="image" src="https://github.com/user-attachments/assets/a89add2c-b005-48fa-a532-5f44161f5e93">

解决方案：在下拉菜单项中添加 icon、icon-size、custom-click 等属性，以便用户传入自定义值来覆盖默认样式和行为。

注意：其中 custom-click 的定义方式还有待斟酌，目前是使用 props 来传入一个函数来进行自定义的，因为如果通过 emit 来传入的话，在下拉菜单容器中不知如何检测菜单项是否有定义自定义事件，使用 props 来传入的话则简单些。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新功能**
  - 增加自定义下拉菜单图标和大小的功能。
  - 支持为菜单项定义自定义点击事件处理程序。
  - 新增下拉菜单项“地图”和“延迟 0.5s 展开”，增强用户交互体验。

- **文档**
  - 更新文档示例，展示新特性和用法。
  - 详细介绍新增属性及其默认值。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->