### PR TITLE
refactor: ♻️ 重构Input、Textarea组件的事件执行时序

### DIFF
--- a/docs/component/input.md
+++ b/docs/component/input.md
@@ -47,6 +47,11 @@ function handleChange(event) {
 ## 有值且聚焦时展示清空按钮
 设置 `clear-trigger` 属性，可以控制是否聚焦时才展示清空按钮。
 
+:::warning 注意
+支付宝小程序暂不支持 `clear-trigger` 属性，且某种情况下清空按钮无法点击，原因参考此[issue](https://github.com/ant-design/ant-design-mini/issues/1255)（希望可以早点解决，所以直接给蚂蚁的组件库提了个issue）。
+:::
+
+
 ```html
 <wd-input v-model="value" clear-trigger="focus" clearable @change="handleChange"/>
 ```

--- a/docs/component/textarea.md
+++ b/docs/component/textarea.md
@@ -44,6 +44,11 @@ const value = ref<string>('')
 ## 有值且聚焦时展示清空按钮
 设置 `clear-trigger` 属性，可以控制是否聚焦时才展示清空按钮。
 
+:::warning 注意
+支付宝小程序暂不支持 `clear-trigger` 属性，且某种情况下清空按钮无法点击，原因参考此[issue](https://github.com/ant-design/ant-design-mini/issues/1255)（希望可以早点解决，所以直接给蚂蚁的组件库提了个issue）。
+:::
+
+
 ```html
 <wd-textarea clear-trigger="focus" v-model="value14" :maxlength="120" clearable show-word-limit />
 ```

--- a/src/uni_modules/wot-design-uni/components/common/util.ts
+++ b/src/uni_modules/wot-design-uni/components/common/util.ts
@@ -439,23 +439,17 @@ export const requestAnimationFrame = (cb = () => {}) => {
 }
 
 /**
- * 设置多少个requestAnimationFrame 之后执行回调函数
- * @param {number} n - 执行次数
- * @param {function} cb - 回调函数
+ * 暂停指定时间函数
+ * @param ms 延迟时间
+ * @returns
  */
-export const requestAnimationFrameTimer = (n: number, cb = () => {}) => {
-  let count = 0
-  const recursiveFunc = () => {
-    requestAnimationFrame(() => {
-      count++
-      if (count === n) {
-        cb()
-      } else {
-        recursiveFunc()
-      }
-    })
-  }
-  recursiveFunc()
+export const pause = (ms: number) => {
+  return new AbortablePromise((resolve) => {
+    const timer = setTimeout(() => {
+      clearTimeout(timer)
+      resolve(true)
+    }, ms)
+  })
 }
 
 /**

--- a/src/uni_modules/wot-design-uni/components/wd-input/wd-input.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-input/wd-input.vue
@@ -248,8 +248,8 @@ function handleClear() {
   })
 }
 async function handleBlur() {
-  // 等待100毫秒，clear执行完毕
-  await pause(100)
+  // 等待150毫秒，clear执行完毕
+  await pause(150)
   if (clearing.value) {
     clearing.value = false
     return
@@ -260,10 +260,6 @@ async function handleBlur() {
   })
 }
 function handleFocus({ detail }: any) {
-  if (clearing.value) {
-    clearing.value = false
-    return
-  }
   focusing.value = true
   emit('focus', detail)
 }

--- a/src/uni_modules/wot-design-uni/components/wd-textarea/wd-textarea.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-textarea/wd-textarea.vue
@@ -239,8 +239,8 @@ function handleClear() {
   })
 }
 async function handleBlur({ detail }: any) {
-  // 等待100毫秒，clear执行完毕
-  await pause(100)
+  // 等待150毫秒，clear执行完毕
+  await pause(150)
 
   if (clearing.value) {
     clearing.value = false
@@ -254,10 +254,6 @@ async function handleBlur({ detail }: any) {
   })
 }
 function handleFocus({ detail }: any) {
-  if (clearing.value) {
-    clearing.value = false
-    return
-  }
   focusing.value = true
   emit('focus', detail)
 }


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
#284 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
Input和Textarea增加`clear-triger`属性，设置为`focus`后在h5平台会出现点击清空按钮无效的问题，同时iOS App平台输入汉字会出现输入法频繁闪出的问题。故调整相关事件的时序，增加执行前校验。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 文档中增加了对 `clear-trigger` 属性在 Alipay 小程序中不支持的警告说明，提醒用户潜在的兼容性问题。
	
- **功能改进**
	- `wd-input` 和 `wd-textarea` 组件的 `clear` 函数更名为 `handleClear`，提升了代码的可读性。
	- 修改 `handleBlur` 函数，引入异步处理，确保在清除操作完成后再触发模糊事件，提高了组件的响应性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->