### PR TITLE
fix: 🐛 修复Notice在Tabbar页面时跳转至其他页面导致播放异常的问题并提供reset方法

### DIFF
--- a/docs/component/notice-bar.md
+++ b/docs/component/notice-bar.md
@@ -115,6 +115,40 @@ const onNext = (index: number) => {
 <wd-notice-bar prefix="warn-bold" direction="vertical" text="只有一条消息不会滚动" :speed="0.5" :delay="3" custom-class="space" />
 ```
 
+## 重置播放动画 <el-tag text style="vertical-align: middle;margin-left:8px;" effect="plain">1.3.13</el-tag>
+通过`ref`获取组件实例，调用`reset`方法即可重置播放动画。当你遇到`NoticeBar`的播放动画异常的情况时，可以调用`reset`方法重置动画。  
+
+例如：在`APP-VUE`端，`Tabbar`页面使用`NoticeBar`时，从其它界面返回到`NoticeBar`页面，会偶发`NoticeBar`动画异常，此时可以调用`reset`方法重置动画。
+
+参考issues：[#358](https://github.com/Moonofweisheng/wot-design-uni/issues/358)、[#650](https://github.com/Moonofweisheng/wot-design-uni/issues/650)
+
+```html
+<wd-notice-bar ref="notice" prefix="warn-bold" direction="vertical" :text="textArray" :delay="3" />
+<wd-button @click="handleReset">重置播放动画</wd-button>
+```
+
+```ts
+// uni_modules
+import { type NoticeBarInstance } from '@/uni_modules/wot-design-uni/components/wd-notice-bar/types'
+// npm
+// import { type NoticeBarInstance } from 'wot-design-uni/components/wd-notice-bar/types'
+
+const notice = ref<NoticeBarInstance>()
+
+const textArray = ref([
+  '欢迎使用wot design uni',
+  '该组件库基于uniapp ->Vue3, ts构建',
+  '项目地址：https://github.com/Moonofweisheng/wot-design-uni',
+  '我们的目标是打造最强uniapp组件库',
+  '诚挚邀请大家共同建设',
+  '这是一条消息提示信息，这是一条消息提示信息，这是一条消息提示信息，这是一条消息提示信息，这是一条消息提示信息'
+])
+
+function handleReset() {
+  notice.value?.reset()
+}
+```
+
 ## Attributes
 
 | 参数             | 说明                                   | 类型                       | 可选值                  | 默认值       | 最低版本 |
@@ -138,6 +172,12 @@ const onNext = (index: number) => {
 | close    | 关闭按钮点击时   | -                                                                              | -        |
 | next     | 下一次滚动前触发 | index: `number`                                                                | -        |
 | click    | 点击时触发       | `{ text: string, index: number }`，其中`text`为当前文本，`index`为当前文本索引 | 1.2.16   |
+
+## Methods
+
+| 方法名称 | 说明 | 参数 | 最低版本 |
+|---------|-----|-----|---------|
+| reset | 用于重置播放动画| - | $LOWEST_VERSION$ |
 
 ## Slot
 

--- a/src/pages/noticeBar/Index.vue
+++ b/src/pages/noticeBar/Index.vue
@@ -1,12 +1,3 @@
-<!--
- * @Author: weisheng
- * @Date: 2023-06-13 11:47:12
- * @LastEditTime: 2024-04-16 13:13:31
- * @LastEditors: weisheng
- * @Description:
- * @FilePath: \wot-design-uni\src\pages\noticeBar\Index.vue
- * 记得注释
--->
 <template>
   <page-wraper>
     <view>
@@ -73,11 +64,24 @@
         <wd-notice-bar @click="handleClick" prefix="warn-bold" direction="vertical" :text="textArray" :delay="3" custom-class="space" />
         <wd-notice-bar @click="handleClick" prefix="warn-bold" direction="vertical" text="只有一条消息不会滚动" :delay="3" custom-class="space" />
       </demo-block>
+
+      <demo-block title="重置播放动画">
+        <wd-notice-bar ref="notice" prefix="warn-bold" direction="vertical" :text="textArray" :delay="3" custom-class="space" />
+
+        <wd-button @click="handleReset">重置播放动画</wd-button>
+      </demo-block>
     </view>
   </page-wraper>
 </template>
 <script lang="ts" setup>
+import { type NoticeBarInstance } from '@/uni_modules/wot-design-uni/components/wd-notice-bar/types'
 import { ref } from 'vue'
+
+const notice = ref<NoticeBarInstance>()
+
+function handleReset() {
+  notice.value?.reset()
+}
 
 const textArray = ref([
   '欢迎使用wot design uni',

--- a/src/uni_modules/wot-design-uni/components/wd-notice-bar/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-notice-bar/index.scss
@@ -48,13 +48,6 @@
   @include e(content) {
     position: absolute;
     white-space: nowrap;
-
-    @include m(play) {
-      animation: notice-bar-play linear both;
-    }
-    @include m(play-infinite) {
-      animation: notice-bar-play-infinite linear infinite both;
-    }
   }
   @include m(ellipse) {
     .wd-notice-bar__content {
@@ -71,17 +64,5 @@
       position: static;
       white-space: normal;
     }
-  }
-}
-
-@keyframes notice-bar-play {
-  100% {
-    transform: translate3d(-100%, 0, 0);
-  }
-}
-
-@keyframes notice-bar-play-infinite {
-  100% {
-    transform: translate3d(-100%, 0, 0);
   }
 }

--- a/src/uni_modules/wot-design-uni/components/wd-notice-bar/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-notice-bar/types.ts
@@ -1,4 +1,4 @@
-import type { PropType } from 'vue'
+import type { ComponentPublicInstance, ExtractPropTypes, PropType } from 'vue'
 import { baseProps, makeBooleanProp, makeNumberProp, makeStringProp } from '../common/props'
 
 export type NoticeBarType = 'warning' | 'info' | 'danger' | ''
@@ -54,3 +54,14 @@ export const noticeBarProps = {
    */
   direction: makeStringProp<NoticeBarScrollDirection>('horizontal')
 }
+
+export type NoticeBarProps = ExtractPropTypes<typeof noticeBarProps>
+
+export type NoticeBarExpose = {
+  /**
+   * 重置NoticeBar动画
+   */
+  reset: () => void
+}
+
+export type NoticeBarInstance = ComponentPublicInstance<NoticeBarProps, NoticeBarExpose>


### PR DESCRIPTION
✅ Closes: #358 #650 

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
#358 #650 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
问题背景：
1. 当前使用transition实现Noticebar的播放动画，动画开始时会使用uni.createSelectorQuery查询节点信息。
2. 当前实现了功能：多行水平轮播。
3. `onActivated`生命周期仅在H5端支持（uni-app文档中标示App也支持，不过实测不支持）。

以上导致没有很好的办法解决此问题，故在`H5`端使用`onActivated`钩子重置动画，并对外提供了`reset`方法，用于重置动画。
<!--
1. 要解决的具体问题。
5. 列出最终的 API 实现和用法。
6. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充