### PR TITLE
fix: 🐛 修复直接使用title插槽不设置closeText时不显示title插槽内容，新增radius属性，header插槽

### DIFF
--- a/docs/component/number-keyboard.md
+++ b/docs/component/number-keyboard.md
@@ -243,6 +243,7 @@ const onDelete = () => showToast('删除')
 | name  | 说明 | 类型 | 最低版本 |
 | ----- | ---- | ---- | -------- |
 | title | 标题 | -    | 1.2.12   |
+| header | 顶部 | -    |         |
 
 ## Events
 

--- a/src/uni_modules/wot-design-uni/components/wd-number-keyboard/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-number-keyboard/types.ts
@@ -1,5 +1,5 @@
 import type { PropType } from 'vue'
-import { baseProps, makeBooleanProp, makeNumberProp, makeStringProp } from '../common/props'
+import { baseProps, makeBooleanProp, makeNumberProp, makeStringProp, numericProp } from '../common/props'
 
 export type KeyboardMode = 'default' | 'custom'
 export type KeyType = '' | 'delete' | 'extra' | 'close'
@@ -75,5 +75,9 @@ export const numberKeyboardProps = {
   /**
    * 额外按键
    */
-  extraKey: [String, Array] as PropType<string | Array<string>>
+  extraKey: [String, Array] as PropType<string | Array<string>>,
+  /**
+   * 背景圆角大小，默认单位为px
+   */
+  radius: numericProp
 }

--- a/src/uni_modules/wot-design-uni/components/wd-number-keyboard/wd-number-keyboard.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-number-keyboard/wd-number-keyboard.vue
@@ -5,14 +5,17 @@
     :z-index="zIndex"
     :safe-area-inset-bottom="safeAreaInsetBottom"
     :modal-style="modal ? '' : 'opacity: 0;'"
+    :custom-style="rootStyle"
     :modal="hideOnClickOutside"
     :lockScroll="lockScroll"
     @click-modal="handleClose"
   >
     <view :class="`wd-number-keyboard ${customClass}`" :style="customStyle">
-      <view class="wd-number-keyboard__header">
-        <text class="wd-number-keyboard__title" v-if="showTitle">{{ title }}</text>
-        <slot name="title" v-else></slot>
+      <slot name="header"></slot>
+      <view class="wd-number-keyboard__header" v-if="showTitle">
+        <slot name="title">
+          <text class="wd-number-keyboard__title">{{ title }}</text>
+        </slot>
         <view class="wd-number-keyboard__close" hover-class="wd-number-keyboard__close--hover" v-if="showClose" @click="handleClose">
           <text>{{ closeText }}</text>
         </view>
@@ -42,10 +45,11 @@ export default {
 
 <script lang="ts" setup>
 import wdPopup from '../wd-popup/wd-popup.vue'
-import { computed, ref, watch } from 'vue'
+import { computed, ref, watch, useSlots } from 'vue'
 import WdKey from './key/index.vue'
 import { numberKeyboardProps, type Key } from './types'
 import type { NumberKeyType } from './key/types'
+import { objToStyle, isDef, addUnit } from '../common/util'
 
 const props = defineProps(numberKeyboardProps)
 const emit = defineEmits(['update:visible', 'input', 'close', 'delete', 'update:modelValue'])
@@ -64,8 +68,18 @@ const showClose = computed(() => {
   return props.closeText && props.mode === 'default'
 })
 
+const slots = useSlots()
 const showTitle = computed(() => {
-  return !!props.title
+  return !!props.title || showClose.value || slots.title
+})
+
+const rootStyle = computed(() => {
+  const style: Record<string, string | number> = {}
+  if (isDef(props.radius)) {
+    style['border-radius'] = `${addUnit(props.radius)} ${addUnit(props.radius)} 0 0`
+    style['overflow'] = 'hidden'
+  }
+  return `${objToStyle(style)};`
 })
 
 /**

--- a/src/uni_modules/wot-design-uni/components/wd-number-keyboard/wd-number-keyboard.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-number-keyboard/wd-number-keyboard.vue
@@ -65,7 +65,7 @@ const showClose = computed(() => {
 })
 
 const showTitle = computed(() => {
-  return props.title || showClose.value
+  return !!props.title
 })
 
 /**

--- a/src/uni_modules/wot-design-uni/components/wd-number-keyboard/wd-number-keyboard.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-number-keyboard/wd-number-keyboard.vue
@@ -10,10 +10,9 @@
     @click-modal="handleClose"
   >
     <view :class="`wd-number-keyboard ${customClass}`" :style="customStyle">
-      <view class="wd-number-keyboard__header" v-if="showTitle">
-        <slot name="title">
-          <text class="wd-number-keyboard__title">{{ title }}</text>
-        </slot>
+      <view class="wd-number-keyboard__header">
+        <text class="wd-number-keyboard__title" v-if="showTitle">{{ title }}</text>
+        <slot name="title" v-else></slot>
         <view class="wd-number-keyboard__close" hover-class="wd-number-keyboard__close--hover" v-if="showClose" @click="handleClose">
           <text>{{ closeText }}</text>
         </view>


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [x] 新特性提交
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
在开发过程中，只设置title插槽的情况下，插槽不生效，由于判断条件只判断title值和closeText值导致该BUG，增加slots.title的判断解决该问题；某种情况下弹出框需要设置radius因此加入radius属性，解决某些产品UI弹出框的一致性；在使用组件过程中发现title插槽不满足需求，高度有限制，在实际使用过程中需要在NumberKeyboard顶部设置一些其他元素，例如输入框、用户基础信息等，因此加入header插槽，增加组件的拓展性。
### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 支持自定义键盘顶部的 `header` 插槽。
	- 引入 `random-key-order` 属性以增强安全性。
	- 更新 `extra-key` 属性，支持多个额外键的数组形式。
	- 新增 `radius` 属性以自定义背景圆角。

- **文档**
	- 更新了 `wd-number-keyboard` 组件的文档，增加了新特性和使用示例。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->