### PR TITLE
feat: ✨ Img组件新增属性 show-menu-by-longpress 支持微信小程序长按弹出菜单栏

### DIFF
--- a/docs/component/img.md
+++ b/docs/component/img.md
@@ -8,25 +8,21 @@
 
 基础用法与原生 image 标签一致，可以设置 `src` 、 `width` 、`height` 等原生属性。
 
-原生属性，参考[uni-app image官方文档](https://uniapp.dcloud.net.cn/component/image.html#image)。
+原生属性，参考[uni-app image 官方文档](https://uniapp.dcloud.net.cn/component/image.html#image)。
 
-此处需要注意的是src属性：
+此处需要注意的是 src 属性：
 
 使用 `相对路径`，需要注意 `src` 需要以组件存放位置相对图片位置为相对路径。
 
-使用 `文件导入` ，需要注意的是微信小程序image标签路径接受二进制数据以及base64编码。单独使用import图片路径无法访问。
+使用 `文件导入` ，需要注意的是微信小程序 image 标签路径接受二进制数据以及 base64 编码。单独使用 import 图片路径无法访问。
 
 ```html
-<wd-img
- :width="100"
- :height="100"
-  :src="joy"
-/>
+<wd-img :width="100" :height="100" :src="joy" />
 ```
 
 ```typescript
 // import { joy } from '../images/joy'
-const joy = 'data:image/jpeg;base64,...'  // 图片文件base64
+const joy = 'data:image/jpeg;base64,...' // 图片文件base64
 ```
 
 ## 插槽
@@ -37,13 +33,11 @@ const joy = 'data:image/jpeg;base64,...'  // 图片文件base64
 <template>
   <wd-img :width="100" :height="100" src="https://www.123.com/a.jpg">
     <template #error>
-      <view class="error-wrap">
-        加载失败
-      </view>
+      <view class="error-wrap">加载失败</view>
     </template>
     <template #loading>
       <view class="loading-wrap">
-        <wd-loading/>
+        <wd-loading />
       </view>
     </template>
   </wd-img>
@@ -73,15 +67,10 @@ const joy = 'data:image/jpeg;base64,...'  // 图片文件base64
 
 通过 `mode` 属性可以设置图片填充模式，可选值见下方表格。
 
-mode为小程序原生属性，参考[微信小程序image官方文档](https://developers.weixin.qq.com/miniprogram/dev/component/image.html)。
+mode 为小程序原生属性，参考[微信小程序 image 官方文档](https://developers.weixin.qq.com/miniprogram/dev/component/image.html)。
 
 ```html
-<wd-img
- :width="100"
- :height="100"
-  mode="center"
-  :src="joy"
-/>
+<wd-img :width="100" :height="100" mode="center" :src="joy" />
 ```
 
 ## 圆形设置
@@ -89,53 +78,44 @@ mode为小程序原生属性，参考[微信小程序image官方文档](https://
 通过 `round` 属性可以设置以圆形展示。
 
 ```html
-<wd-img
- :width="100"
- :height="100"
-  round
-  :src="joy"
-/>
+<wd-img :width="100" :height="100" round :src="joy" />
 ```
 
 ## 可预览
 
-通过设置`enable-preview`属性可以支持点击预览，底层调用uni.previewImage来实现预览效果
+通过设置`enable-preview`属性可以支持点击预览，底层调用 uni.previewImage 来实现预览效果
 
 ```html
-<wd-img
-  :width="100"
-  :height="100"
-  :src="joy"
-  :enable-preview="true"
-/>
+<wd-img :width="100" :height="100" :src="joy" :enable-preview="true" />
 ```
 
 ## Attributes
 
-| 参数           | 说明                   | 类型            | 可选值                                                                                                                                                                             | 默认值        | 最低版本 |
-| -------------- | ---------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | -------- |
-| src            | 图片链接               | string          | -                                                                                                                                                                                  | -             | -        |
-| width          | 宽度，默认单位为px     | number / string | -                                                                                                                                                                                  | -             | -        |
-| height         | 高度，默认单位为px     | number / string | -                                                                                                                                                                                  | -             | -        |
-| mode           | 填充模式               | ImageMode       | 'top left' / 'top right' / 'bottom left' / 'bottom right' / 'right' / 'left' / 'center' / 'bottom' / 'top' / 'heightFix' / 'widthFix' / 'aspectFill' / 'aspectFit' / 'scaleToFill' | 'scaleToFill' | -        |
-| round          | 是否显示为圆形         | boolean         | -                                                                                                                                                                                  | false         | -        |
-| radius         | 圆角大小，默认单位为px | number / string | -                                                                                                                                                                                  | -             | -        |
-| enable-preview | 是否支持点击预览       | boolean         | -                                                                                                                                                                                  | false         | 1.2.11   |
+| 参数                   | 说明                                               | 类型            | 可选值                                                                                                                                                                             | 默认值        | 最低版本         |
+| ---------------------- | -------------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | ---------------- |
+| src                    | 图片链接                                           | string          | -                                                                                                                                                                                  | -             | -                |
+| width                  | 宽度，默认单位为 px                                | number / string | -                                                                                                                                                                                  | -             | -                |
+| height                 | 高度，默认单位为 px                                | number / string | -                                                                                                                                                                                  | -             | -                |
+| mode                   | 填充模式                                           | ImageMode       | 'top left' / 'top right' / 'bottom left' / 'bottom right' / 'right' / 'left' / 'center' / 'bottom' / 'top' / 'heightFix' / 'widthFix' / 'aspectFill' / 'aspectFit' / 'scaleToFill' | 'scaleToFill' | -                |
+| round                  | 是否显示为圆形                                     | boolean         | -                                                                                                                                                                                  | false         | -                |
+| radius                 | 圆角大小，默认单位为 px                            | number / string | -                                                                                                                                                                                  | -             | -                |
+| enable-preview         | 是否支持点击预览                                   | boolean         | -                                                                                                                                                                                  | false         | 1.2.11           |
+| show-menu-by-longpress | 开启长按图片显示识别小程序码菜单，仅微信小程序支持 | boolean         | -                                                                                                                                                                                  | false         | $LOWEST_VERSION$ |
 
 ## Events
 
-| 事件名称 | 说明                 | 参数              | 最低版本 |
-| -------- | -------------------- | ----------------- | -------- |
-| click    | 点击事件             | (event: MouseEvent) => void                 | -        |
-| load     | 当图片载入完毕时触发 | `{height, width}` | -        |
-| error    | 当错误发生时触发     | `{errMsg}`        | -        |
+| 事件名称 | 说明                 | 参数                        | 最低版本 |
+| -------- | -------------------- | --------------------------- | -------- |
+| click    | 点击事件             | (event: MouseEvent) => void | -        |
+| load     | 当图片载入完毕时触发 | `{height, width}`           | -        |
+| error    | 当错误发生时触发     | `{errMsg}`                  | -        |
 
 ## Slots
 
-| 名称    | 说明               | 最低版本         |
-| ------- | ------------------ | ---------------- |
-| loading | 图片加载时展示     | 1.2.21 |
-| error   | 图片加载失败后展示 | 1.2.21 |
+| 名称    | 说明               | 最低版本 |
+| ------- | ------------------ | -------- |
+| loading | 图片加载时展示     | 1.2.21   |
+| error   | 图片加载失败后展示 | 1.2.21   |
 
 ## 外部样式类
 

--- a/src/uni_modules/wot-design-uni/components/wd-img/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-img/types.ts
@@ -49,5 +49,9 @@ export const imgProps = {
   /**
    * 是否允许预览
    */
-  enablePreview: makeBooleanProp(false)
+  enablePreview: makeBooleanProp(false),
+  /**
+   * 开启长按图片显示识别小程序码菜单，仅在微信小程序平台有效
+   */
+  showMenuByLongpress: makeBooleanProp(false)
 }

--- a/src/uni_modules/wot-design-uni/components/wd-img/wd-img.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-img/wd-img.vue
@@ -5,6 +5,7 @@
       :style="status !== 'success' ? 'width: 0;height: 0;' : ''"
       :src="src"
       :mode="mode"
+      :show-menu-by-longpress="showMenuByLongpress"
       :lazy-load="lazyLoad"
       @load="handleLoad"
       @error="handleError"


### PR DESCRIPTION
✅ Closes: #611

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

show-menu-by-longpress | boolean | false | 否 | 长按图片显示发送给朋友、收藏、保存图片、搜一搜、打开名片/前往群聊/打开小程序（若图片中包含对应二维码或小程序码）的菜单。 | 2.7.0
-- | -- | -- | -- | -- | --

使用微信小程序原生支持的能力

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在 `wd-img` 组件中添加了 `showMenuByLongpress` 属性，允许用户通过长按图像显示菜单，适用于微信小程序平台。
	- 增强了 `<wd-img>` 组件的功能，支持长按手势以提供更多用户交互选项。

- **文档**
	- 更新了 `wd-img` 组件的文档，进行了格式和排版的修正，提高了可读性和专业性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->