### PR TITLE
fix: 🐛 修复DropMenu第一次通过open()而非用户点击打开时展开菜单定位错误问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-drop-menu/wd-drop-menu.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-drop-menu/wd-drop-menu.vue
@@ -34,7 +34,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import { getCurrentInstance, inject, onBeforeMount, ref, watch } from 'vue'
+import { getCurrentInstance, inject, onBeforeMount, onMounted, ref, watch } from 'vue'
 import { closeOther } from '../common/clickoutside'
 import { type Queue, queueKey } from '../composables/useQueue'
 import { getRect, uuid } from '../common/util'
@@ -66,6 +66,10 @@ watch(
 
 onBeforeMount(() => {
   windowHeight.value = uni.getSystemInfoSync().windowHeight
+})
+
+onMounted(() => {
+  updateOffset()
 })
 
 function noop(event: Event) {
@@ -100,19 +104,25 @@ function toggle(child: any) {
 }
 
 /**
+ * 更新 offset
+ */
+async function updateOffset() {
+  const rect = await getRect(`#${dropMenuId.value}`, false, proxy)
+  if (!rect) return
+  const { top, bottom } = rect
+  if (props.direction === 'down') {
+    offset.value = Number(bottom)
+  } else {
+    offset.value = windowHeight.value - Number(top)
+  }
+}
+
+/**
  * 控制菜单内容是否展开
  */
-function fold(child: any) {
-  getRect(`#${dropMenuId.value}`, false, proxy).then((rect) => {
-    if (!rect) return
-    const { top, bottom } = rect
-    if (props.direction === 'down') {
-      offset.value = Number(bottom)
-    } else {
-      offset.value = windowHeight.value - Number(top)
-    }
-    child.$.exposed!.toggle()
-  })
+async function fold(child: any) {
+  await updateOffset()
+  child.$.exposed!.toggle()
 }
 </script>
 


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
3. 列出最终的 API 实现和用法。
4. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 增强了下拉菜单组件的响应能力，确保菜单显示方向的偏移量准确计算。
  
- **改进**
  - 优化了菜单折叠功能的执行流程，确保在切换可见性之前完成偏移量更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->