### PR TITLE
fix: 🐛 col-picker 点击遮罩关闭执行两次

### DIFF
--- a/docs/component/col-picker.md
+++ b/docs/component/col-picker.md
@@ -278,7 +278,7 @@ onMounted(async () => {
 
 const columnChange: ColPickerColumnChange = async ({ selectedItem, resolve, finish }) => {
   // 模拟异步请求
-  
+
   await sleep(0.3)
   const areaData = findChildrenByCode(colPickerData, selectedItem.value)
   if (areaData && areaData.length) {
@@ -302,7 +302,6 @@ function sleep(second: number = 1) {
     }, 1000 * second)
   })
 }
-
 ```
 
 ## 禁用
@@ -577,7 +576,7 @@ function handleConfirm({ selectedItems }: any) {
 
 ## 自定义选择器
 
-如果默认的 cell 类型的展示格式不满足需求，可以通过默认插槽进行自定义选择器样式。在标签上添加 use-default-slot 属性并设置为 true。 
+如果默认的 cell 类型的展示格式不满足需求，可以通过默认插槽进行自定义选择器样式。在标签上添加 use-default-slot 属性并设置为 true。
 
 ```html
 <view style="margin-bottom: 10px;">当前选中项: {{ displayValue }}</view>
@@ -653,8 +652,8 @@ const columnChange = ({ selectedItem, resolve, finish }) => {
 | ellipsis               | 是否超出隐藏                                                                                                                   | boolean           | -      | false   | -        |
 | prop                   | 表单域 `model` 字段名，在使用表单校验功能的情况下，该属性是必填的                                                              | string            | -      | -       | -        |
 | rules                  | 表单验证规则，结合`wd-form`组件使用                                                                                            | `FormItemRule []` | -      | `[]`    | -        |
-| lineWidth     | 底部条宽度，单位像素             | number          | -      | -     | 1.3.7        |
-| lineHeight    | 底部条高度，单位像素             | number          | -      | -      | 1.3.7        |
+| lineWidth              | 底部条宽度，单位像素                                                                                                           | number            | -      | -       | 1.3.7    |
+| lineHeight             | 底部条高度，单位像素                                                                                                           | number            | -      | -       | 1.3.7    |
 
 ### FormItemRule 数据结构
 
@@ -679,7 +678,7 @@ const columnChange = ({ selectedItem, resolve, finish }) => {
 | 事件名称 | 说明                       | 参数                                             | 最低版本 |
 | -------- | -------------------------- | ------------------------------------------------ | -------- |
 | confirm  | 最后一列选项选中时触发     | `{ value(选项值数组), selectedItems(选项数组) }` | -        |
-| cancel   | 点击关闭按钮或者蒙层时触发 | -                                                | -        |
+| close    | 点击关闭按钮或者蒙层时触发 | -                                                | -        |
 
 ## Methods
 

--- a/src/uni_modules/wot-design-uni/components/wd-action-sheet/wd-action-sheet.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-action-sheet/wd-action-sheet.vue
@@ -127,9 +127,9 @@ function select(rowIndex: number, type: 'action' | 'panels', colIndex?: number) 
 }
 function handleClickModal() {
   emit('click-modal')
-  if (props.closeOnClickModal) {
-    close()
-  }
+  // if (props.closeOnClickModal) {
+  //   close()
+  // }
 }
 function handleCancel() {
   emit('cancel')


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
[#569](https://github.com/Moonofweisheng/wot-design-uni/issues/569)
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档更新**
  - 更新了`col-picker`组件的文档格式和结构，提升了可读性。
  - 将事件名称从`cancel`更改为`close`，以更准确地反映功能。

- **功能变更**
  - 修改了`wd-action-sheet`组件的行为，点击模态框时不再自动关闭，提供了更灵活的用户交互方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->