### PR TITLE
fix: 🐛 修复 Collapse v-model绑定数据变化时未更新折叠面板状态的问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-collapse-item/wd-collapse-item.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-collapse-item/wd-collapse-item.vue
@@ -31,7 +31,7 @@ export default {
 
 <script lang="ts" setup>
 import wdIcon from '../wd-icon/wd-icon.vue'
-import { computed, getCurrentInstance, onMounted, ref, type CSSProperties } from 'vue'
+import { computed, getCurrentInstance, onMounted, ref, watch, type CSSProperties } from 'vue'
 import { addUnit, getRect, isArray, isDef, isPromise, isString, objToStyle, requestAnimationFrame, uuid } from '../common/util'
 import { useParent } from '../composables/useParent'
 import { COLLAPSE_KEY } from '../wd-collapse/types'
@@ -79,6 +79,13 @@ const isSelected = computed(() => {
   const { name } = props
   return (isString(modelValue) && modelValue === name) || (isArray(modelValue) && modelValue.indexOf(name as string) >= 0)
 })
+
+watch(
+  () => isSelected.value,
+  (newVal) => {
+    updateExpand(newVal)
+  }
+)
 
 onMounted(() => {
   updateExpand(isSelected.value)

--- a/src/uni_modules/wot-design-uni/components/wd-collapse/wd-collapse.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-collapse/wd-collapse.vue
@@ -69,7 +69,7 @@ watch(
       console.error('value must be Array')
     }
   },
-  { deep: true, immediate: true }
+  { deep: true }
 )
 
 watch(
@@ -94,22 +94,10 @@ function updateChange(activeNames: string | string[] | boolean) {
   })
 }
 
-// 更新全部自组件展开状态
-const updateChildren = async () => {
-  for (const item of children) {
-    try {
-      await item.$.exposed!.updateExpand()
-    } catch (error) {
-      console.warn(`更新折叠面板状态失败: ${error}`)
-    }
-  }
-}
-
-async function toggle(name: string, expanded: boolean) {
+function toggle(name: string, expanded: boolean) {
   const { accordion, modelValue } = props
   if (accordion) {
     updateChange(name === modelValue ? '' : name)
-    await updateChildren()
   } else if (expanded) {
     updateChange((modelValue as string[]).concat(name))
   } else {
@@ -121,7 +109,7 @@ async function toggle(name: string, expanded: boolean) {
  * 切换所有面板展开状态，传 true 为全部展开，false 为全部收起，不传参为全部切换
  * @param options 面板状态
  */
-const toggleAll = async (options: CollapseToggleAllOptions = {}) => {
+const toggleAll = (options: CollapseToggleAllOptions = {}) => {
   if (props.accordion) {
     return
   }
@@ -141,7 +129,6 @@ const toggleAll = async (options: CollapseToggleAllOptions = {}) => {
     }
   })
   updateChange(names)
-  await updateChildren()
 }
 
 /**


### PR DESCRIPTION
✅ Closes: #741

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
#741
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
将更新`CollapseItem`状态的逻辑转到`CollapseItem`组件中，父组件只关注更新选中项。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 增强了折叠项的响应性，支持根据父组件的选择状态自动更新展开状态。
	- 更新了折叠组件的切换功能，简化了控制逻辑，移除了异步行为。

- **bug 修复**
	- 修复了折叠组件在状态切换时的控制流问题，确保更顺畅的用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->