### PR TITLE
fix(tabs): 修复Tabs在ios低版本不渲染(#247)

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-tabs/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/types.ts
@@ -1,5 +1,6 @@
 import { type ExtractPropTypes, type InjectionKey } from 'vue'
 import { baseProps, makeBooleanProp, makeNumberProp, makeNumericProp, makeStringProp, numericProp } from '../common/props'
+import type { TabProps } from '../wd-tab/types' 
 
 export type TabsProvide = {
   state: {
@@ -62,3 +63,5 @@ export const tabsProps = {
 }
 
 export type TabsProps = ExtractPropTypes<typeof tabsProps>
+
+export type TTabProps = Pick<TabProps, 'name' | 'title' | 'disabled'>

--- a/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
@@ -143,7 +143,7 @@ export default {
 import { computed, getCurrentInstance, onMounted, ref, watch, nextTick, reactive, type CSSProperties } from 'vue'
 import { addUnit, checkNumRange, debounce, getRect, isDef, isNumber, isString, objToStyle } from '../common/util'
 import { useTouch } from '../composables/useTouch'
-import { TABS_KEY, tabsProps } from './types'
+import { TABS_KEY, tabsProps, TTabProps } from './types'
 import { useChildren } from '../composables/useChildren'
 import { useTranslate } from '../composables/useTranslate'
 
@@ -174,10 +174,15 @@ const { proxy } = getCurrentInstance() as any
 const touch = useTouch()
 
 // tabs数据
-const items = computed(() => {
-  return children.map((child, index) => {
-    return { disabled: child.disabled, title: child.title, name: isDef(child.name) ? child.name : index }
+const items = ref<TTabProps[]>([])
+// 解决ios低版本tabs不渲染
+watch(children, newChildren => {
+  items.value = newChildren.map((child, index) => {
+    return { disabled: child.disabled, title: child.title, name: isDef(child.name)? child.name : index }
   })
+}, {
+  deep: true,
+  flush: 'post'
 })
 
 const bodyStyle = computed(() => {


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
#247

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
解决tabs在ios低版本不渲染
修改代码如下
``` tabs.vue
// tabs数据
const items = ref<TTabProps[]>([])
// 解决ios低版本tabs不渲染
watch(children, newChildren => {
  items.value = newChildren.map((child, index) => {
    return { disabled: child.disabled, title: child.title, name: isDef(child.name)? child.name : index }
  })
}, {
  deep: true,
  flush: 'post'
})
```


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充