### PR TITLE
feat(wd-datetime-picker): datetime-picker 增加自定义 Cell 样式属性

### DIFF
--- a/docs/component/datetime-picker.md
+++ b/docs/component/datetime-picker.md
@@ -334,5 +334,6 @@ const displayFormatTabLabel = (items) => {
 | 类名 | 说明 | 最低版本 |
 |-----|------|--------|
 | custom-view-class | pickerView 外部自定义样式 | - |
+| custom-cell-class | pickerView cell 外部自定义样式 | - |
 | custom-label-class | label 外部自定义样式 | - |
 | custom-value-class | value 外部自定义样式 | - |

--- a/docs/component/datetime-picker.md
+++ b/docs/component/datetime-picker.md
@@ -334,6 +334,6 @@ const displayFormatTabLabel = (items) => {
 | 类名 | 说明 | 最低版本 |
 |-----|------|--------|
 | custom-view-class | pickerView 外部自定义样式 | - |
-| custom-cell-class | pickerView cell 外部自定义样式 | - |
+| custom-cell-class | pickerView cell 外部自定义样式 | $LOWEST_VERSION$ |
 | custom-label-class | label 外部自定义样式 | - |
 | custom-value-class | value 外部自定义样式 | - |

--- a/src/uni_modules/wot-design-uni/components/wd-datetime-picker/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-datetime-picker/types.ts
@@ -156,6 +156,10 @@ export const datetimePickerProps = {
    */
   rules: makeArrayProp<FormItemRule>(),
   /**
+   * picker cell 外部自定义样式
+   */
+  customCellClass: makeStringProp(''),
+  /**
    * pickerView 外部自定义样式
    */
   customViewClass: makeStringProp(''),

--- a/src/uni_modules/wot-design-uni/components/wd-datetime-picker/wd-datetime-picker.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-datetime-picker/wd-datetime-picker.vue
@@ -8,7 +8,7 @@
     <!--文案-->
     <view class="wd-picker__field" @click="showPopup">
       <slot v-if="useDefaultSlot"></slot>
-      <view v-else class="wd-picker__cell">
+      <view v-else :class="['wd-picker__cell', customCellClass]">
         <view
           v-if="label || useLabelSlot"
           :class="`wd-picker__label ${customLabelClass} ${isRequired ? 'is-required' : ''}`"


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

直接使用 datetime-picker 组件而又不想使用自定义插槽的情况下，该组件会被包裹在一个 cell 元素中，而现有的属性无法调整该容器 cell 的样式，所以简单的补充了一个属性，以便自定义。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 在日期时间选择器组件中增加了 `customCellClass` 属性，允许用户自定义单元格样式。
	- 更新了日期时间选择器的文档，增加了 `custom-cell-class` 的说明，提供更好的定制选项。
- **文档**
	- 增加了关于 `custom-cell-class` 的文档条目，说明其为单元格的外部自定义样式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->