### PR TITLE
feat: ✨ Fab 悬浮按钮组件支持自定义触发器和控制能否展开

### DIFF
--- a/docs/component/fab.md
+++ b/docs/component/fab.md
@@ -42,19 +42,19 @@ const disabled = ref<boolean>(false)
 ```
 
 ```scss
-  :deep(.custom-button) {
-    min-width: auto !important;
-    box-sizing: border-box;
-    width: 32px !important;
-    height: 32px !important;
-    border-radius: 16px !important;
-    margin: 8rpx;
-  }
+:deep(.custom-button) {
+  min-width: auto !important;
+  box-sizing: border-box;
+  width: 32px !important;
+  height: 32px !important;
+  border-radius: 16px !important;
+  margin: 8rpx;
+}
 
-  :deep(.custom-radio) {
-    height: 32px !important;
-    line-height: 32px !important;
-  }
+:deep(.custom-radio) {
+  height: 32px !important;
+  line-height: 32px !important;
+}
 ```
 
 ## 动作菜单展开/收起
@@ -62,18 +62,17 @@ const disabled = ref<boolean>(false)
 通过`v-model:active`控制动作按钮菜单的展开/收起
 
 ```html
-<wd-fab v-model:active="active">
+<wd-fab v-model:active="active"></wd-fab>
 ```
 
 ```ts
 const active = ref<boolean>(false)
-
 ```
 
 ## 可拖动按钮
 
 ```html
-<wd-fab :draggable="true">
+<wd-fab :draggable="true"></wd-fab>
 ```
 
 :::warning
@@ -82,19 +81,26 @@ const active = ref<boolean>(false)
 
 ## Attributes
 
-| 参数           | 说明                               | 类型         | 可选值                                                                                    | 默认值                                         | 最低版本         |
-| -------------- | ---------------------------------- | ------------ | ----------------------------------------------------------------------------------------- | ---------------------------------------------- | ---------------- |
-| v-model:active | 是否激活                           | boolean      | -                                                                                         | false                                          | 0.1.57           |
-| type           | 类型                               | FabType      | 'primary' &#124; 'success' &#124; 'info' &#124; 'warning' &#124; 'error' &#124; 'default' | 'primary'                                      | 0.1.57           |
-| position       | 悬浮按钮位置                       | FabPosition  | 'left-top' &#124; 'right-top' &#124; 'left-bottom' &#124; 'right-bottom'                  | 'right-bottom'                                 | 0.1.57           |
-| draggable      | 按钮能否拖动                       | boolean      |                                                                                           | false                                          | 1.2.19           |
-| direction      | 悬浮按钮菜单弹出方向               | FabDirection | 'top' &#124; 'right' &#124; 'bottom' &#124; 'left'                                        | 'top'                                          | 0.1.57           |
-| disabled       | 是否禁用                           | boolean      | -                                                                                         | false                                          | 0.1.57           |
-| inactiveIcon   | 悬浮按钮未展开时的图标             | string       | -                                                                                         | 'add'                                          | 0.1.57           |
-| activeIcon     | 悬浮按钮展开时的图标               | string       | -                                                                                         | 'close'                                        | 0.1.57           |
-| zIndex         | 自定义悬浮按钮层级                 | number       | -                                                                                         | 99                                             | 0.1.57           |
-| gap            | 自定义悬浮按钮与可视区域边缘的间距 | FabGap       | -                                                                                         | \{ top: 16, left: 16, right: 16, bottom: 16 \} | 1.2.26 |
-| customStyle    | 自定义样式                         | string       | -                                                                                         | ''                                             | 0.1.57           |
+| 参数           | 说明                                                  | 类型         | 可选值                                                                                    | 默认值                                         | 最低版本         |
+| -------------- | ----------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------- | ---------------------------------------------- | ---------------- |
+| v-model:active | 是否激活                                              | boolean      | -                                                                                         | false                                          | 0.1.57           |
+| type           | 类型                                                  | FabType      | 'primary' &#124; 'success' &#124; 'info' &#124; 'warning' &#124; 'error' &#124; 'default' | 'primary'                                      | 0.1.57           |
+| position       | 悬浮按钮位置                                          | FabPosition  | 'left-top' &#124; 'right-top' &#124; 'left-bottom' &#124; 'right-bottom'                  | 'right-bottom'                                 | 0.1.57           |
+| draggable      | 按钮能否拖动                                          | boolean      |                                                                                           | false                                          | 1.2.19           |
+| direction      | 悬浮按钮菜单弹出方向                                  | FabDirection | 'top' &#124; 'right' &#124; 'bottom' &#124; 'left'                                        | 'top'                                          | 0.1.57           |
+| disabled       | 是否禁用                                              | boolean      | -                                                                                         | false                                          | 0.1.57           |
+| inactiveIcon   | 悬浮按钮未展开时的图标                                | string       | -                                                                                         | 'add'                                          | 0.1.57           |
+| activeIcon     | 悬浮按钮展开时的图标                                  | string       | -                                                                                         | 'close'                                        | 0.1.57           |
+| zIndex         | 自定义悬浮按钮层级                                    | number       | -                                                                                         | 99                                             | 0.1.57           |
+| gap            | 自定义悬浮按钮与可视区域边缘的间距                    | FabGap       | -                                                                                         | \{ top: 16, left: 16, right: 16, bottom: 16 \} | 1.2.26           |
+| customStyle    | 自定义样式                                            | string       | -                                                                                         | ''                                             | 0.1.57           |
+| trigger-expand | 用于控制点击时是否展开菜单，设置为 false 时触发 click | boolean      | -                                                                                         | true                                           | $LOWEST_VERSION$ |
+
+## Events
+
+| 事件名称 | 说明                                             | 参数 | 最低版本         |
+| -------- | ------------------------------------------------ | ---- | ---------------- |
+| click    | trigger-expand 设置为 false 时，点击悬浮按钮触发 | —    | $LOWEST_VERSION$ |
 
 ## 外部样式类
 

--- a/docs/component/fab.md
+++ b/docs/component/fab.md
@@ -79,6 +79,25 @@ const active = ref<boolean>(false)
 开启拖动后`direction`属性将失效，会根据拖动后的位置自动计算弹出方向。拖动完成后按钮将会自动吸边。
 :::
 
+## 自定义触发器
+
+通过`trigger`插槽自定义触发器，`expandable`控制点击触发器是否展开/收起动作按钮菜单。
+
+
+```html
+<wd-fab position="left-bottom" :expandable="false">
+  <template #trigger>
+    <wd-button @click="handleClick" icon="share" type="error">分享给朋友</wd-button>
+  </template>
+</wd-fab>
+```
+```ts
+const handleClick = () => {
+  console.log('点击了')
+}
+
+```
+
 ## Attributes
 
 | 参数           | 说明                                                  | 类型         | 可选值                                                                                    | 默认值                                         | 最低版本         |
@@ -94,13 +113,19 @@ const active = ref<boolean>(false)
 | zIndex         | 自定义悬浮按钮层级                                    | number       | -                                                                                         | 99                                             | 0.1.57           |
 | gap            | 自定义悬浮按钮与可视区域边缘的间距                    | FabGap       | -                                                                                         | \{ top: 16, left: 16, right: 16, bottom: 16 \} | 1.2.26           |
 | customStyle    | 自定义样式                                            | string       | -                                                                                         | ''                                             | 0.1.57           |
-| trigger-expand | 用于控制点击时是否展开菜单，设置为 false 时触发 click | boolean      | -                                                                                         | true                                           | $LOWEST_VERSION$ |
+| expandable     | 用于控制点击时是否展开菜单，设置为 false 时触发 click | boolean      | -                                                                                         | true                                           | $LOWEST_VERSION$ |
 
 ## Events
 
-| 事件名称 | 说明                                             | 参数 | 最低版本         |
-| -------- | ------------------------------------------------ | ---- | ---------------- |
-| click    | trigger-expand 设置为 false 时，点击悬浮按钮触发 | —    | $LOWEST_VERSION$ |
+| 事件名称 | 说明                                         | 参数 | 最低版本         |
+| -------- | -------------------------------------------- | ---- | ---------------- |
+| click    | expandable 设置为 false 时，点击悬浮按钮触发 | —    | $LOWEST_VERSION$ |
+
+## Slot
+
+| name    | 说明                                                           | 最低版本         |
+| ------- | -------------------------------------------------------------- | ---------------- |
+| trigger | 触发器插槽，用于自定义点击按钮，使用此插槽时组件不会抛出 click | $LOWEST_VERSION$ |
 
 ## 外部样式类
 

--- a/src/pages/fab/Index.vue
+++ b/src/pages/fab/Index.vue
@@ -43,7 +43,23 @@
           <wd-button type="primary" @click="active = !active" round>切换</wd-button>
         </view>
       </demo-block>
-      <wd-fab v-model:active="active" :disabled="disabled" :type="type" :position="position" :direction="direction" :draggable="draggable">
+
+      <demo-block title="自定义触发器">
+        <view @click.stop="">
+          <wd-switch v-model="useTriggerSlot" size="22px" />
+        </view>
+      </demo-block>
+      <wd-fab
+        v-if="!useTriggerSlot"
+        v-model:active="active"
+        :disabled="disabled"
+        :type="type"
+        :position="position"
+        :direction="direction"
+        :draggable="draggable"
+        :trigger-expend="triggerExpend"
+        @click="showToast('我被点了')"
+      >
         <wd-button @click="showToast('一键三连')" :disabled="disabled" custom-class="custom-button" type="primary" round>
           <wd-icon name="github-filled" size="22px"></wd-icon>
         </wd-button>
@@ -58,6 +74,12 @@
           <wd-icon name="thumb-up" size="22px"></wd-icon>
         </wd-button>
       </wd-fab>
+
+      <wd-fab v-else position="left-bottom" :draggable="draggable" :trigger-expend="false" @click="showToast('自定义trigger插槽')">
+        <template #trigger>
+          <wd-button icon="share" type="error">分享给朋友</wd-button>
+        </template>
+      </wd-fab>
     </page-wraper>
   </view>
 </template>
@@ -70,7 +92,11 @@ const type = ref<'primary' | 'success' | 'info' | 'warning' | 'error' | 'default
 const position = ref<'left-top' | 'right-top' | 'left-bottom' | 'right-bottom'>('left-bottom')
 const direction = ref<'top' | 'right' | 'bottom' | 'left'>('top')
 const disabled = ref<boolean>(false)
-const draggable = ref(false)
+const draggable = ref<boolean>(false)
+const triggerExpend = ref<boolean>(true)
+
+const useTriggerSlot = ref<boolean>(false)
+
 const { closeOutside } = useQueue()
 </script>
 <style lang="scss" scoped>
@@ -78,6 +104,7 @@ const { closeOutside } = useQueue()
   position: relative;
   height: 100%;
   width: 100%;
+  padding-bottom: 88rpx;
   :deep(.custom-button) {
     min-width: auto !important;
     box-sizing: border-box;

--- a/src/pages/fab/Index.vue
+++ b/src/pages/fab/Index.vue
@@ -57,7 +57,6 @@
         :position="position"
         :direction="direction"
         :draggable="draggable"
-        :trigger-expend="triggerExpend"
         @click="showToast('我被点了')"
       >
         <wd-button @click="showToast('一键三连')" :disabled="disabled" custom-class="custom-button" type="primary" round>
@@ -75,9 +74,9 @@
         </wd-button>
       </wd-fab>
 
-      <wd-fab v-else position="left-bottom" :draggable="draggable" :trigger-expend="false" @click="showToast('自定义trigger插槽')">
+      <wd-fab v-else position="left-bottom" :draggable="draggable" :expandable="false">
         <template #trigger>
-          <wd-button icon="share" type="error">分享给朋友</wd-button>
+          <wd-button @click="handleCustomClick" icon="share" type="error">分享给朋友</wd-button>
         </template>
       </wd-fab>
     </page-wraper>
@@ -93,17 +92,21 @@ const position = ref<'left-top' | 'right-top' | 'left-bottom' | 'right-bottom'>(
 const direction = ref<'top' | 'right' | 'bottom' | 'left'>('top')
 const disabled = ref<boolean>(false)
 const draggable = ref<boolean>(false)
-const triggerExpend = ref<boolean>(true)
-
 const useTriggerSlot = ref<boolean>(false)
 
 const { closeOutside } = useQueue()
+
+function handleCustomClick() {
+  showToast('分享给朋友')
+}
 </script>
 <style lang="scss" scoped>
 .fab {
   position: relative;
   height: 100%;
   width: 100%;
+  min-height: 100vh;
+  box-sizing: border-box;
   padding-bottom: 88rpx;
   :deep(.custom-button) {
     min-width: auto !important;

--- a/src/uni_modules/wot-design-uni/components/wd-fab/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-fab/types.ts
@@ -51,7 +51,7 @@ export const fabProps = {
   /**
    * 用于控制点击时是否展开菜单
    */
-  triggerExpend: makeBooleanProp(true)
+  expandable: makeBooleanProp(true)
 }
 
 export type FabProps = ExtractPropTypes<typeof fabProps>

--- a/src/uni_modules/wot-design-uni/components/wd-fab/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-fab/types.ts
@@ -47,7 +47,11 @@ export const fabProps = {
   gap: {
     type: Object as PropType<FabGap>,
     default: () => ({})
-  }
+  },
+  /**
+   * 用于控制点击时是否展开菜单
+   */
+  triggerExpend: makeBooleanProp(true)
 }
 
 export type FabProps = ExtractPropTypes<typeof fabProps>

--- a/src/uni_modules/wot-design-uni/components/wd-fab/wd-fab.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-fab/wd-fab.vue
@@ -14,7 +14,7 @@
       </wd-button>
     </view>
     <wd-transition
-      v-if="triggerExpend"
+      v-if="expandable"
       :enter-class="`wd-fab__transition-enter--${fabDirection}`"
       enter-active-class="wd-fab__transition-enter-active"
       :leave-to-class="`wd-fab__transition-leave-to--${fabDirection}`"
@@ -205,8 +205,6 @@ onMounted(() => {
   }
 
   const { start } = useRaf(async () => {
-    console.log(2323)
-
     await getBounding()
     initPosition()
     inited.value = true
@@ -226,7 +224,7 @@ function handleClick() {
   if (props.disabled) {
     return
   }
-  if (!props.triggerExpend) {
+  if (!props.expandable) {
     emit('click')
     return
   }


### PR DESCRIPTION
✅ Closes: #512 
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

#512 

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

提供expandable属性用于控制点击触发器是否展开。  
提供trigger插槽用于自定义触发器。  
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 引入自定义触发器功能，允许开发者使用自定义按钮触发 FAB 操作。
	- 添加可扩展属性，控制 FAB 操作菜单的展开行为。

- **文档更新**
	- 更新 FAB 组件文档，增加自定义触发器和可扩展属性的说明，提供更清晰的 API 参考。

- **样式调整**
	- 对 FAB 组件的样式进行小幅调整，确保布局一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->