### PR TITLE
feat: ✨ tabs支持左对齐 

### DIFF
--- a/docs/component/tabs.md
+++ b/docs/component/tabs.md
@@ -127,16 +127,31 @@ const tab = ref('例子')
 </wd-tabs>
 ```
 
+## 左对齐超出即可滚动 <el-tag text style="vertical-align: middle;margin-left:8px;" effect="plain">1.3.15</el-tag>
+
+`slidable`设置为`always`时，所有的标签会向左侧收缩对齐，超出即可滑动。
+
+```html
+<wd-tabs v-model="tab" slidable="always">
+  <block v-for="item in 5" :key="item">
+    <wd-tab :title="`超大标签${item}`">
+      <view class="content">内容{{ item }}</view>
+    </wd-tab>
+  </block>
+</wd-tabs>
+```
+
+
 ---
 
-标签页在标签数大于等于 6 个时，可以滑动；当标签数大于等于 10 个时，将会显示导航地图，便于快速定位到某个标签。可以通过设置 `slidable-num` 修改可滑动的数量阈值；设置 `map-num` 修改显示导航地图的阈值。
+标签页在标签数大于等于 6 个时，可以滑动；当标签数大于等于 10 个时，将会显示导航地图，便于快速定位到某个标签。可以通过设置 `slidable-num` 修改可滑动的数量阈值；设置 `map-num` 修改显示导航地图的阈值。`slidable`设置为`always`时，所有的标签会向左侧收缩对齐，超出即可滑动。
 
 ## Tabs Attributes
 
 | 参数          | 说明                             | 类型            | 可选值 | 默认值 | 最低版本 |
 | ------------- | -------------------------------- | --------------- | ------ | ------ | -------- |
 | v-model       | 绑定值                           | string / number | -      | -      | -        |
-| slidable-num  | 可滑动的标签数阈值               | number          | -      | 6      | -        |
+| slidable-num  | 可滑动的标签数阈值，`slidable`设置为`auto`时生效 | number          | -      | 6      | -        |
 | map-num       | 显示导航地图的标签数阈值         | number          | -      | 10     | -        |
 | sticky        | 粘性布局                         | boolean         | -      | false  | -        |
 | offset-top    | 粘性布局时距离窗口顶部距离       | number          | -      | 0      | -        |
@@ -147,6 +162,7 @@ const tab = ref('例子')
 | inactiveColor | 非活动标签文字颜色               | string          | -      | -      | -        |
 | animated      | 是否开启切换标签内容时的转场动画 | boolean         | -      | false  | -        |
 | duration      | 切换动画过渡时间，单位毫秒       | number          | -      | 300    | -        |
+| slidable      | 是否开启滚动导航     | TabsSlidable   | `always`  | `auto`   | $LOWEST_VERSION$   |
 
 ## Tab Attributes
 

--- a/src/pages/tabs/Index.vue
+++ b/src/pages/tabs/Index.vue
@@ -74,10 +74,20 @@
     </demo-block>
 
     <demo-block title="数量大于6时可滚动" transparent>
-      <wd-tabs v-model="tab6" lazy-render @change="handleChange">
+      <wd-tabs v-model="tab6" @change="handleChange">
         <block v-for="item in 7" :key="item">
           <wd-tab :title="`标签${item}`">
             <view class="content">内容{{ tab6 + 1 }}</view>
+          </wd-tab>
+        </block>
+      </wd-tabs>
+    </demo-block>
+
+    <demo-block title="左对齐超出即可滚动" transparent>
+      <wd-tabs v-model="tab9" slidable="always" @change="handleChange">
+        <block v-for="item in 5" :key="item">
+          <wd-tab :title="`超大标签${item}`">
+            <view class="content">内容{{ tab9 + 1 }}</view>
           </wd-tab>
         </block>
       </wd-tabs>
@@ -108,6 +118,8 @@ const tab5 = ref<number>(0)
 const tab6 = ref<number>(0)
 const tab7 = ref<number>(0)
 const tab8 = ref<number>(0)
+const tab9 = ref<number>(0)
+
 const toast = useToast()
 function handleClick({ index, name }: any) {
   console.log('event', { index, name })

--- a/src/uni_modules/wot-design-uni/components/wd-tab/wd-tab.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-tab/wd-tab.vue
@@ -1,6 +1,6 @@
 <template>
   <view :class="`wd-tab ${customClass}`" :style="customStyle">
-    <view v-if="painted" class="wd-tab__body" :style="isShow ? '' : 'display: none;'">
+    <view v-if="painted" class="wd-tab__body" :style="tabBodyStyle">
       <slot />
     </view>
   </view>
@@ -16,8 +16,8 @@ export default {
 }
 </script>
 <script lang="ts" setup>
-import { getCurrentInstance, ref, watch } from 'vue'
-import { isDef, isNumber, isString } from '../common/util'
+import { getCurrentInstance, ref, watch, type CSSProperties } from 'vue'
+import { isDef, isNumber, isString, objToStyle } from '../common/util'
 import { useParent } from '../composables/useParent'
 import { TABS_KEY } from '../wd-tabs/types'
 import { computed } from 'vue'
@@ -33,6 +33,14 @@ const { parent: tabs, index } = useParent(TABS_KEY)
 // 激活项下标
 const activeIndex = computed(() => {
   return isDef(tabs) ? tabs.state.activeIndex : 0
+})
+
+const tabBodyStyle = computed(() => {
+  const style: CSSProperties = {}
+  if (!isShow.value && (!isDef(tabs) || !tabs.props.animated)) {
+    style.display = 'none'
+  }
+  return objToStyle(style)
 })
 
 watch(

--- a/src/uni_modules/wot-design-uni/components/wd-tabs/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/index.scss
@@ -91,6 +91,7 @@
   }
 
   @include e(nav-item) {
+    position: relative;
     flex: 1;
     min-width: 0;
     text-align: center;
@@ -119,6 +120,11 @@
     width: $-tabs-nav-line-width;
     background: $-tabs-nav-line-bg-color;
     border-radius: calc($-tabs-nav-line-height / 2);
+
+    @include m(inner){
+      left: 50%; 
+      transform: translateX(-50%)
+    }
   }
 
   @include e(container) {

--- a/src/uni_modules/wot-design-uni/components/wd-tabs/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/types.ts
@@ -1,11 +1,19 @@
-import { type ExtractPropTypes, type InjectionKey } from 'vue'
+import { type ComponentPublicInstance, type ExtractPropTypes, type InjectionKey } from 'vue'
 import { baseProps, makeBooleanProp, makeNumberProp, makeNumericProp, makeStringProp, numericProp } from '../common/props'
 
 export type TabsProvide = {
   state: {
     activeIndex: number
+    lineStyle: string // 激活项边框线样式
+    inited: boolean // 是否初始化
+    animating: boolean // 是否动画中
+    mapShow: boolean // map的开关
+    scrollLeft: number // scroll-view偏移量
   }
+  props: Partial<TabsProps>
 }
+
+export type TabsSlidable = 'auto' | 'always'
 
 export const TABS_KEY: InjectionKey<TabsProvide> = Symbol('wd-tabs')
 
@@ -58,7 +66,24 @@ export const tabsProps = {
   /**
    * 切换动画过渡时间，单位毫秒
    */
-  duration: makeNumberProp(300)
+  duration: makeNumberProp(300),
+  /**
+   * 是否开启滚动导航
+   * 可选值：'auto' | 'always'
+   * @default auto
+   */
+  slidable: makeStringProp<TabsSlidable>('auto')
+}
+
+export type TabsExpose = {
+  // 修改选中的tab Index
+  setActive: (value: number | string, init: boolean, setScroll: boolean) => void
+  // scroll-view滑动到active的tab_nav
+  scrollIntoView: () => void
+  // 更新底部条样式
+  updateLineStyle: (animation: boolean) => void
 }
 
 export type TabsProps = ExtractPropTypes<typeof tabsProps>
+
+export type TabsInstance = ComponentPublicInstance<TabsProps, TabsExpose>


### PR DESCRIPTION
✅ Closes: https://github.com/Moonofweisheng/wot-design-uni/issues/380
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
#380 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

支持tabs选项左对齐，同时在开启动画时默认不对隐藏tabs项添加`display:none`


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了 `wd-tabs` 组件文档，新增左对齐滚动标签功能。
	- 新增 `slidable` 属性，支持标签在超出可用空间时滚动。
	- 新增示例代码，展示如何使用左对齐滚动标签。

- **文档**
	- 修改了 `slidable-num` 属性的描述，以明确其在 `slidable` 设置为 `auto` 时的有效性。
	- 文档结构保持一致，涵盖了 `wd-tabs` 组件的各种功能和用法示例。

- **样式**
	- 更新了 `wd-tabs` 组件的样式，以增强暗黑主题和默认主题的视觉一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->