### PR TITLE
feat: ✨ StatusTip缺省提示组件提供图片内容插槽(#538)

### DIFF
--- a/docs/component/status-tip.md
+++ b/docs/component/status-tip.md
@@ -54,6 +54,18 @@
 <wd-status-tip image="https://registry.npmmirror.com/wot-design-uni-assets/*/files/panda.jpg" tip="查看我的头像" />
 ```
 
+## 自定义图片内容
+
+使用插槽 `image` 可以自定义图片内容。
+
+```html
+<wd-status-tip tip="自定义图片内容">
+  <template #image>
+    <wd-icon name="ie-filled" size="100px"></wd-icon>
+  </template>
+</wd-status-tip>
+```
+
 ## Attributes
 
 | 参数       | 说明                                               | 类型                          | 可选值                                                          | 默认值                                                        | 最低版本         |
@@ -70,3 +82,9 @@
 | ------ | ------------------------- | ---------------- | ------ | ------ | -------- |
 | height | 图片高度，默认单位为 `px` | string \| number | -      | -      | 1.2.12   |
 | width  | 图片宽度，默认单位为 `px` | string \| number | -      | -      | 1.2.12   |
+
+## Slot
+
+| name    | 说明                     | 最低版本 |
+| ------- | ------------------------ | -------- |
+| image   | 图片内容                  | $LOWEST_VERSION$ |

--- a/src/pages/statusTip/Index.vue
+++ b/src/pages/statusTip/Index.vue
@@ -42,6 +42,14 @@
     <demo-block title="自定义图片">
       <wd-status-tip image="https://registry.npmmirror.com/wot-design-uni-assets/*/files/panda.jpg" tip="查看我的头像" />
     </demo-block>
+
+    <demo-block title="插槽自定义图片内容">
+      <wd-status-tip tip="插槽自定义图片内容">
+        <template #image>
+          <wd-icon name="ie-filled" size="100px"></wd-icon>
+        </template>
+      </wd-status-tip>
+    </demo-block>
   </page-wraper>
 </template>
 <script lang="ts" setup></script>

--- a/src/uni_modules/wot-design-uni/components/wd-status-tip/wd-status-tip.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-status-tip/wd-status-tip.vue
@@ -1,15 +1,16 @@
 <!--
  * @Author: weisheng
  * @Date: 2023-06-12 10:04:19
- * @LastEditTime: 2024-09-19 14:44:17
- * @LastEditors: weisheng
+ * @LastEditTime: 2024-09-20 10:23:38
+ * @LastEditors: jiaoxueyan
  * @Description: 
  * @FilePath: \wot-design-uni\src\uni_modules\wot-design-uni\components\wd-status-tip\wd-status-tip.vue
  * 记得注释
 -->
 <template>
   <view :class="`wd-status-tip  ${customClass}`" :style="customStyle">
-    <wd-img v-if="imgUrl" :mode="imageMode" :src="imgUrl" custom-class="wd-status-tip__image" :custom-style="imgStyle"></wd-img>
+    <slot name="image" v-if="$slots.image"></slot>
+    <wd-img v-else-if="imgUrl" :mode="imageMode" :src="imgUrl" custom-class="wd-status-tip__image" :custom-style="imgStyle"></wd-img>
     <view v-if="tip" class="wd-status-tip__text">{{ tip }}</view>
   </view>
 </template>


### PR DESCRIPTION
✅ Closes: #538

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
[ #538 ](https://github.com/Moonofweisheng/wot-design-uni/issues/538)


### 💡 需求背景和解决方案
1. 提供image插槽用于自定义图片内容。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了 `wd-status-tip` 组件，允许用户通过 `image` 插槽自定义图像内容。
	- 在 `Index.vue` 中新增了演示区块，展示如何使用插槽替换默认图像。
- **文档**
	- 更新了 `wd-status-tip` 组件的文档，增加了关于 `image` 插槽的详细说明和示例。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->