### PR TITLE
feat: 为tabs组件添加showScrollbar属性

### DIFF
--- a/docs/component/tabs.md
+++ b/docs/component/tabs.md
@@ -147,6 +147,7 @@ const tab = ref('例子')
 | inactiveColor | 非活动标签文字颜色               | string          | -      | -      | -        |
 | animated      | 是否开启切换标签内容时的转场动画 | boolean         | -      | false  | -        |
 | duration      | 切换动画过渡时间，单位毫秒       | number          | -      | 300    | -        |
+| showScrollbar | 当标签可以滑动时是否显示滚动条    | boolean          | -      | false   | -        |
 
 ## Tab Attributes
 

--- a/docs/component/tabs.md
+++ b/docs/component/tabs.md
@@ -147,7 +147,7 @@ const tab = ref('例子')
 | inactiveColor | 非活动标签文字颜色               | string          | -      | -      | -        |
 | animated      | 是否开启切换标签内容时的转场动画 | boolean         | -      | false  | -        |
 | duration      | 切换动画过渡时间，单位毫秒       | number          | -      | 300    | -        |
-| showScrollbar | 当标签可以滑动时是否显示滚动条    | boolean          | -      | false   | -        |
+| showScrollbar | 当标签可以滑动时是否显示滚动条    | boolean          | -      | false   | $LOWEST_VERSION$ |
 
 ## Tab Attributes
 

--- a/src/uni_modules/wot-design-uni/components/wd-tabs/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/types.ts
@@ -58,7 +58,13 @@ export const tabsProps = {
   /**
    * 切换动画过渡时间，单位毫秒
    */
-  duration: makeNumberProp(300)
+  duration: makeNumberProp(300),
+  /**
+   * 控制是否出现滚动条
+   *
+   * 默认为 false
+   */
+  showScrollbar: makeBooleanProp(false)
 }
 
 export type TabsProps = ExtractPropTypes<typeof tabsProps>

--- a/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
@@ -80,7 +80,7 @@
       <!--头部导航容器-->
       <view class="wd-tabs__nav">
         <view class="wd-tabs__nav--wrap">
-          <scroll-view :scroll-x="slidableNum < items.length" scroll-with-animation :scroll-left="state.scrollLeft">
+          <scroll-view :showScrollbar="showScrollbar" :scroll-x="slidableNum < items.length" scroll-with-animation :scroll-left="state.scrollLeft">
             <view class="wd-tabs__nav-container">
               <!--nav列表-->
               <view


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

### 💡 需求背景和解决方案

1. 要解决的问题：wd-tabs在标签可以滑动时会出现滚动条需要手动样式覆盖比较麻烦
![1](https://github.com/user-attachments/assets/6ca45ccd-4a07-41a3-839b-7c2aac8da50a)

2. 添加通过(showScrollbar)属性控制滚动条是否可以显示


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

## Summary by CodeRabbit

- **新功能**
  - 在`wd-tabs`组件中添加`showScrollbar`属性，允许用户通过配置来展示是否展示滚动条
- 文档
  - 更新了`wd-tabs`组件的文档，说明属性的作用以及默认值
  