### PR TITLE
修复wd-upload 在小程序中关闭图片偏移的情况

### DIFF
--- a/docs/component/upload.md
+++ b/docs/component/upload.md
@@ -135,8 +135,8 @@ const beforePreview = ({ file, resolve }) => {
     })
 }
 
-function handleChange({ files }) {
-  fileList.value = files
+function handleChange({ fileList }) {
+  fileList.value = fileList
 }
 ```
 
@@ -178,8 +178,8 @@ const beforeUpload = ({ files, resolve }) => {
     })
 }
 
-function handleChange({ files }) {
-  fileList.value = files
+function handleChange({ fileList }) {
+  fileList.value = fileList
 }
 ```
 
@@ -222,8 +222,8 @@ const beforeRemove = ({ file, fileList, resolve }) => {
     })
 }
 
-function handleChange({ files }) {
-  fileList.value = files
+function handleChange({ fileList }) {
+  fileList.value = fileList
 }
 ```
 
@@ -251,7 +251,7 @@ const fileList = ref<any[]>([
   }
 ])
 
-const beforeChoose = (file, resolve) => {
+const beforeChoose = ({fileList, resolve}) => {
   messageBox
     .confirm({
       msg: '是否选择',
@@ -265,8 +265,8 @@ const beforeChoose = (file, resolve) => {
     })
 }
 
-function handleChange({ files }) {
-  fileList.value = files
+function handleChange({ fileList }) {
+  fileList.value = fileList
 }
 ```
 
@@ -443,8 +443,8 @@ const action = ref<string>('https://mockapi.eolink.com/zhTuw2P8c29bc981a741931bd
 
 const fileList = ref([])
 
-function handleChange({ files }) {
-  fileList.value = files
+function handleChange({ fileList }) {
+  fileList.value = fileList
 }
 ```
 
@@ -461,8 +461,8 @@ const action = ref<string>('https://mockapi.eolink.com/zhTuw2P8c29bc981a741931bd
 
 const fileList = ref([])
 
-function handleChange({ files }) {
-  fileList.value = files
+function handleChange({ fileList }) {
+  fileList.value = fileList
 }
 ```
 
@@ -479,8 +479,8 @@ const action = ref<string>('https://mockapi.eolink.com/zhTuw2P8c29bc981a741931bd
 
 const fileList = ref([])
 
-function handleChange({ files }) {
-  fileList.value = files
+function handleChange({ fileList }) {
+  fileList.value = fileList
 }
 ```
 
@@ -497,8 +497,8 @@ const action = ref<string>('https://mockapi.eolink.com/zhTuw2P8c29bc981a741931bd
 
 const fileList = ref([])
 
-function handleChange({ files }) {
-  fileList.value = files
+function handleChange({ fileList }) {
+  fileList.value = fileList
 }
 ```
 

--- a/src/uni_modules/wot-design-uni/components/wd-upload/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-upload/index.scss
@@ -131,6 +131,7 @@
     color: $-upload-close-icon-color;
     width: $-upload-close-icon-size;
     height: $-upload-close-icon-size;
+    line-height: $-upload-close-icon-size;
 
     &::after {
       position: absolute;


### PR DESCRIPTION
修复wd-upload 在小程序中关闭图片偏移的情况


### 🤔 这个 PR 的性质是？(至少选择一个)

- [ x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 改动很小 我就不提Issue了 大佬有时间看下

wd-upload组件 在小程序中关闭图标向下偏移 目前没有发现样式覆盖  只引入了tailwind 没有冲突
检查元素发现在 .wd-upload__close 类中没有 line-height （行高）  这个属性 加上 
    line-height: var(--wot-upload-close-icon-size, 16px); 后会发正常 下面是图片

![6edcc5a3cd697cd7eb077abd64153d7](https://github.com/user-attachments/assets/021eb2b3-e26a-460c-8dde-035260c55401)
修改之后
![image](https://github.com/user-attachments/assets/28197dd2-8764-492b-a191-ab6a59a902b6)



### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x ] 文档已补充或无须补充
- [x ] 代码演示已提供或无须提供
- [ x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **样式更新**
	- 调整了上传组件的样式，优化了上传关闭图标的垂直对齐，提升了视觉效果。
- **文档更新**
	- 更新了上传组件文档中的函数参数，统一了文件处理的参数命名，提高了代码可读性和一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->