### PR TITLE
fix: 🐛 修复NumberKeyboard的title插槽无效问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-number-keyboard/wd-number-keyboard.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-number-keyboard/wd-number-keyboard.vue
@@ -10,10 +10,9 @@
     @click-modal="handleClose"
   >
     <view :class="`wd-number-keyboard ${customClass}`" :style="customStyle">
-      <view class="wd-number-keyboard__header" v-if="showTitle">
-        <slot name="title">
-          <text class="wd-number-keyboard__title">{{ title }}</text>
-        </slot>
+      <view class="wd-number-keyboard__header">
+        <text class="wd-number-keyboard__title" v-if="showTitle">{{ title }}</text>
+        <slot name="title" v-else></slot>
         <view class="wd-number-keyboard__close" hover-class="wd-number-keyboard__close--hover" v-if="showClose" @click="handleClose">
           <text>{{ closeText }}</text>
         </view>


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
目前使用 NumberKeyboard 过程中需要自定义title内容，但是发现组件源码需要设置 title 值 或者 showClose=true 才能使得 title 的插槽生效，修改后支持用户自定义title样式，拓展性更强

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 改进了数字键盘组件的标题条件渲染，允许根据`showTitle`属性显示或隐藏标题。
- **修复**
	- 维持了关闭按钮的可见性逻辑，确保用户体验一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->