### PR TITLE
fix: 修复IndexBar数据源更新时，右侧索引栏未正确更新问题。

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-index-anchor/wd-index-anchor.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-index-anchor/wd-index-anchor.vue
@@ -14,7 +14,7 @@
 
 <script setup lang="ts">
 import { indexAnchorProps } from './type'
-import { onMounted, getCurrentInstance, ref, computed } from 'vue'
+import { onMounted, getCurrentInstance, ref, computed, onUnmounted } from 'vue'
 import { indexBarInjectionKey } from '../wd-index-bar/type'
 import { getRect, isDef, uuid } from '../common/util'
 import { useParent } from '../composables/useParent'
@@ -45,6 +45,15 @@ onMounted(() => {
     indexBar.anchorState.anchorList.push({ top: 0, index: props.index })
   }
   getInfo()
+})
+
+onUnmounted(() => {
+  if (isDef(indexBar)) {
+    const index = indexBar.anchorState.anchorList.findIndex(v => v.index === props.index)
+    if (index !== -1) {
+      indexBar.anchorState.anchorList.splice(index, 1)
+    }
+  }
 })
 </script>
 


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
#545 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Moonofweisheng/wot-design-uni/issues/545#issue-2477403921
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 解决 indexBar 数据源更新时，右侧索引栏为正确更新问题。原本的代码中 wd-index-anchor 组件中，仅在 onMounted 时，将当前索引 push 进了 anchorList 中，但是未在卸载时从 anchorList 移除。
2. 最终解决：在 wd-index-anchor 组件中，增加了 onUnmounted 时的处理，当组件卸载时，将自己从 anchorList 中移除。
 
### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充