### PR TITLE
fix: 🐛 修复picker-view动态设置columns时获取选中值异常的问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-picker-view/wd-picker-view.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-picker-view/wd-picker-view.vue
@@ -57,10 +57,10 @@ const selectedIndex = ref<Array<number>>([]) // 格式化之后，每列选中�
 watch(
   [() => props.modelValue, () => props.columns],
   (newValue, oldValue) => {
-    if (!isEqual(oldValue[1], newValue[1])) {
+    if (!isEqual(oldValue[1], newValue[1]) && isArray(newValue[1]) && newValue[1].length > 0) {
       formatColumns.value = formatArray(newValue[1], props.valueKey, props.labelKey)
     }
-    if (!isEqual(oldValue[0], newValue[0]) && isDef(newValue[0])) {
+    if (isDef(newValue[0])) {
       selectWithValue(newValue[0])
     }
   },
@@ -79,7 +79,6 @@ const { proxy } = getCurrentInstance() as any
  */
 function selectWithValue(value: string | number | boolean | number[] | string[] | boolean[]) {
   if (formatColumns.value.length === 0) return
-
   // 使其默认选中首项
   if (value === '' || !isDef(value) || (isArray(value) && value.length === 0)) {
     value = formatColumns.value.map((col) => {


### PR DESCRIPTION
✅ Closes: #492

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
调整`picker-view`初始化的时机，当列数据存在时才对列数据进行初始化，每次列变更都对当前选中值进行检查。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 优化了组件的响应性，减少了不必要的更新，提升了性能和稳定性。
  
- **修复**
  - 简化了条件逻辑，确保在选择值时更新更准确和快速。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->