### PR TITLE
feat: ✨ config-provider 支持customClass 与 customeStyle

### DIFF
--- a/docs/component/config-provider.md
+++ b/docs/component/config-provider.md
@@ -129,3 +129,10 @@ const themeVars: ConfigProviderThemeVars = {
 | theme      | 主题风格，设置为 `dark` 来开启深色模式，全局生效 | string | `dark`/`light` | -      | -        |
 | theme-vars | 自定义主题变量                                   | `ConfigProviderThemeVars` | -              | -      | -        |
 
+
+## 外部样式类
+
+| 类名         | 说明       | 最低版本         |
+| ------------ | ---------- | ---------------- |
+| custom-class | 根节点样式 | $LOWEST_VERSION$ |
+| custom-style | 根节点样式 | $LOWEST_VERSION$ |

--- a/src/uni_modules/wot-design-uni/components/wd-config-provider/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-config-provider/types.ts
@@ -1,9 +1,10 @@
 import type { ExtractPropTypes, PropType } from 'vue'
-import { makeStringProp } from '../common/props'
+import { makeStringProp, baseProps } from '../common/props'
 
 export type ConfigProviderTheme = 'light' | 'dark'
 
 export const configProviderProps = {
+  ...baseProps,
   /**
    * 主题风格，设置为 dark 来开启深色模式，全局生效
    */

--- a/src/uni_modules/wot-design-uni/components/wd-config-provider/wd-config-provider.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-config-provider/wd-config-provider.vue
@@ -27,15 +27,17 @@ export default {
 <script lang="ts" setup>
 import { computed } from 'vue'
 import { configProviderProps } from './types'
+import { objToStyle } from '../common/util'
 
 const props = defineProps(configProviderProps)
 
 const themeClass = computed(() => {
-  return `wot-theme-${props.theme}`
+  return `wot-theme-${props.theme} ${props.customClass}`
 })
 
 const themeStyle = computed(() => {
-  return mapThemeVarsToCSSVars(props.themeVars)
+  const styleObj = mapThemeVarsToCSSVars(props.themeVars)
+  return styleObj ? `${objToStyle(styleObj)};${props.customStyle}` : props.customStyle
 })
 
 const kebabCase = (str: string): string => {


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

用于自定义设置布局组件根节点的样式


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 增加了对 `ConfigProvider` 主题变量的外部样式类支持，允许用户自定义主题和样式。
	- 改进了 `wd-config-provider` 组件的功能，支持更多配置选项和动态样式处理。

- **文档**
	- 更新了 `config-provider.md` 文档，新增了关于 `custom-class` 和 `custom-style` 的说明及其使用要求。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->