### PR TITLE
fix: upload组件beforePreview新增file参数, 方便用户在预览前根据文件信息判断

### DIFF
--- a/docs/component/upload.md
+++ b/docs/component/upload.md
@@ -99,7 +99,7 @@ const action: string = 'https://mockapi.eolink.com/zhTuw2P8c29bc981a741931bdd86e
 
 ## 拦截预览图片操作
 
-设置 `before-preview` 函数，在用户点击图片进行预览时，会执行 `before-preview` 函数，接收 { index: 当前预览的下标, imgList: 所有图片地址列表, resolve }，通过 `resolve` 函数告知组件是否确定通过，`resolve` 接受 1 个 boolean 值，`resolve(true)` 表示选项通过，`resolve(false)` 表示选项不通过，不通过时不会执行预览图片操作。
+设置 `before-preview` 函数，在用户点击图片进行预览时，会执行 `before-preview` 函数，接收 { file: 预览文件, index: 当前预览的下标, imgList: 所有图片地址列表, resolve }，通过 `resolve` 函数告知组件是否确定通过，`resolve` 接受 1 个 boolean 值，`resolve(true)` 表示选项通过，`resolve(false)` 表示选项不通过，不通过时不会执行预览图片操作。
 
 ```html
 <wd-upload
@@ -588,7 +588,7 @@ const customUpload: UploadMethod = (file, formData, options) => {
 | before-upload                 | 上传文件之前的钩子，参数为上传的文件和文件列表，若返回 false 或者返回 Promise 且被 reject，则停止上传。                                                                        | function({ files, fileList, resolve }) | -                                              | -                          | -                |
 | before-choose                 | 选择图片之前的钩子，参数为文件列表，若返回 false 或者返回 Promise 且被 reject，则停止上传。                                                                                    | function({ fileList, resolve })        | -                                              | -                          | -                |
 | before-remove                 | 删除文件之前的钩子，参数为要删除的文件和文件列表，若返回 false 或者返回 Promise 且被 reject，则停止上传。                                                                      | function({ file, fileList, resolve })  | -                                              | -                          | -                |
-| before-preview                | 图片预览前的钩子，参数为预览的图片下标和图片列表，若返回 false 或者返回 Promise 且被 reject，则停止上传。                                                                      | function({ index, imgList, resolve })  | -                                              | -                          | -                |
+| before-preview                | 图片预览前的钩子，参数为预览的图片下标和图片列表，若返回 false 或者返回 Promise 且被 reject，则停止上传。                                                                      | function({file, index, imgList, resolve })  | -                                              | -                          | -                |
 | build-form-data               | 构建上传`formData`的钩子，参数为上传的文件、待处理的`formData`，返回值为处理后的`formData`，若返回 false 或者返回 Promise 且被 reject，则停止上传。                            | function({ file, formData, resolve })  | -                                              | -                          | 0.1.61           |
 | loading-type                  | [加载中图标类型](/component/loading)                                                                                                                                           | string                                 | -                                              | circular-ring              | -                |
 | loading-color                 | [加载中图标颜色](/component/loading)                                                                                                                                           | string                                 | -                                              | #ffffff                    | -                |

--- a/src/pages/upload/Index.vue
+++ b/src/pages/upload/Index.vue
@@ -126,7 +126,7 @@ const beforeChoose = ({ file, resolve }: any) => {
     })
 }
 
-const beforePreview = ({ resolve }: any) => {
+const beforePreview = ({ resolve, file }: any) => {
   messageBox
     .confirm({
       msg: '是否预览图片',

--- a/src/uni_modules/wot-design-uni/components/wd-loadmore/wd-loadmore.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-loadmore/wd-loadmore.vue
@@ -2,7 +2,7 @@
   <view :class="['wd-loadmore', customClass]" :style="customStyle" @click="reload">
     <wd-divider v-if="state === 'finished'">{{ finishedText || translate('finished') }}</wd-divider>
     <block v-if="state === 'error'">
-      <text class="wd-loadmore__text">{{ errorText || translate('error') }} </text>
+      <text class="wd-loadmore__text">{{ errorText || translate('error') }}</text>
       <text class="wd-loadmore__text is-light">{{ translate('retry') }}</text>
       <wd-icon name="refresh" custom-class="wd-loadmore__refresh" />
     </block>

--- a/src/uni_modules/wot-design-uni/components/wd-upload/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-upload/types.ts
@@ -64,6 +64,7 @@ export type UploadCameraType = 'front' | 'back'
 export type UploadStatusType = 'pending' | 'loading' | 'success' | 'fail'
 
 export type UploadBeforePreviewOption = {
+  file: UploadFileItem
   index: number
   imgList: string[]
   resolve: (isPass: boolean) => void

--- a/src/uni_modules/wot-design-uni/components/wd-upload/wd-upload.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-upload/wd-upload.vue
@@ -564,6 +564,7 @@ function handlePreviewFile(file: UploadFileItem) {
 function handlePreviewImage(index: number, lists: string[]) {
   const { onPreviewFail } = props
   uni.previewImage({
+    file,
     urls: lists,
     current: lists[index],
     fail() {
@@ -620,6 +621,7 @@ function onPreviewImage(file: UploadFileItem) {
   const index: number = lists.findIndex((item) => item.url === file.url)
   if (beforePreview) {
     beforePreview({
+      file,
       index,
       imgList: lists.map((file) => file.url),
       resolve: (isPass: boolean) => {
@@ -644,6 +646,7 @@ function onPreviewVideo(file: UploadFileItem) {
   const index: number = lists.findIndex((item) => item.url === file.url)
   if (beforePreview) {
     beforePreview({
+      file,
       index,
       imgList: [],
       resolve: (isPass: boolean) => {
@@ -663,6 +666,7 @@ function onPreviewFile(file: UploadFileItem) {
   const index: number = lists.findIndex((item) => item.url === file.url)
   if (beforePreview) {
     beforePreview({
+      file,
       index,
       imgList: [],
       resolve: (isPass: boolean) => {


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

文档示例代码也写了file属性,  实际上没有这个属性

<img width="569" alt="image" src="https://github.com/user-attachments/assets/4a57a019-35ff-45b9-a221-9a301f6282a1">



### 💡 需求背景和解决方案

需要根据文件信息处理预览逻辑, beforePreview新增file参数

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在上传组件的预览功能中新增了 `file` 参数，增强了对文件预览的控制和信息获取。
  - 更新了 `beforePreview` 函数，允许开发者在预览过程中访问特定文件的信息。

- **文档**
  - 更新了上传组件的文档，以反映 `before-preview` 函数参数的变化，确保信息一致性。

- **样式**
  - 修复了 `wd-loadmore` 组件中错误信息文本的格式问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->