### PR TITLE
fix: 🐛 修复Input、Textarea未设置labelWidth时通过CSS变量设置label宽度无效的问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-input/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-input/types.ts
@@ -125,7 +125,7 @@ export const inputProps = {
   /**
    * 设置左侧标题宽度
    */
-  labelWidth: makeStringProp('33%'),
+  labelWidth: makeStringProp(''),
   /**
    * 使用 label 插槽
    */

--- a/src/uni_modules/wot-design-uni/components/wd-textarea/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-textarea/types.ts
@@ -207,17 +207,16 @@ export const textareaProps = {
   showWordLimit: makeBooleanProp(false),
 
   /**
-   * * 设置左侧标题。
+   * 设置左侧标题。
    * 类型：string
    */
   label: String,
 
   /**
-   * * 设置左侧标题宽度。
+   * 设置左侧标题宽度。
    * 类型：string
-   * 默认值：'33%'
    */
-  labelWidth: makeStringProp('33%'),
+  labelWidth: makeStringProp(''),
 
   /**
    * * 是否使用label插槽。


### PR DESCRIPTION
✅ Closes: #573

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
Input、Textarea未设置labelWidth时通过CSS变量设置label宽度无效，原因是组件的props设置了默认值，会产生行内样式覆盖CSS变量。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了输入组件和文本区域组件的 `labelWidth` 属性的默认值，改为不设置宽度，可能会影响组件的布局和样式表现。
  
- **文档**
	- 精简了文本区域组件的文档注释，去除了强调的符号，使文档更为简洁。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->