### PR TITLE
Feature: inputNumber可支持输入框禁用并支持触发点击事件

### DIFF
--- a/docs/component/input-number.md
+++ b/docs/component/input-number.md
@@ -125,6 +125,7 @@ function handleChange1({ value }) {
 | change | 值修改事件 | ` { value }` | - |
 | focus | 输入框获取焦点事件 | ` { value, height }` | - |
 | blur | 输入框失去焦点事件 | ` { value }` | - |
+| clickInput | 禁用input框时点击触发 | 暂无 | - |
 
 ## 外部样式类
 

--- a/src/pages/inputNumber/Index.vue
+++ b/src/pages/inputNumber/Index.vue
@@ -13,7 +13,7 @@
       <wd-input-number v-model="value4" @change="handleChange4" disabled />
     </demo-block>
     <demo-block title="禁用输入框">
-      <wd-input-number v-model="value10" @change="handleChange4" disable-input />
+      <wd-input-number v-model="value10" @change="handleChange4" disable-input @clickInput="handleClickInput" />
     </demo-block>
     <demo-block title="无输入框">
       <view class="flex">
@@ -75,6 +75,10 @@ function handleChange8({ value }: any) {
 }
 function handleChange9({ value }: any) {
   console.log(value)
+}
+
+function handleClickInput() {
+  console.log('点击了输入框')
 }
 </script>
 <style lang="scss" scoped>

--- a/src/uni_modules/wot-design-uni/components/wd-input-number/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-input-number/index.scss
@@ -3,7 +3,6 @@
 
 .wot-theme-dark {
   @include b(input-number) {
-    display: inline-block;
     @include e(action) {
       color: $-dark-color;
       @include when(disabled) {

--- a/src/uni_modules/wot-design-uni/components/wd-input-number/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-input-number/index.scss
@@ -3,6 +3,7 @@
 
 .wot-theme-dark {
   @include b(input-number) {
+    display: inline-block;
     @include e(action) {
       color: $-dark-color;
       @include when(disabled) {
@@ -70,6 +71,7 @@
     position: relative;
     display: inline-block;
     vertical-align: middle;
+    line-height: 2;
   }
 
   @include e(input) {

--- a/src/uni_modules/wot-design-uni/components/wd-input-number/wd-input-number.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-input-number/wd-input-number.vue
@@ -5,16 +5,20 @@
     </view>
     <view v-if="!withoutInput" class="wd-input-number__inner" @click.stop="">
       <input
+        v-if="!disableInput"
         class="wd-input-number__input"
         :style="`${inputWidth ? 'width: ' + inputWidth : ''}`"
         type="digit"
-        :disabled="disabled || disableInput"
+        :disabled="disabled"
         v-model="inputValue"
         :placeholder="placeholder"
         @input="handleInput"
         @focus="handleFocus"
         @blur="handleBlur"
       />
+      <view @click="handleClickInput" v-else :style="`${inputWidth ? 'width: ' + inputWidth : ''}`" class="wd-input-number__input">
+        {{ inputValue }}
+      </view>
       <view class="wd-input-number__input-border"></view>
     </view>
     <view :class="`wd-input-number__action ${maxDisabled || disablePlus ? 'is-disabled' : ''}`" @click="add">
@@ -40,7 +44,7 @@ import { debounce, isDef, isEqual } from '../common/util'
 import { inputNumberProps } from './types'
 
 const props = defineProps(inputNumberProps)
-const emit = defineEmits(['focus', 'blur', 'change', 'update:modelValue'])
+const emit = defineEmits(['focus', 'blur', 'change', 'update:modelValue', 'clickInput'])
 
 const minDisabled = ref<boolean>(false)
 const maxDisabled = ref<boolean>(false)
@@ -160,7 +164,9 @@ function handleInput(event: any) {
 function handleFocus(event: any) {
   emit('focus', event.detail)
 }
-
+function handleClickInput(event: any) {
+  emit('clickInput')
+}
 function handleBlur() {
   const value = formatValue(inputValue.value)
   if (!isEqual(inputValue.value, value)) {


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
1、点击input-number 组件禁用input，可被点击，触发点击事件，去做弹窗中进行数据更新的效果
2、
```使用示例
 <demo-block title="禁用输入框">
      <wd-input-number v-model="value10" @change="handleChange4" disable-input @clickInput="handleClickInput" />
    </demo-block>
```
3、使用交互

Uploading QQ2024812-132423.mp4…




<!--
1. 要解决的具体问题。
3. 列出最终的 API 实现和用法。
4. 涉及UI/交互变动需要有截图或 GIF。
-->




### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 添加了 `clickInput` 事件，允许在输入框被禁用时点击时触发，并提供更好的用户反馈。
	- 输入组件根据 `disableInput` 属性的值动态渲染可编辑输入框或只读视图。
	- 新事件 `clickInput` 允许父组件响应只读模式下的用户点击。
  
- **样式**
	- 改进了输入组件的样式，增加了 `line-height` 属性，提升文本可读性。

- **文档**
	- 更新了 `input-number` 组件文档，增加了关于新事件的说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->