### PR TITLE
fix: 🐛 修复NumberKeyboard的title插槽无效问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-number-keyboard/wd-number-keyboard.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-number-keyboard/wd-number-keyboard.vue
@@ -10,10 +10,9 @@
     @click-modal="handleClose"
   >
     <view :class="`wd-number-keyboard ${customClass}`" :style="customStyle">
-      <view class="wd-number-keyboard__header" v-if="showTitle">
-        <slot name="title">
-          <text class="wd-number-keyboard__title">{{ title }}</text>
-        </slot>
+      <view class="wd-number-keyboard__header">
+        <text class="wd-number-keyboard__title" v-if="showTitle">{{ title }}</text>
+        <slot name="title" v-else></slot>
         <view class="wd-number-keyboard__close" hover-class="wd-number-keyboard__close--hover" v-if="showClose" @click="handleClose">
           <text>{{ closeText }}</text>
         </view>


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 更新了数字键盘组件的标题显示逻辑，优化了条件渲染。
- **修复**
	- 保持了关闭按钮的可见性逻辑不变，确保用户体验一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->