### PR TITLE
fix(wd-form): empty toast when reject is Error

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-form/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-form/types.ts
@@ -35,7 +35,10 @@ export interface FormItemRule {
   required: boolean
   message: string
   pattern?: RegExp
-  validator?: (value: any, rule: FormItemRuleWithoutValidator) => boolean | Promise<string> | Promise<boolean> | Promise<void> | Promise<unknown>
+  validator?: (
+    value: any,
+    rule: FormItemRuleWithoutValidator
+  ) => boolean | Promise<string> | Promise<Error> | Promise<boolean> | Promise<void> | Promise<unknown>
 }
 
 export type FormItemRuleWithoutValidator = Omit<FormItemRule, 'validator'>

--- a/src/uni_modules/wot-design-uni/components/wd-form/wd-form.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-form/wd-form.vue
@@ -94,11 +94,23 @@ async function validate(prop?: string): Promise<{ valid: boolean; errors: ErrorM
                     valid = false
                   }
                 })
-                .catch((error) => {
-                  errors.push({
-                    prop,
-                    message: error.message || error || rule.message
-                  })
+                .catch((error: any) => {
+                  if (error instanceof Error) {
+                    errors.push({
+                      prop,
+                      message: error.message || rule.message
+                    })
+                  } else if (typeof error === 'string') {
+                    errors.push({
+                      prop,
+                      message: error
+                    })
+                  } else {
+                    errors.push({
+                      prop,
+                      message: rule.message
+                    })
+                  }
                   valid = false
                 })
             )

--- a/src/uni_modules/wot-design-uni/components/wd-form/wd-form.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-form/wd-form.vue
@@ -97,7 +97,7 @@ async function validate(prop?: string): Promise<{ valid: boolean; errors: ErrorM
                 .catch((error) => {
                   errors.push({
                     prop,
-                    message: error || rule.message
+                    message: error.message || error || rule.message
                   })
                   valid = false
                 })


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/Moonofweisheng/wot-design-uni/issues/667

### 💡 需求背景和解决方案

wd-form 中 rules, 当 Promise.reject 参数为 Error 时, toast 将显示空提示

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新特性**
	- 改进了表单验证的错误处理逻辑，提供更具体的错误反馈。
- **修复**
	- 优化了错误消息的分配机制，确保在验证失败时能够返回更准确的信息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->