### PR TITLE
feat: ✨ datetime-picker新增right-icon插槽

### DIFF
--- a/docs/component/datetime-picker.md
+++ b/docs/component/datetime-picker.md
@@ -255,6 +255,40 @@ const displayFormatTabLabel = (items) => {
 
 ```
 
+## 自定义icon
+
+添加 `right-icon` 插槽来自定义右侧图标。
+
+
+```html
+ <wd-datetime-picker label="自定义icon" v-model="value" ref="dateTimePickerRef">
+        <template #right-icon="{ disabled, readonly }">
+          <view @click.stop="rightIconClick" v-if="!disabled && !readonly">
+            <wd-icon custom-class="wd-picker__arrow" :name="isEmpty ? 'arrow-right' : 'close'" />
+          </view>
+        </template>
+</wd-datetime-picker>
+```
+
+```typescript
+import type {,
+  DatetimePickerExpose
+} from '@/uni_modules/wot-design-uni/components/wd-datetime-picker/types'
+
+const value = ref<any[]>(['', Date.now()])
+const dateTimePickerRef=ref<DatetimePickerExpose>(null)
+
+/* right-icon点击事件 */
+function rightIconClick() {
+  if (isEmpty.value) {
+    dateTimePickerRef.value!.open()
+    return
+  }
+  value.value = []
+}
+```
+
+
 ## Attributes
 
 | 参数 | 说明 | 类型 | 可选值 | 默认值 | 最低版本 |
@@ -328,6 +362,7 @@ const displayFormatTabLabel = (items) => {
 |------|-----|---------|
 | default | 使用默认插槽 | - |
 | label | 左侧标题插槽 | - |
+| right-icon | 右侧图标插槽 | $LOWEST_VERSION$ |
 
 ## 外部样式类
 

--- a/docs/component/datetime-picker.md
+++ b/docs/component/datetime-picker.md
@@ -362,7 +362,7 @@ function rightIconClick() {
 |------|-----|---------|
 | default | 使用默认插槽 | - |
 | label | 左侧标题插槽 | - |
-| right-icon | 右侧图标插槽 | $LOWEST_VERSION$ |
+| right-icon | 右侧图标插槽,作用域参数：{ disabled, readonly } | $LOWEST_VERSION$ |
 
 ## 外部样式类
 

--- a/src/pages/datetimePicker/Index.vue
+++ b/src/pages/datetimePicker/Index.vue
@@ -33,6 +33,15 @@
     <demo-block title="范围tab展示格式" transparent>
       <wd-datetime-picker label="日期选择" v-model="value15" @confirm="handleConfirm15" :display-format-tab-label="displayFormatTabLabel" />
     </demo-block>
+    <demo-block title="自定义icon" transparent>
+      <wd-datetime-picker label="自定义icon" v-model="value18" ref="dateTimePickerRef">
+        <template #right-icon="{ disabled, readonly }">
+          <view @click.stop="rightIconClick" v-if="!disabled && !readonly">
+            <wd-icon custom-class="wd-picker__arrow" :name="isEmpty ? 'arrow-right' : 'close'" />
+          </view>
+        </template>
+      </wd-datetime-picker>
+    </demo-block>
   </page-wraper>
 </template>
 <script lang="ts" setup>
@@ -41,9 +50,10 @@ import type { DatetimePickerViewFilter, DatetimePickerViewFormatter } from '@/un
 import type {
   DatetimePickerDisplayFormat,
   DatetimePickerDisplayFormatTabLabel,
-  DatetimePickerInstance
+  DatetimePickerInstance,
+  DatetimePickerExpose
 } from '@/uni_modules/wot-design-uni/components/wd-datetime-picker/types'
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 
 const value1 = ref<string>('')
 const value2 = ref<number>(Date.now())
@@ -62,9 +72,12 @@ const value14 = ref<any[]>(['', ''])
 const value15 = ref<any[]>(['', Date.now()])
 const value16 = ref(Date.now())
 const value17 = ref(Date.now())
+const value18 = ref<any[]>(['', Date.now()])
 
 const minDate = ref<number>(Date.now())
 const maxDate = ref<number>(new Date(new Date().getFullYear() + 1, new Date().getMonth(), new Date().getDate()).getTime())
+
+const dateTimePickerRef = ref<DatetimePickerExpose>()
 
 const formatter: DatetimePickerViewFormatter = (type, value) => {
   switch (type) {
@@ -160,5 +173,18 @@ function handleConfirm16({ value }: any) {
 }
 /** picker触发cancel事件，同步触发cancel事件 */
 function onCancel() {}
+/* 自定义icon */
+const isEmpty = computed(() => {
+  return value18.value.every((item) => item == '')
+})
+/* right-icon点击事件 */
+function rightIconClick() {
+  if (isEmpty.value) {
+    dateTimePickerRef.value!.open()
+    return
+  }
+  value18.value = []
+  toast.success('清空成功')
+}
 </script>
 <style lang="scss" scoped></style>

--- a/src/uni_modules/wot-design-uni/components/wd-datetime-picker/wd-datetime-picker.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-datetime-picker/wd-datetime-picker.vue
@@ -38,7 +38,9 @@
                 {{ showValue ? showValue : placeholder || translate('placeholder') }}
               </view>
             </view>
-            <wd-icon v-if="!disabled && !readonly" custom-class="wd-picker__arrow" name="arrow-right" />
+            <slot name="right-icon" :disabled="disabled" :readonly="readonly">
+              <wd-icon v-if="!disabled && !readonly" custom-class="wd-picker__arrow" name="arrow-right" />
+            </slot>
           </view>
           <view v-if="errorMessage" class="wd-picker__error-message">{{ errorMessage }}</view>
         </view>

--- a/src/uni_modules/wot-design-uni/components/wd-pagination/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-pagination/index.scss
@@ -33,10 +33,11 @@
   @include edeep(nav) {
     min-width: $-pagination-nav-width;
     @include m(active){
-      color: rgba(0,0,0,0.65)      
+      opacity:0.935;
     }
     @include m(disabled){
-      color: rgba(0,0,0,0.15)      
+     // color: rgba(0,0,0,0.15)    
+      opacity:0.985;  
     }
   }
   @include e(size){


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 在 `wd-datetime-picker` 组件中添加了自定义右侧图标的功能，用户可以通过新的 `right-icon` 插槽进行定制。
  - 提供了基于状态的条件渲染示例，图标会根据选择器的状态变化。

- **文档**
  - 更新了文档以包含新的 `right-icon` 插槽及其使用示例。
  
- **样式**
  - 修改了 `wd-pagination` 组件的样式，更新了活动和禁用状态的颜色属性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->