### PR TITLE
refactor: ♻️  Tabs 设置激活项方法setActive调整为立即执行

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
@@ -219,7 +219,7 @@ const updateActive = (value: number | string = 0, init: boolean = false, setScro
  * @param {String |Number } value - radio绑定的value或者tab索引，默认值0
  * @param {Boolean } init - 是否伴随初始化操作
  */
-const setActive = debounce(updateActive, 100, { leading: false })
+const setActive = debounce(updateActive, 100, { leading: true })
 
 watch(
   () => props.modelValue,
@@ -310,7 +310,6 @@ async function updateLineStyle(animation: boolean = true) {
   if (!state.inited) return
   const { autoLineWidth, lineWidth, lineHeight } = props
   try {
-    const rects = await getRect($item, true, proxy)
     const lineStyle: CSSProperties = {}
     if (isDef(lineWidth)) {
       lineStyle.width = addUnit(lineWidth)
@@ -325,12 +324,13 @@ async function updateLineStyle(animation: boolean = true) {
       lineStyle.height = addUnit(lineHeight)
       lineStyle.borderRadius = `calc(${addUnit(lineHeight)} / 2)`
     }
+    const rects = await getRect($item, true, proxy)
     const rect = rects[state.activeIndex]
     let left = rects.slice(0, state.activeIndex).reduce((prev, curr) => prev + Number(curr.width), 0) + Number(rect.width) / 2
     if (left) {
       lineStyle.transform = `translateX(${left}px) translateX(-50%)`
       if (animation) {
-        lineStyle.transition = 'width 300ms ease, transform 300ms ease'
+        lineStyle.transition = 'width 0.3s cubic-bezier(0.4, 0, 0.2, 1), transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);'
       }
       state.useInnerLine = false
       state.lineStyle = objToStyle(lineStyle)


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [x] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
防抖方法setActive调整为立即执行，同时调整切换时指示线切换动画
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 改进了选项卡组件的状态管理和用户交互反馈。
- **错误修复**
	- 增强了对 `modelValue` 属性的错误处理，提供更具体的错误消息。
- **样式改进**
	- 更新了线条动画的过渡样式，使其更加平滑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->