### PR TITLE
feat: ✨ Collapse 折叠面板组件支持嵌套使用

### DIFF
--- a/src/pages/collapse/Index.vue
+++ b/src/pages/collapse/Index.vue
@@ -1,9 +1,11 @@
 <template>
   <page-wraper>
     <wd-toast></wd-toast>
-    <demo-block title="基础用法" transparent>
-      <wd-button @click="collapse?.toggleAll()">toggleAll</wd-button>
 
+    <demo-block title="toggleAll" transparent>
+      <wd-button @click="collapse?.toggleAll()">toggleAll</wd-button>
+    </demo-block>
+    <demo-block title="基础用法" transparent>
       <wd-collapse ref="collapse" v-model="value1" @change="handleChange1">
         <wd-collapse-item
           v-for="(item, index) in itemList"
@@ -55,6 +57,19 @@
         <wd-collapse-item title="标签3" name="item3">这是一条简单的示例文字。</wd-collapse-item>
       </wd-collapse>
     </demo-block>
+
+    <demo-block title="嵌套" transparent>
+      <wd-collapse v-model="collapseRoot" @change="handleChange1">
+        <wd-collapse-item v-for="item in 5" :key="item" :title="`标签${item}`" :name="`${item}`">
+          <wd-collapse v-model="collapseList[item - 1]">
+            <wd-collapse-item v-for="(item, index) in itemList" :key="index" :title="item.title" :name="item.name">
+              {{ item.body }}
+            </wd-collapse-item>
+          </wd-collapse>
+        </wd-collapse-item>
+      </wd-collapse>
+    </demo-block>
+
     <demo-block title="查看更多" transparent>
       <wd-collapse viewmore v-model="value4" @change="handleChange4">
         这是一条简单的示例文字。这是一条简单的示例文字。这是一条简单的示例文字。这是一条简单的示例文字。这是一条简单的示例文字。这是一条简单的示例文字。这是一条简单的示例文字。这是一条简单的示例文字。
@@ -120,7 +135,33 @@ const value6 = ref<boolean>(false)
 const value7 = ref<string[]>(['item1'])
 const desc7 = '如订单处于暂停状态，进入“我的订单”页面，找到要取消的订单，点击“取消订单”按钮；选择订单取消原因后，点击“下一步”提交申请即可。'
 const accordion = ref<boolean>(true)
-const name = ref<string>('item1')
+
+const collapseRoot = ref<string[]>(['0'])
+const collapseList = ref<Array<string[]>>([['item1'], ['item2'], ['item3'], ['item4'], ['item5']])
+
+function handleChange1({ value }: any) {
+  console.log(value)
+}
+function handleChange2({ value }: any) {
+  console.log(value)
+}
+function handleChange3({ value }: any) {
+  console.log(value)
+}
+function handleChange4({ value }: any) {
+  console.log(value)
+}
+function handleChange5({ value }: any) {
+  console.log(value)
+}
+function handleChange6({ value }: any) {
+  console.log(value)
+}
+function handleChange7({ value }: any) {
+  console.log(value)
+}
+
+/**
 
 function handleChange1({ value }: any) {
   console.log(value)

--- a/src/uni_modules/wot-design-uni/components/wd-collapse-item/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-collapse-item/index.scss
@@ -60,7 +60,6 @@
 
   @include e(wrapper) {
     position: relative;
-    transition: height 0.3s ease-in-out;
     overflow: hidden;
     will-change: height;
   }


### PR DESCRIPTION
✅ Closes: #503

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
#503 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
collapse使用`height`作为触发动画的属性，需要指定高度。但是指定高度之后子元素无法自由伸展，所以增加动画结束之后将高度移除的逻辑，避免限制子元素的高度。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 引入了新的演示区块“嵌套”，支持多层折叠内容的组织。
	- 增加了多个处理状态变化的新函数，提升了组件的灵活性。
	- 增强了折叠项组件的 ID 生成和状态管理功能。

- **用户体验改进**
	- 改进了折叠组件的过渡效果，使其在展开和收起时更加流畅。

- **样式调整**
	- 移除了折叠项高度的过渡效果，可能导致高度变化更加突兀。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->