### PR TITLE
fix: 🐛 修复Collapse折叠面板组件内容溢出问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-collapse-item/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-collapse-item/types.ts
@@ -31,6 +31,11 @@ export type CollapseItemExpose = {
    * @returns boolean
    */
   getExpanded: () => boolean
+  /**
+   * 更新展开状态
+   * @returns Promise<void>
+   */
+  updateExpand: () => Promise<void>
 }
 
 export type CollapseItemInstance = ComponentPublicInstance<CollapseItemProps, CollapseItemExpose>

--- a/src/uni_modules/wot-design-uni/components/wd-collapse-item/wd-collapse-item.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-collapse-item/wd-collapse-item.vue
@@ -74,20 +74,6 @@ const selected = computed(() => {
   }
 })
 
-watch(
-  () => selected.value,
-  () => {
-    if (!inited.value) {
-      return
-    }
-    updateExpend()
-  },
-  {
-    deep: true,
-    immediate: true
-  }
-)
-
 onMounted(() => {
   updateExpend()
 })
@@ -126,6 +112,7 @@ function handleTransitionEnd() {
 // 点击子项
 function handleClick() {
   if (props.disabled) return
+  updateExpend()
   let name = props.name
   const nexexpanded = !expanded.value // 执行后展开状态
   if (nexexpanded) {

--- a/src/uni_modules/wot-design-uni/components/wd-collapse-item/wd-collapse-item.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-collapse-item/wd-collapse-item.vue
@@ -75,10 +75,10 @@ const selected = computed(() => {
 })
 
 onMounted(() => {
-  updateExpend()
+  updateExpand()
 })
 
-function updateExpend() {
+function updateExpand() {
   return getRect(`#${collapseId.value}`, false, proxy).then((rect) => {
     const { height: rectHeight } = rect
     height.value = isDef(rectHeight) ? Number(rectHeight) : ''
@@ -112,7 +112,6 @@ function handleTransitionEnd() {
 // 点击子项
 function handleClick() {
   if (props.disabled) return
-  updateExpend()
   let name = props.name
   const nexexpanded = !expanded.value // 执行后展开状态
   if (nexexpanded) {
@@ -123,16 +122,16 @@ function handleClick() {
       }
       if (isPromise(response)) {
         response.then(() => {
-          collapse && collapse.toggle(name, !expanded.value)
+          handleChangeExpand(name)
         })
       } else {
-        collapse && collapse.toggle(name, !expanded.value)
+        handleChangeExpand(name)
       }
     } else {
-      collapse && collapse.toggle(name, !expanded.value)
+      handleChangeExpand(name)
     }
   } else {
-    collapse && collapse.toggle(name, !expanded.value)
+    handleChangeExpand(name)
   }
 }
 
@@ -140,7 +139,12 @@ function getExpanded() {
   return expanded.value
 }
 
-defineExpose<CollapseItemExpose>({ getExpanded })
+function handleChangeExpand(name: string) {
+  updateExpand()
+  collapse && collapse.toggle(name, !expanded.value)
+}
+
+defineExpose<CollapseItemExpose>({ getExpanded, updateExpand })
 </script>
 
 <style lang="scss" scoped>

--- a/src/uni_modules/wot-design-uni/components/wd-collapse/wd-collapse.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-collapse/wd-collapse.vue
@@ -126,6 +126,7 @@ const toggleAll = (options: boolean | CollapseToggleAllOptions = {}) => {
         names.push(item.name || index)
       }
     } else {
+      item.$.exposed!.updateExpand()
       if (isDef(expanded) ? expanded : !item.$.exposed!.getExpanded()) {
         names.push(item.name || index)
       }


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

https://github.com/Moonofweisheng/wot-design-uni/issues/503

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

问题：

1. 点击子项，会改变其他子项的`wd-collapse-item__wrapper`的高度，导致如果折叠面板内容是文字省略号到展开的状态就不会触发`transitionend`事件置空`wd-collapse-item__wrapper`的高度，从而造成了内容溢出的问题
2. 即使折叠面板里的内容变化触发了`transitionend`事件，也会有一个先溢出再展开的效果，而不是直接展开的效果
![3b4210ce29180dea7a22e4880c6f3b77](https://github.com/user-attachments/assets/baba8ba5-0058-4b55-bcbb-0d2197441c26)

解决办法：

1. 取消每一项`wd-collapse-item`对`selected`的监听，不会造成点击子项影响其他子项的`wd-collapse-item__wrapper`高度
2. 在点击子项的`handleClick`事件调用`updateExpend()`，只更新点击的那一个子项，不影响其他子项

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 增加了 `updateExpand` 方法，允许外部更新折叠项的展开状态。
	- 改进了 `toggleAll` 方法，确保在切换所有面板时正确更新子组件的展开状态。
- **变更**
	- 移除了对选中属性的观察，简化了展开状态的控制逻辑。
	- 重命名了 `updateExpend` 为 `updateExpand`，并更新了相关调用。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->