### PR TITLE
fix: 表单校验不隐藏错误消息dom

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-cell/wd-cell.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-cell/wd-cell.vue
@@ -38,7 +38,7 @@
           <wd-icon v-if="isLink" custom-class="wd-cell__arrow-right" name="arrow-right" />
           <slot v-else name="right-icon" />
         </view>
-        <view v-if="errorMessage" class="wd-cell__error-message">{{ errorMessage }}</view>
+        <view class="wd-cell__error-message">{{ errorMessage }}</view>
       </view>
       <!--right content END-->
     </view>

--- a/src/uni_modules/wot-design-uni/components/wd-input/wd-input.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-input/wd-input.vue
@@ -67,7 +67,7 @@
           <slot name="suffix"></slot>
         </view>
       </view>
-      <view v-if="errorMessage" class="wd-input__error-message">{{ errorMessage }}</view>
+      <view class="wd-input__error-message">{{ errorMessage }}</view>
     </view>
   </view>
 </template>


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
目前的校验错误信息标签如果没有是隐藏的，校验后出现错误信息页面都撑高，不太好做样式的处理，比如加固定高度校验后不会页面撑高

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1、方便给错误信息的样式处理，比如手动给 error-message 的标签加高度，去掉 v-if 后也不影响现有的交互
2、去掉 v-if="errorMessage"

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充