### PR TITLE
feat: ✨ form 表单禁用功能

### DIFF
--- a/src/pages/form/Index.vue
+++ b/src/pages/form/Index.vue
@@ -1,7 +1,7 @@
 <template>
   <page-wraper>
     <demo-block title="基础表单" transparent>
-      <wd-form ref="form1" :model="model1">
+      <wd-form ref="form1" :model="model1" disabled>
         <wd-cell-group border>
           <wd-input
             label="用户名"

--- a/src/uni_modules/wot-design-uni/components/composables/useChildren.ts
+++ b/src/uni_modules/wot-design-uni/components/composables/useChildren.ts
@@ -80,6 +80,9 @@ export function useChildren<
   const linkChildren = (value?: ProvideValue) => {
     const link = (child: ComponentInternalInstance) => {
       if (child.proxy) {
+        if ((value as any).props?.disabled) {
+          child.props.disabled = true
+        }
         internalChildren.push(child)
         publicChildren.push(child.proxy as Child)
         sortChildren(parent, publicChildren, internalChildren)

--- a/src/uni_modules/wot-design-uni/components/wd-form/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-form/types.ts
@@ -63,7 +63,11 @@ export const formProps = {
   errorType: {
     type: String as PropType<'toast' | 'message' | 'none'>,
     default: 'message'
-  }
+  },
+  /**
+   * 表单整体禁用，开启之后，里面的表单项都会被禁用
+   */
+  disabled: makeBooleanProp(false)
 }
 export type FormProps = ExtractPropTypes<typeof formProps>
 


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
[表单禁用功能](https://github.com/Moonofweisheng/wot-design-uni/issues/524)
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在表单组件中添加了“禁用”属性，允许用户在需要时禁用整个表单。
  - 子组件会继承父组件的禁用状态，确保一致的用户体验。

- **文档**
  - 更新了“禁用”属性的描述，明确其功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->