### PR TITLE
fix: 🐛 wd-textarea组件maxlength限制长度无效

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-textarea/wd-textarea.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-textarea/wd-textarea.vue
@@ -169,7 +169,7 @@ const isRequired = computed(() => {
 
 // 当前文本域文字长度
 const currentLength = computed(() => {
-  return String(props.modelValue || '').length
+  return String(formatValue(props.modelValue) || '').length
 })
 
 const rootClass = computed(() => {


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

问题描述：在 form 表单中使用 textarea 组件，并设置了 maxlength 属性时，textarea 的文本长度第一次渲染正常，从第二次开始 maxlength 的限制会失效，导致，整个文本内容都被渲染出来。

问题复现：

https://github.com/user-attachments/assets/b691620d-485a-4bd4-8799-b10b8b31c16a


### 💡 需求背景和解决方案

```ts
// 当前文本域文字长度
const currentLength = computed(() => {
  // 当前长度，每次都应该通过 `formatValue` 来格式化
  return String(formatValue(props.modelValue) || '').length
})
```

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 修复了文本区域长度计算不准确的问题，通过引入格式化逻辑来确保文本值的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->