### PR TITLE
fix: 修复 wd-picker-view 动态传入 columns 时无法正确选中默认值（#492）

### DIFF
--- a/src/pages/pickerView/Index.vue
+++ b/src/pages/pickerView/Index.vue
@@ -23,6 +23,12 @@
     <demo-block :title="`多级联动，数值: [${value5}]`">
       <wd-picker-view v-model="value5" :columns="columns5" :column-change="onChangeDistrict" @change="(e) => onChange(5, e)" />
     </demo-block>
+
+    <demo-block :title="`只有一项数据,数值: [${value7}]`">
+      <wd-picker-view ref="picker7" v-model="value7" :columns="storeList" label-key="storeName" value-key="storeId" />
+      <button @click="getList">getList</button>
+      <button @click="getSelects">getSelects</button>
+    </demo-block>
   </page-wraper>
 </template>
 <script lang="ts" setup>
@@ -118,6 +124,27 @@ function onChange(index: number, e: any) {
     // toast.show(`当前选中项: ${value}, 下标: ${index}`)
   }
   // this.setData({ [`value${dataset.index}`]: value })
+}
+
+const value7 = ref<string>('')
+const storeList = ref<
+  {
+    storeId: number
+    storeName: string
+  }[]
+>([])
+const getList = () => {
+  storeList.value = [
+    {
+      storeId: 21,
+      storeName: 'aaa'
+    }
+  ]
+}
+const picker7 = ref()
+const getSelects = () => {
+  console.log(picker7.value.getValues())
+  console.log(picker7.value.getSelects())
 }
 </script>
 <style lang="scss" scoped></style>

--- a/src/uni_modules/wot-design-uni/components/wd-picker-view/wd-picker-view.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-picker-view/wd-picker-view.vue
@@ -78,8 +78,9 @@ const { proxy } = getCurrentInstance() as any
  * @param {String|Number|Boolean|Array<String|Number|Boolean|Array<any>>}value
  */
 function selectWithValue(value: string | number | boolean | number[] | string[] | boolean[]) {
-  if (formatColumns.value.length === 0) return
-
+  if (formatColumns.value.length === 0 || (formatColumns.value.length === 1 && formatColumns.value[0].length === 0)) {
+    return
+  }
   // 使其默认选中首项
   if (value === '' || !isDef(value) || (isArray(value) && value.length === 0)) {
     value = formatColumns.value.map((col) => {
@@ -120,6 +121,7 @@ function selectWithValue(value: string | number | boolean | number[] | string[] 
 function correctSelected(value: number[]) {
   let selected = deepClone(value)
   value.forEach((row, col) => {
+    if (formatColumns.value[col].length === 0) return
     row = range(row, 0, formatColumns.value[col].length - 1)
     selected = correctSelectedIndex(col, row, selected)
   })
@@ -211,6 +213,7 @@ function getChangeDiff(value: number[]) {
   let selected: number[] = deepClone(selectedIndex.value)
 
   value.forEach((row, col) => {
+    if (formatColumns.value[0].length === 0) return
     row = range(row, 0, formatColumns.value[col].length - 1)
     if (row === origin[col]) return
     selected = correctSelectedIndex(col, row, selected)
@@ -266,6 +269,11 @@ function getSelects() {
  */
 function getValues() {
   const { valueKey } = props
+  // columns 为空时，直接抛出 undefined
+  if (formatColumns.value[0].length === 0) {
+    return undefined
+  }
+
   const values = selectedIndex.value.map((row, col) => {
     return formatColumns.value[col][row][valueKey]
   })


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

[issue#492](https://github.com/Moonofweisheng/wot-design-uni/issues/492)

### 💡 需求背景和解决方案

解决方案：
原 columns 为空时，修正 formatColumns 相关的方法判断条件
1. getValues方法 在 formatColumns 为空时，抛出 undefined
2. getChangeDiff 方法 formatColumns 为空时，不进行 correctSelectedIndex（修正选中项指定列行的值）方法的调用
3. selectWithValue 方法对 formatColumns 数组的判空


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在选择器视图中添加了新部分，支持单个数据项的选择和展示。
	- 新增了两个按钮“获取列表”和“获取选择”，用于填充和记录选择的值。
  
- **改进**
	- 增强了选择组件的条件检查，以处理可能为空的列，从而提高了功能的健壮性和可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->