### PR TITLE
fix: 🐛 修复Picker和SelectPicker清空按钮颜色与Input不统一的问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/common/abstracts/variable.scss
+++ b/src/uni_modules/wot-design-uni/components/common/abstracts/variable.scss
@@ -209,6 +209,7 @@ $-cell-value-fs: var(--wot-cell-value-fs, 14px) !default; // 右侧内容字号
 $-cell-value-color: var(--wot-cell-value-color, rgba(0, 0, 0, 0.85)) !default; // 右侧内容文字颜色
 $-cell-arrow-size: var(--wot-cell-arrow-size, 18px) !default; // 右箭头大小
 $-cell-arrow-color: var(--wot-cell-arrow-color, rgba(0, 0, 0, 0.25)) !default; // 右箭头颜色
+$-cell-clear-color: var(--wot-cell-clear-color, #585858) !default; // 清空按钮颜色
 $-cell-tap-bg: var(--wot-cell-tap-bg, rgba(0, 0, 0, 0.06)) !default; // 点击态背景色
 
 $-cell-title-fs-large: var(--wot-cell-title-fs-large, 16px) !default; // 大尺寸标题字号

--- a/src/uni_modules/wot-design-uni/components/wd-picker/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-picker/index.scss
@@ -86,8 +86,7 @@
   }
   @include when(error) {
     .wd-picker__value,
-    :deep(.wd-picker__arrow),
-    :deep(.wd-picker__clear) {
+    :deep(.wd-picker__arrow) {
       color: $-input-error-color;
     }
   }
@@ -178,6 +177,10 @@
     font-size: $-cell-icon-size;
     color: $-cell-arrow-color;
     line-height: $-cell-line-height;
+  }
+
+  @include edeep(clear){
+    color: $-cell-clear-color;
   }
 
   @include e(wraper) {

--- a/src/uni_modules/wot-design-uni/components/wd-picker/wd-picker.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-picker/wd-picker.vue
@@ -22,7 +22,9 @@
               {{ showValue ? showValue : placeholder || translate('placeholder') }}
             </view>
             <wd-icon v-if="showArrow" custom-class="wd-picker__arrow" name="arrow-right" />
-            <wd-icon v-else-if="showClear" custom-class="wd-picker__clear" name="error-fill" @click.stop="handleClear" />
+            <view v-else-if="showClear" @click.stop="handleClear">
+              <wd-icon custom-class="wd-picker__clear" name="error-fill" />
+            </view>
           </view>
           <view v-if="errorMessage" class="wd-picker__error-message">{{ errorMessage }}</view>
         </view>

--- a/src/uni_modules/wot-design-uni/components/wd-select-picker/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-select-picker/index.scss
@@ -72,8 +72,7 @@
       .wd-select-picker__value {
         color: $-input-error-color;
       }
-      :deep(.wd-select-picker__arrow),
-      :deep(.wd-select-picker__clear) {
+      :deep(.wd-select-picker__arrow) {
         color: $-input-error-color;
       }
     }
@@ -137,6 +136,10 @@
     font-size: $-cell-icon-size;
     color: $-cell-arrow-color;
     line-height: $-cell-line-height;
+  }
+
+  @include edeep(clear) {
+    color: $-cell-clear-color;
   }
  
   @include e(loading) {

--- a/src/uni_modules/wot-design-uni/components/wd-select-picker/wd-select-picker.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-select-picker/wd-select-picker.vue
@@ -26,7 +26,9 @@
               {{ showValue || placeholder || translate('placeholder') }}
             </view>
             <wd-icon v-if="showArrow" custom-class="wd-select-picker__arrow" name="arrow-right" />
-            <wd-icon v-else-if="showClear" custom-class="wd-select-picker__clear" name="error-fill" @click.stop="handleClear" />
+            <view v-else-if="showClear" @click.stop="handleClear">
+              <wd-icon custom-class="wd-select-picker__clear" name="error-fill" />
+            </view>
           </view>
 
           <view v-if="errorMessage" class="wd-select-picker__error-message">{{ errorMessage }}</view>


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
#579 #469 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
Picker和SelectPicker的清空按钮颜色同输入框的清空按钮，同时改为不受error状态影响。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 引入了新的颜色变量 `$-cell-clear-color`，用于清除按钮的样式。
	- 更新了 `wd-picker` 和 `wd-select-picker` 组件的样式，以支持深色主题和错误状态的视觉反馈。

- **样式**
	- 修改了 `wd-picker` 和 `wd-select-picker` 组件的样式规则，增强了在不同状态下的颜色管理。
	- 为清除按钮添加了新的样式规则，以改善视觉反馈。

- **文档**
	- 更新了组件模板结构，优化了清除图标的渲染方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->