### PR TITLE
feat: ✨ Swiper 支持指定轮播项的文件类型

### DIFF
--- a/docs/component/swiper.md
+++ b/docs/component/swiper.md
@@ -346,7 +346,13 @@ const isLoop = ref(false)
 
 ### SwiperList
 
-轮播图项的列表配置，包括 图片或视频地址`value`、视频封面`poster` 等属性，支持扩展属性。
+轮播图项的列表配置，包括 图片或视频地址`value`、视频封面`poster` 、文件资源的类型`type`等属性，支持扩展属性。指定`type`后组件将不在内部判断文件类型，以`type`为准。
+| name      | 说明          | 最低版本 |
+| --------- | ------------ | -------- |
+| value | 图片或视频地址 |-   |
+| poster | 视频封面 |-   |
+| type | 用于指定文件资源的类型，可选值`image`、`video` | $LOWEST_VERSION$ |
+
 
 ### SwiperIndicatorProps
 

--- a/src/uni_modules/wot-design-uni/components/wd-swiper/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-swiper/types.ts
@@ -26,12 +26,17 @@ export type IndicatorPositionType = 'left' | 'top-left' | 'top' | 'top-right' | 
  */
 export type AdjustHeightType = 'first' | 'current' | 'highest' | 'none'
 
+// 资源类型
+export type SwiperItemType = 'image' | 'video'
+
 export interface SwiperList {
   [key: string]: any
   // 图片、视频等资源地址
   value?: string
   // 视频资源的封面
   poster?: string
+  // 资源文件类型，可选值：'image' | 'video'
+  type?: SwiperItemType
 }
 
 export const swiperProps = {


### PR DESCRIPTION
✅ Closes: #712

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
#712
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
轮播项增加type属性，可选值：`image`和`video`，`type`优先于组件内部对于文件类型的判断。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 更新了 `wd-swiper` 组件文档，新增 `type` 属性以指定资源类型为 `image` 或 `video`。
  - 引入 `autoplayVideo`、`stopPreviousVideo` 和 `stopAutoplayWhenVideoPlay` 属性，控制视频播放行为。
  - 增加了 `text-key` 和 `value-key` 属性，允许用户自定义图像 URL 和标题的键。

- **文档**
  - 扩展了文档内容，提供了新属性的详细描述和使用指南。
  - 更新了外部样式类，替换了过时的类名。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->