### PR TITLE
feat: ✨ Tabs 新增 `autoLineWidth` 设置底部条宽度自动同步文本内容'

### DIFF
--- a/docs/component/tabs.md
+++ b/docs/component/tabs.md
@@ -57,6 +57,25 @@ const tab = ref('例子')
 }
 ```
 
+## 自动调整底部条宽度
+
+设置 `auto-line-width` 属性，自动调整底部条宽度为文本内容宽度。
+
+```html
+<wd-tabs v-model="tab" @change="handleChange" auto-line-width>
+  <block v-for="item in tabs" :key="item">
+    <wd-tab :title="`${item}`" :name="item">
+      <view class="content">内容{{ tab }}</view>
+    </wd-tab>
+  </block>
+</wd-tabs>
+```
+
+```typescript
+const tabs = ref(['Wot', 'Design', 'Uni'])
+const tab = ref('Design')
+```
+
 ## 粘性布局
 
 设置 `sticky` 属性，使用粘性布局。可以设置 `offset-top` 属性，当距离窗口顶部多少像素时，固定标签头。在`H5`端使用自定义导航栏时需要参考[sticky 的吸顶距离](/component/sticky.html#吸顶距离)进行配置。
@@ -141,6 +160,7 @@ const tab = ref('例子')
 | sticky        | 粘性布局                         | boolean         | -      | false  | -        |
 | offset-top    | 粘性布局时距离窗口顶部距离       | number          | -      | 0      | -        |
 | swipeable     | 开启手势滑动                     | boolean         | -      | false  | -        |
+| autoLineWidth | 自动调整底部条宽度               | boolean         | -      | false  | -        |
 | lineWidth     | 底部条宽度，单位像素             | number          | -      | 19     | -        |
 | lineHeight    | 底部条高度，单位像素             | number          | -      | 3      | -        |
 | color         | 文字颜色                         | string          | -      | -      | -        |

--- a/src/pages/tabs/Index.vue
+++ b/src/pages/tabs/Index.vue
@@ -23,6 +23,16 @@
       </wd-tabs>
     </demo-block>
 
+    <demo-block title="自动调整底部条宽度" transparent>
+      <wd-tabs v-model="autoLineWidthTab" @change="handleChange" auto-line-width>
+        <block v-for="item in autoLineWidthTabs" :key="item">
+          <wd-tab :title="`${item}`" :name="item">
+            <view class="content">内容{{ autoLineWidthTab }}</view>
+          </wd-tab>
+        </block>
+      </wd-tabs>
+    </demo-block>
+
     <demo-block title="粘性布局" transparent>
       <wd-tabs v-model="tab2" sticky @change="handleChange">
         <block v-for="item in 4" :key="item">
@@ -99,6 +109,9 @@ import { useToast } from '@/uni_modules/wot-design-uni'
 import { ref } from 'vue'
 const tabs = ref(['这', '是', '一', '个', '例子'])
 const tab = ref('一')
+
+const autoLineWidthTabs = ref(['Wot', 'Design', 'Uni'])
+const autoLineWidthTab = ref('Design')
 
 const tab1 = ref<number>(0)
 const tab2 = ref<number>(0)

--- a/src/uni_modules/wot-design-uni/components/wd-tabs/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/types.ts
@@ -36,6 +36,10 @@ export const tabsProps = {
    */
   swipeable: makeBooleanProp(false),
   /**
+   * 自动调整底部条宽度，设置了 lineWidth 后无效
+   */
+  autoLineWidth: makeBooleanProp(false),
+  /**
    * 底部条宽度，单位像素
    */
   lineWidth: numericProp,

--- a/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
@@ -19,7 +19,7 @@
                     :class="`wd-tabs__nav-item  ${state.activeIndex === index ? 'is-active' : ''} ${item.disabled ? 'is-disabled' : ''}`"
                     :style="state.activeIndex === index ? (color ? 'color:' + color : '') : inactiveColor ? 'color:' + inactiveColor : ''"
                   >
-                    {{ item.title }}
+                    <text class="wd-tabs__nav-item-text">{{ item.title }}</text>
                   </view>
                   <!--下划线-->
                   <view class="wd-tabs__line" :style="state.lineStyle"></view>
@@ -90,7 +90,7 @@
                 :class="`wd-tabs__nav-item ${state.activeIndex === index ? 'is-active' : ''} ${item.disabled ? 'is-disabled' : ''}`"
                 :style="state.activeIndex === index ? (color ? 'color:' + color : '') : inactiveColor ? 'color:' + inactiveColor : ''"
               >
-                {{ item.title }}
+                <text class="wd-tabs__nav-item-text">{{ item.title }}</text>
               </view>
               <!--下划线-->
               <view class="wd-tabs__line" :style="state.lineStyle"></view>
@@ -152,6 +152,7 @@ import { useChildren } from '../composables/useChildren'
 import { useTranslate } from '../composables/useTranslate'
 
 const $item = '.wd-tabs__nav-item'
+const $itemText = '.wd-tabs__nav-item-text'
 const $container = '.wd-tabs__nav-container'
 
 const props = defineProps(tabsProps)
@@ -308,14 +309,21 @@ function toggleMap() {
  * @description 更新navBar underline的偏移量
  * @param {Boolean} animation 是否伴随动画
  */
-function updateLineStyle(animation: boolean = true) {
+async function updateLineStyle(animation: boolean = true) {
   if (!state.inited) return
-  const { lineWidth, lineHeight } = props
-  getRect($item, true, proxy).then((rects) => {
+  const { autoLineWidth, lineWidth, lineHeight } = props
+  try {
+    const rects = await getRect($item, true, proxy)
     const lineStyle: CSSProperties = {}
 
-    if (isDef(lineWidth)) {
+    if (isDef(lineWidth) && !autoLineWidth) {
       lineStyle.width = addUnit(lineWidth)
+    } else {
+      if (autoLineWidth) {
+        const textRects = await getRect($itemText, true, proxy)
+        const textWidth = Number(textRects[state.activeIndex].width)
+        lineStyle.width = addUnit(textWidth)
+      }
     }
     if (isDef(lineHeight)) {
       lineStyle.height = addUnit(lineHeight)
@@ -328,7 +336,9 @@ function updateLineStyle(animation: boolean = true) {
       lineStyle.transition = 'width 300ms ease, transform 300ms ease'
     }
     state.lineStyle = objToStyle(lineStyle)
-  })
+  } catch (error) {
+    console.error('[wot design] error(wd-tabs): update line style failed', error)
+  }
 }
 /**
  * @description 通过控制tab的active来展示选定的tab


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在`wd-tabs`组件中添加了`auto-line-width`属性，允许底部条宽度自动调整以适应文本内容。
	- 更新文档以包含新属性`autoLineWidth`的说明及示例。

- **改进**
	- 增强了`wd-tabs`组件的错误处理能力，改进了活动标签指示器的样式调整逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->