### PR TITLE
feat: ✨ Upload 添加 use-preview 属性支持关闭文件预览点击文件替换上传(#664)

### DIFF
--- a/docs/component/upload.md
+++ b/docs/component/upload.md
@@ -97,6 +97,19 @@ const action: string = 'https://mockapi.eolink.com/zhTuw2P8c29bc981a741931bdd86e
 ></wd-upload>
 ```
 
+## 关闭预览点击文件替换
+
+上传组件可通过设置 `use-preview` 来关闭文件预览并启用点击文件替换。
+
+```html
+<wd-upload
+  :file-list="fileList"
+  :use-preview="false"
+  action="https://mockapi.eolink.com/zhTuw2P8c29bc981a741931bdd86eb04dc1e8fd64865cb5/upload"
+  @change="handleChange"
+></wd-upload>
+```
+
 ## 拦截预览图片操作
 
 设置 `before-preview` 函数，在用户点击图片进行预览时，会执行 `before-preview` 函数，接收 { file: 预览文件, index: 当前预览的下标, imgList: 所有图片地址列表, resolve }，通过 `resolve` 函数告知组件是否确定通过，`resolve` 接受 1 个 boolean 值，`resolve(true)` 表示选项通过，`resolve(false)` 表示选项不通过，不通过时不会执行预览图片操作。
@@ -601,6 +614,7 @@ const action: string = 'https://mockapi.eolink.com/zhTuw2P8c29bc981a741931bdd86e
 | header                        | 设置上传的请求头部                                                                                                                                                             | object                                 | -                                              | -                          | -                |
 | multiple                      | 是否支持多选文件                                                                                                                                                               | boolean                                | -                                              | -                          | -                |
 | disabled                      | 是否禁用                                                                                                                                                                       | boolean                                | -                                              | false                      | -                |
+| use-preview                 | 是否点击已上传的图片或视频可预览，值为false的情况下再次弹出上传                                                                                                                                                     | boolean                                | -                                              | true                       | 1.3.15 |
 | limit                         | 最大允许上传个数                                                                                                                                                               | number                                 | -                                              | -                          | -                |
 | show-limit-num                | 限制上传个数的情况下，是否展示当前上传的个数                                                                                                                                   | boolean                                | -                                              | false                      | -                |
 | max-size                      | 文件大小限制，单位为`byte`                                                                                                                                                     | number                                 | -                                              | -                          | -                |

--- a/src/pages/upload/Index.vue
+++ b/src/pages/upload/Index.vue
@@ -11,6 +11,9 @@
     <demo-block title="最大上传数限制">
       <wd-upload :file-list="fileList3" :limit="3" :action="action" @change="handleChange3"></wd-upload>
     </demo-block>
+    <demo-block title="关闭预览点击文件替换">
+      <wd-upload accept="image" :use-preview="false" v-model:file-list="fileList17" image-mode="aspectFill" :action="action"></wd-upload>
+    </demo-block>
     <demo-block title="拦截预览图片操作">
       <wd-upload :file-list="fileList4" :action="action" @change="handleChange4" :before-preview="beforePreview"></wd-upload>
     </demo-block>
@@ -119,6 +122,11 @@ const fileList16 = ref<UploadFile[]>([
   {
     url: 'https://registry.npmmirror.com/wot-design-uni-assets/*/files/panda.jpg',
     name: 'panda'
+  }
+])
+const fileList17 = ref<UploadFile[]>([
+  {
+    url: 'https://registry.npmmirror.com/wot-design-uni-assets/*/files/panda.jpg'
   }
 ])
 

--- a/src/uni_modules/wot-design-uni/components/wd-upload/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-upload/types.ts
@@ -317,6 +317,11 @@ export const uploadProps = {
    */
   autoUpload: makeBooleanProp(true),
   /**
+   * 是否点击已上传的图片或视频可预览，值为false的情况下再次弹出上传
+   * 类型：boolean
+   */
+  usePreview: makeBooleanProp(true),
+  /**
    * 自定义上传文件的请求方法
    * 类型：UploadMethod
    * 默认值：-


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [x] 站点、文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

[<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->](https://github.com/Moonofweisheng/wot-design-uni/issues/664)

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 更新了上传组件文档，增加了“关闭预览点击文件替换”功能，允许用户通过设置 `use-preview` 属性为 `false` 来点击已上传文件进行替换。
	- 在上传组件的示例中添加了新的演示块，展示如何禁用预览功能。

- **文档**
	- 更新了上传组件的文档，增加了新属性 `use-preview` 的说明，并更新了属性表以反映其类型和默认值。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->