### PR TITLE
style: 💄 优化StatusTip缺省提示在英文场景下的表现

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-status-tip/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-status-tip/index.scss
@@ -32,6 +32,6 @@
     line-height: $-statustip-line-height;
     color: $-statustip-color;
     text-align: center;
-    word-break: break-all;
+    overflow-wrap: break-word;
   }
 }


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
将StatusTip提示文字的换行策略从`break-all`调整为`break-word`，以优化在英文场景下的样式表现。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式**
	- 修改了 `.wot-theme-dark` 类和 `b(status-tip)` 块的 CSS 样式，使文本在溢出容器时的处理方式更自然。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->