### PR TITLE
feat: wd-input-number自定义按钮图标

### DIFF
--- a/docs/component/input-number.md
+++ b/docs/component/input-number.md
@@ -1,7 +1,6 @@
 <frame/>
 
-#  InputNumber 计数器
-
+# InputNumber 计数器
 
 ## 基本用法
 
@@ -49,7 +48,6 @@ function handleChange1({ value }) {
 ```html
 <wd-input-number v-model="value" @change="handleChange" disable-input />
 ```
-
 
 ## 无输入框
 
@@ -117,18 +115,23 @@ function handleChange1({ value }) {
 | disable-plus | 禁用增加按钮 | boolean | - | false | 0.2.14 |
 | disable-minus | 禁用减少按钮 | boolean | - | false | 0.2.14 |
 
-
 ## Events
 
 | 事件名称 | 说明 | 参数 | 最低版本 |
 |---------|-----|-----|---------|
-| change | 值修改事件 | ` { value }` | - |
-| focus | 输入框获取焦点事件 | ` { value, height }` | - |
-| blur | 输入框失去焦点事件 | ` { value }` | - |
+| change | 值修改事件 | `{ value }` | - |
+| focus | 输入框获取焦点事件 | `{ value, height }` | - |
+| blur | 输入框失去焦点事件 | `{ value }` | - |
+
+## Slots
+
+| name   | 说明                 | 参数                    | 最低版本 |
+| ------ | -------------------- | ----------------------- | -------- |
+| left-icon  | 左侧图标         | `{ value }` | $LOWEST_VERSION$   |
+| right-icon  | 右侧图标         | `{ value }` | $LOWEST_VERSION$   |
 
 ## 外部样式类
 
 | 类名 | 说明 | 最低版本 |
 |-----|------|--------|
 | custom-class | 根节点样式 | - |
-

--- a/src/uni_modules/wot-design-uni/components/wd-input-number/wd-input-number.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-input-number/wd-input-number.vue
@@ -1,7 +1,9 @@
 <template>
   <view :class="`wd-input-number ${customClass} ${disabled ? 'is-disabled' : ''} ${withoutInput ? 'is-without-input' : ''}`" :style="customStyle">
     <view :class="`wd-input-number__action ${minDisabled || disableMinus ? 'is-disabled' : ''}`" @click="sub">
-      <wd-icon name="decrease" custom-class="wd-input-number__action-icon"></wd-icon>
+      <slot name="left-icon" :value="inputValue">
+        <wd-icon name="decrease" custom-class="wd-input-number__action-icon"></wd-icon>
+      </slot>
     </view>
     <view v-if="!withoutInput" class="wd-input-number__inner" @click.stop="">
       <input
@@ -18,7 +20,9 @@
       <view class="wd-input-number__input-border"></view>
     </view>
     <view :class="`wd-input-number__action ${maxDisabled || disablePlus ? 'is-disabled' : ''}`" @click="add">
-      <wd-icon name="add" custom-class="wd-input-number__action-icon"></wd-icon>
+      <slot name="right-icon" :value="inputValue">
+        <wd-icon name="add" custom-class="wd-input-number__action-icon"></wd-icon>
+      </slot>
     </view>
   </view>
 </template>


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
[issue](https://github.com/Moonofweisheng/wot-design-uni/issues/463)

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

1. 可以自定义 input-number 的图标
2. 添加 left-icon 和 right-icon 插槽

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 在 `InputNumber` 组件中新增了左侧和右侧图标的插槽，提升了图标自定义灵活性。
  
- **文档**
  - 优化了 `InputNumber` 组件文档的格式和结构，增强了可读性。
  - 增加了插槽部分的详细说明，提供了更清晰的定制指导。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->