### PR TITLE
docs: ✏️  textarea组件的maxlength属性类型错误

### DIFF
--- a/docs/component/textarea.md
+++ b/docs/component/textarea.md
@@ -129,7 +129,7 @@ const value = ref<string>('')
 | placeholderStyle        | 原生属性，指定 placeholder 的样式                                                                                  | string            | -                                | -         | -        |
 | placeholderClass        | 原生属性，指定 placeholder 的样式类                                                                                | string            | -                                | -         | -        |
 | disabled                | 原生属性，禁用                                                                                                     | boolean           | -                                | false     | -        |
-| maxlength               | 原生属性，最大输入长度，设置为 -1 的时候不限制最大长度                                                             | string            | -                                | -         | -        |
+| maxlength               | 原生属性，最大输入长度，设置为 -1 的时候不限制最大长度                                                             | number            | -                                | -         | -        |
 | auto-focus              | 原生属性，自动聚焦，拉起键盘。                                                                                     | boolean           | -                                | false     | -        |
 | focus                   | 原生属性，获取焦点                                                                                                 | boolean           | -                                | false     | -        |
 | auto-height             | 原生属性，是否自动增高，设置 auto-height 时，style.height 不生效                                                   | boolean           | -                                | false     | -        |

--- a/src/uni_modules/wot-design-uni/components/wd-textarea/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-textarea/types.ts
@@ -60,7 +60,7 @@ export const textareaProps = {
 
   /**
    * * 最大输入长度，设置为-1表示不限制最大长度。
-   * 类型：string
+   * 类型：number
    * 默认值：-1
    */
   maxlength: makeNumberProp(-1),


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档更新**
	- 修改了`maxlength`属性的类型声明，从`string`更改为`number`，以增强类型安全性并提高文档的清晰性。
	- 更新文档以反映`maxlength`属性的使用方式和限制条件。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->