### PR TITLE
feat: ✨ MessageBox 新增确认、取消按钮的 ButtonProps 属性

### DIFF
--- a/docs/component/message-box.md
+++ b/docs/component/message-box.md
@@ -86,7 +86,6 @@ function confirm() {
       console.log('点击了取消按钮')
     })
 }
-
 ```
 
 ## Prompt 弹框
@@ -116,7 +115,6 @@ function prompt() {
       console.log(error)
     })
 }
-
 ```
 
 ## 插槽
@@ -125,10 +123,10 @@ function prompt() {
 
 ```html
 <wd-message-box selector="wd-message-box-slot">
-  <wd-rate custom-class="custom-rate-class" v-model="rate"/>
+  <wd-rate custom-class="custom-rate-class" v-model="rate" />
 </wd-message-box>
 
- <wd-button @click="withSlot">custom</wd-button>
+<wd-button @click="withSlot">custom</wd-button>
 ```
 
 ```typescript
@@ -148,7 +146,6 @@ function withSlot() {
       console.log(error)
     })
 }
-
 ```
 
 ```scss
@@ -167,6 +164,7 @@ function withSlot() {
 <wd-message-box />
 <wd-button @click="beforeConfirm">beforeConfirm</wd-button>
 ```
+
 ```typescript
 import { useMessage, useToast } from '@/uni_modules/wot-design-uni'
 const message = useMessage()
@@ -191,7 +189,47 @@ function beforeConfirm() {
       console.log(error)
     })
 }
+```
 
+## 自定义操作按钮<el-tag text style="vertical-align: middle;margin-left:8px;" effect="plain">$LOWEST_VERSION$</el-tag>
+
+可以通过按钮属性 `cancel-button-props` 和 `confirm-button-props` 自定义操作按钮的样式，具体参考 [Button Attributes](/component/button.html#attributes)。
+
+```html
+<wd-message-box></wd-message-box>
+<wd-button @click="withButtonProps">自定义按钮</wd-button>
+```
+
+```typescript
+function withButtonProps() {
+  message
+    .confirm({
+      msg: '自定义按钮样式',
+      title: '提示',
+      cancelButtonProps: {
+        type: 'error',
+        customClass: 'custom-shadow'
+      },
+      confirmButtonProps: {
+        type: 'success',
+        customClass: 'custom-shadow'
+      }
+    })
+    .then(() => {})
+    .catch((error) => {
+      console.log(error)
+    })
+}
+```
+
+```css
+:deep() {
+  .wd-message-box {
+    .custom-shadow {
+      box-shadow: 0 3px 1px -2px rgb(0 0 0 / 20%), 0 2px 2px 0 rgb(0 0 0 / 14%), 0 1px 5px 0 rgb(0 0 0 / 12%);
+    }
+  }
+}
 ```
 
 ---
@@ -212,26 +250,27 @@ MessageBox.confirm(options)
 MessageBox.prompt(options)
 ```
 
-
 ## Options Attributes
 
-| 参数              | 说明                                                          | 类型            | 可选值                   | 默认值           | 最低版本 |
-| ----------------- | ------------------------------------------------------------- | --------------- | ------------------------ | ---------------- | -------- |
-| title             | 标题                                                          | string          | -                        | -                | -        |
-| msg               | 消息文案                                                      | string          | -                        | -                | -        |
-| type              | 弹框类型                                                      | string          | alert / confirm / prompt | alert            | -        |
-| closeOnClickModal | 是否支持点击蒙层进行关闭，点击蒙层回调传入的 action 为'modal' | boolean         | -                        | true             | -        |
-| inputType         | 当 type 为 prompt 时，输入框类型                              | string          | -                        | text             | -        |
-| inputValue        | 当 type 为 prompt 时，输入框初始值                            | string / number | -                        | -                | -        |
-| inputPlaceholder  | 当 type 为 prompt 时，输入框 placeholder                      | string          | -                        | 请输入内容       | -        |
-| inputPattern      | 当 type 为 prompt 时，输入框正则校验，点击确定按钮时进行校验  | regex           | -                        | -                | -        |
-| inputValidate     | 当 type 为 prompt 时，输入框校验函数，点击确定按钮时进行校验  | function        | -                        | -                | -        |
-| inputError        | 当 type 为 prompt 时，输入框检验不通过时的错误提示文案        | string          | -                        | 输入的数据不合法 | -        |
-| confirmButtonText | 确定按钮文案                                                  | string          | -                        | 确定             | -        |
-| cancelButtonText  | 取消按钮文案                                                  | string          | -                        | 取消             | -        |
-| selector          | 指定唯一标识                                                 | string          | -                        | #wd-message-box  | -        |
-| zIndex            | 弹窗层级                                                      | number          | -                        | 99               | -    |
-| lazyRender        | 弹层内容懒渲染，触发展示时才渲染内容                          | boolean         | -                        | true             | -    |
+| 参数                 | 说明                                                                            | 类型            | 可选值                   | 默认值           | 最低版本         |
+| -------------------- | ------------------------------------------------------------------------------- | --------------- | ------------------------ | ---------------- | ---------------- |
+| title                | 标题                                                                            | string          | -                        | -                | -                |
+| msg                  | 消息文案                                                                        | string          | -                        | -                | -                |
+| type                 | 弹框类型                                                                        | string          | alert / confirm / prompt | alert            | -                |
+| closeOnClickModal    | 是否支持点击蒙层进行关闭，点击蒙层回调传入的 action 为'modal'                   | boolean         | -                        | true             | -                |
+| inputType            | 当 type 为 prompt 时，输入框类型                                                | string          | -                        | text             | -                |
+| inputValue           | 当 type 为 prompt 时，输入框初始值                                              | string / number | -                        | -                | -                |
+| inputPlaceholder     | 当 type 为 prompt 时，输入框 placeholder                                        | string          | -                        | 请输入内容       | -                |
+| inputPattern         | 当 type 为 prompt 时，输入框正则校验，点击确定按钮时进行校验                    | regex           | -                        | -                | -                |
+| inputValidate        | 当 type 为 prompt 时，输入框校验函数，点击确定按钮时进行校验                    | function        | -                        | -                | -                |
+| inputError           | 当 type 为 prompt 时，输入框检验不通过时的错误提示文案                          | string          | -                        | 输入的数据不合法 | -                |
+| confirmButtonText    | 确定按钮文案                                                                    | string          | -                        | 确定             | -                |
+| cancelButtonText     | 取消按钮文案                                                                    | string          | -                        | 取消             | -                |
+| selector             | 指定唯一标识                                                                    | string          | -                        | #wd-message-box  | -                |
+| zIndex               | 弹窗层级                                                                        | number          | -                        | 99               | -                |
+| lazyRender           | 弹层内容懒渲染，触发展示时才渲染内容                                            | boolean         | -                        | true             | -                |
+| cancel-button-props  | 取消按钮的属性，具体参考 [Button Attributes](/component/button.html#attributes) | object          | -                        | -                | $LOWEST_VERSION$ |
+| confirm-button-props | 确定按钮的属性，具体参考 [Button Attributes](/component/button.html#attributes) | object          | -                        | -                | $LOWEST_VERSION$ |
 
 ## 外部样式类
 

--- a/src/pages/messageBox/Index.vue
+++ b/src/pages/messageBox/Index.vue
@@ -31,6 +31,10 @@
     <demo-block title="使用beforeConfirm钩子，在弹框确认前，可以进行一些操作">
       <wd-button @click="beforeConfirm">beforeConfirm</wd-button>
     </demo-block>
+
+    <demo-block title="通过button-props自定义按钮">
+      <wd-button @click="withButtonProps">withButtonProps</wd-button>
+    </demo-block>
   </page-wraper>
 </template>
 <script lang="ts" setup>
@@ -103,6 +107,26 @@ function beforeConfirm() {
     })
 }
 
+function withButtonProps() {
+  message
+    .confirm({
+      msg: '自定义按钮样式',
+      title: '提示',
+      cancelButtonProps: {
+        type: 'error',
+        customClass: 'custom-shadow'
+      },
+      confirmButtonProps: {
+        type: 'success',
+        customClass: 'custom-shadow'
+      }
+    })
+    .then(() => {})
+    .catch((error) => {
+      console.log(error)
+    })
+}
+
 function withSlot() {
   message1
     .confirm({
@@ -120,5 +144,10 @@ function withSlot() {
 :deep(.custom-rate-class) {
   display: block;
   height: 22px;
+}
+:deep() {
+  .custom-shadow {
+    box-shadow: 0 3px 1px -2px rgb(0 0 0 / 20%), 0 2px 2px 0 rgb(0 0 0 / 14%), 0 1px 5px 0 rgb(0 0 0 / 12%);
+  }
 }
 </style>

--- a/src/uni_modules/wot-design-uni/components/wd-input/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-input/types.ts
@@ -1,3 +1,4 @@
+import type { PropType } from 'vue'
 import { baseProps, makeArrayProp, makeBooleanProp, makeNumberProp, makeNumericProp, makeStringProp } from '../common/props'
 import type { FormItemRule } from '../wd-form/types'
 
@@ -6,6 +7,8 @@ export type InputClearTrigger = 'focus' | 'always'
 export type InputType = 'text' | 'number' | 'digit' | 'idcard'
 
 export type InputConfirmType = 'send' | 'search' | 'next' | 'go' | 'done'
+
+export type InputSize = 'large'
 
 export const inputProps = {
   ...baseProps,
@@ -137,7 +140,7 @@ export const inputProps = {
   /**
    * 设置输入框大小，可选值：large
    */
-  size: String,
+  size: String as PropType<InputSize>,
   /**
    * 设置输入框错误状态，错误状态时为红色
    */

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/index.scss
@@ -87,6 +87,12 @@
   @include e(actions) {
     padding: 24px;
   }
+  
+  @include edeep(actions-btn) {
+    &:not(:last-child) {
+      margin-right: 16px;
+    }
+  }
 
   @include e(flex) {
     display: flex;
@@ -99,23 +105,4 @@
   @include e(cancel) {
     margin-right: 16px;
   }
-}
-
-.zoomIn-enter-active,
-.zoomIn-leave-active {
-  opacity: 1;
-  transform: translate3d(-50%, -50%, 0) scale(1);
-  transition: all .2s;
-}
-
-.zoomIn-enter {
-  opacity: 0;
-  transform: translate3d(-50%, -50%, 0) scale(0.7);
-  transition: all .2s ease-out;
-}
-
-.zoomIn-leave-to {
-  opacity: 0;
-  transform: translate3d(-50%, -50%, 0) scale(0.9);
-  transition: all .2s ease-out;
 }

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/index.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/index.ts
@@ -1,14 +1,14 @@
 /*
  * @Author: weisheng
  * @Date: 2022-12-14 17:33:21
- * @LastEditTime: 2024-11-05 23:15:31
+ * @LastEditTime: 2024-12-05 13:23:17
  * @LastEditors: weisheng
  * @Description:
  * @FilePath: \wot-design-uni\src\uni_modules\wot-design-uni\components\wd-message-box\index.ts
  * 记得注释
  */
 import { inject, provide, ref } from 'vue'
-import type { Message, MessageOptions, MessageResult, MessageType } from './types'
+import type { Message, MessageOptions, MessageOptionsWithCallBack, MessageResult, MessageType } from './types'
 import { deepMerge } from '../common/util'
 
 const messageDefaultOptionKey = '__MESSAGE_OPTION__'
@@ -16,7 +16,7 @@ const messageDefaultOptionKey = '__MESSAGE_OPTION__'
 const None = Symbol('None')
 
 // 默认模板
-export const defaultOptions: MessageOptions = {
+export const defaultOptions: MessageOptionsWithCallBack = {
   title: '',
   showCancelButton: false,
   show: false,
@@ -25,7 +25,6 @@ export const defaultOptions: MessageOptions = {
   type: 'alert',
   inputType: 'text',
   inputValue: '',
-  inputValidate: null,
   showErr: false,
   zIndex: 99,
   lazyRender: true,
@@ -34,7 +33,7 @@ export const defaultOptions: MessageOptions = {
 
 export function useMessage(selector: string = ''): Message {
   const messageOptionKey = selector ? messageDefaultOptionKey + selector : messageDefaultOptionKey
-  const messageOption = inject(messageOptionKey, ref<MessageOptions | typeof None>(None)) // Message选项
+  const messageOption = inject(messageOptionKey, ref<MessageOptionsWithCallBack | typeof None>(None)) // Message选项
   if (messageOption.value === None) {
     messageOption.value = defaultOptions
     provide(messageOptionKey, messageOption)
@@ -56,16 +55,16 @@ export function useMessage(selector: string = ''): Message {
   const show = (option: MessageOptions | string) => {
     // 返回一个promise
     return new Promise<MessageResult>((resolve, reject) => {
-      const options = deepMerge(defaultOptions, typeof option === 'string' ? { title: option } : option) as MessageOptions
+      const options = deepMerge(defaultOptions, typeof option === 'string' ? { title: option } : option)
       messageOption.value = deepMerge(options, {
         show: true,
-        onConfirm: (res: MessageResult) => {
+        success: (res: MessageResult) => {
           resolve(res)
         },
-        onCancel: (res: MessageResult) => {
+        fail: (res: MessageResult) => {
           reject(res)
         }
-      }) as MessageOptions
+      })
     })
   }
 

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/types.ts
@@ -1,14 +1,15 @@
 /*
  * @Author: weisheng
  * @Date: 2024-04-08 22:34:01
- * @LastEditTime: 2024-11-05 23:17:06
+ * @LastEditTime: 2024-12-05 13:26:50
  * @LastEditors: weisheng
  * @Description:
  * @FilePath: \wot-design-uni\src\uni_modules\wot-design-uni\components\wd-message-box\types.ts
  * 记得注释
  */
 import { baseProps, makeStringProp } from '../common/props'
-import { type InputType } from '../wd-input/types'
+import type { ButtonProps } from '../wd-button/types'
+import { type InputSize, type InputType } from '../wd-input/types'
 
 export type MessageType = 'alert' | 'confirm' | 'prompt'
 
@@ -25,8 +26,6 @@ export type MessageOptions = {
    * 是否展示取消按钮
    */
   showCancelButton?: boolean
-
-  show?: boolean
   /**
    * 是否支持点击蒙层进行关闭，点击蒙层回调传入的action为'modal'
    */
@@ -52,6 +51,10 @@ export type MessageOptions = {
    */
   inputType?: InputType
   /**
+   * 设置输入框大小，可选值：large
+   */
+  inputSize?: InputSize
+  /**
    * 当type为prompt时，输入框初始值
    */
   inputValue?: string | number
@@ -66,7 +69,7 @@ export type MessageOptions = {
   /**
    * 当type为prompt时，输入框校验函数，点击确定按钮时进行校验
    */
-  inputValidate?: InputValidate | null
+  inputValidate?: InputValidate
   /**
    * 当type为prompt时，输入框检验不通过时的错误提示文案
    */
@@ -87,6 +90,20 @@ export type MessageOptions = {
    * 确认前钩子
    */
   beforeConfirm?: (options: MessageBeforeConfirmOption) => void
+  /**
+   * 取消按钮Props
+   */
+  cancelButtonProps?: Partial<ButtonProps>
+  /**
+   * 确认按钮Props
+   */
+  confirmButtonProps?: Partial<ButtonProps>
+}
+
+export type MessageOptionsWithCallBack = MessageOptions & {
+  show?: boolean
+  success?: (res: MessageResult) => void
+  fail?: (res: MessageResult) => void
 }
 
 export type ActionType = 'confirm' | 'cancel' | 'modal'

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
@@ -2,35 +2,41 @@
   <view>
     <wd-popup
       transition="zoom-in"
-      v-model="show"
-      :close-on-click-modal="closeOnClickModal"
-      :lazy-render="lazyRender"
+      v-model="messageState.show"
+      :close-on-click-modal="messageState.closeOnClickModal"
+      :lazy-render="messageState.lazyRender"
       custom-class="wd-message-box"
       @click-modal="toggleModal('modal')"
-      :z-index="zIndex"
+      :z-index="messageState.zIndex"
       :duration="200"
     >
       <view :class="rootClass">
         <view :class="bodyClass">
-          <view v-if="title" class="wd-message-box__title">
-            {{ title }}
+          <view v-if="messageState.title" class="wd-message-box__title">
+            {{ messageState.title }}
           </view>
           <view class="wd-message-box__content">
-            <block v-if="type === 'prompt'">
-              <wd-input v-model="inputValue" :type="inputType" size="large" :placeholder="inputPlaceholder || '请输入'" @input="inputValChange" />
-              <view v-if="showErr" class="wd-message-box__input-error">
-                {{ inputError || translate('inputNoValidate') }}
+            <block v-if="messageState.type === 'prompt'">
+              <wd-input
+                v-model="messageState.inputValue"
+                :type="messageState.inputType"
+                :size="messageState.inputSize"
+                :placeholder="messageState.inputPlaceholder"
+                @input="inputValChange"
+              />
+              <view v-if="messageState.showErr" class="wd-message-box__input-error">
+                {{ messageState.inputError || translate('inputNoValidate') }}
               </view>
             </block>
-            <slot>{{ msg }}</slot>
+            <slot>{{ messageState.msg }}</slot>
           </view>
         </view>
-        <view :class="`wd-message-box__actions ${showCancelButton ? 'wd-message-box__flex' : 'wd-message-box__block'}`">
-          <wd-button type="info" block v-if="showCancelButton" custom-style="margin-right: 16px;" @click="toggleModal('cancel')">
-            {{ cancelButtonText || translate('cancel') }}
+        <view :class="`wd-message-box__actions ${messageState.showCancelButton ? 'wd-message-box__flex' : 'wd-message-box__block'}`">
+          <wd-button v-bind="customCancelProps" v-if="messageState.showCancelButton" @click="toggleModal('cancel')">
+            {{ messageState.cancelButtonText || translate('cancel') }}
           </wd-button>
-          <wd-button block @click="toggleModal('confirm')">
-            {{ confirmButtonText || translate('confirm') }}
+          <wd-button v-bind="customConfirmProps" @click="toggleModal('confirm')">
+            {{ messageState.confirmButtonText || translate('confirm') }}
           </wd-button>
         </view>
       </view>
@@ -52,19 +58,12 @@ export default {
 import wdPopup from '../wd-popup/wd-popup.vue'
 import wdButton from '../wd-button/wd-button.vue'
 import wdInput from '../wd-input/wd-input.vue'
-import { computed, inject, ref, watch } from 'vue'
-import {
-  messageBoxProps,
-  type InputValidate,
-  type MessageBeforeConfirmOption,
-  type MessageOptions,
-  type MessageResult,
-  type MessageType
-} from './types'
+import { computed, inject, reactive, ref, watch } from 'vue'
+import { messageBoxProps, type MessageOptionsWithCallBack, type MessageResult } from './types'
 import { defaultOptions, getMessageDefaultOptionKey } from '.'
-import { isDef, isFunction } from '../common/util'
+import { deepAssign, isDef, isFunction, isUndefined, omitBy } from '../common/util'
 import { useTranslate } from '../composables/useTranslate'
-import { type InputType } from '../wd-input/types'
+import type { ButtonProps } from '../wd-button/types'
 
 const props = defineProps(messageBoxProps)
 
@@ -75,89 +74,63 @@ const rootClass = computed(() => {
 })
 
 const bodyClass = computed(() => {
-  return `wd-message-box__body ${!title.value ? 'is-no-title' : ''} ${type.value === 'prompt' ? 'is-prompt' : ''}`
+  return `wd-message-box__body ${!messageState.title ? 'is-no-title' : ''} ${messageState.type === 'prompt' ? 'is-prompt' : ''}`
 })
 
 const messageOptionKey = getMessageDefaultOptionKey(props.selector)
-const messageOption = inject(messageOptionKey, ref<MessageOptions>(defaultOptions)) // message选项
+const messageOption = inject(messageOptionKey, ref<MessageOptionsWithCallBack>(defaultOptions)) // message选项
+
+const messageState = reactive<MessageOptionsWithCallBack>({
+  msg: '', // 消息内容
+  show: false, // 是否显示弹框
+  title: '', // 标题
+  showCancelButton: false, // 是否展示取消按钮
+  closeOnClickModal: true, // 是否支持点击蒙层关闭
+  confirmButtonText: '', // 确定按钮文案
+  cancelButtonText: '', // 取消按钮文案
+  type: 'alert', // 弹框类型
+  inputType: 'text', // 输入框类型
+  inputValue: '', // 输入框初始值
+  inputPlaceholder: '', // 输入框placeholder
+  inputError: '', // 输入框错误提示文案
+  showErr: false, // 是否显示错误提示
+  zIndex: 99, // 弹窗层级
+  lazyRender: true // 弹层内容懒渲染
+})
 
 /**
- * 消息文案
+ * 确认按钮属性
  */
-const msg = ref<string>('')
-let onConfirm: ((res: MessageResult) => void) | null = null
-let onCancel: ((res: MessageResult) => void) | null = null
-let beforeConfirm: ((options: MessageBeforeConfirmOption) => void) | null = null
-const show = ref<boolean>(false)
-/**
- * 标题
- */
-const title = ref<string>('')
-/**
- * 是否展示取消按钮
- */
-const showCancelButton = ref<boolean>(false)
-/**
- * 是否支持点击蒙层进行关闭，点击蒙层回调传入的action为'modal'
- */
-const closeOnClickModal = ref<boolean>(true)
-/**
- * 确定按钮文案
- */
-const confirmButtonText = ref<string>('')
-/**
- * 取消按钮文案
- */
-const cancelButtonText = ref<string>('')
+const customConfirmProps = computed(() => {
+  const buttonProps: Partial<ButtonProps> = deepAssign(
+    {
+      block: true
+    },
+    isDef(messageState.confirmButtonProps) ? omitBy(messageState.confirmButtonProps, isUndefined) : {}
+  )
+  buttonProps.customClass = `${buttonProps.customClass || ''} wd-message-box__actions-btn`
+  return buttonProps
+})
 
 /**
- * 弹框类型
+ * 取消按钮属性
  */
-const type = ref<MessageType>('alert')
-
-/**
- * 当type为prompt时，输入框类型
- */
-const inputType = ref<InputType>('text')
-
-/**
- * 当type为prompt时，输入框初始值
- */
-const inputValue = ref<string | number>('')
-
-/**
- * 当type为prompt时，输入框placeholder
- */
-const inputPlaceholder = ref<string>('')
-
-/**
- * 当type为prompt时，输入框正则校验，点击确定按钮时进行校验
- */
-const inputPattern = ref<RegExp>()
-
-/**
- * 当type为prompt时，输入框校验函数，点击确定按钮时进行校验
- */
-let inputValidate: InputValidate | null = null
-
-/**
- * 当type为prompt时，输入框检验不通过时的错误提示文案
- */
-const inputError = ref<string>('')
-const showErr = ref<boolean>(false)
-/**
- * 弹窗层级
- */
-const zIndex = ref<number>(99)
-/**
- * 弹层内容懒渲染，触发展示时才渲染内容
- */
-const lazyRender = ref<boolean>(true)
+const customCancelProps = computed(() => {
+  const buttonProps: Partial<ButtonProps> = deepAssign(
+    {
+      block: true,
+      type: 'info'
+    },
+    isDef(messageState.cancelButtonProps) ? omitBy(messageState.cancelButtonProps, isUndefined) : {}
+  )
+  buttonProps.customClass = `${buttonProps.customClass || ''} wd-message-box__actions-btn`
+  return buttonProps
+})
 
 // 监听options变化展示
 watch(
   () => messageOption.value,
-  (newVal: MessageOptions) => {
+  (newVal: MessageOptionsWithCallBack) => {
     reset(newVal)
   },
   {
@@ -167,9 +140,9 @@ watch(
 )
 
 watch(
-  () => show.value,
+  () => messageState.show,
   (newValue) => {
-    resetErr(newValue)
+    resetErr(!!newValue)
   },
   {
     deep: true,
@@ -182,21 +155,21 @@ watch(
  * @param action
  */
 function toggleModal(action: 'confirm' | 'cancel' | 'modal') {
-  if (action === 'modal' && !closeOnClickModal.value) {
+  if (action === 'modal' && !messageState.closeOnClickModal) {
     return
   }
-  if (type.value === 'prompt' && action === 'confirm' && !validate()) {
+  if (messageState.type === 'prompt' && action === 'confirm' && !validate()) {
     return
   }
   switch (action) {
     case 'confirm':
-      if (beforeConfirm) {
-        beforeConfirm({
+      if (messageState.beforeConfirm) {
+        messageState.beforeConfirm({
           resolve: (isPass) => {
             if (isPass) {
               handleConfirm({
                 action: action,
-                value: inputValue.value
+                value: messageState.inputValue
               })
             }
           }
@@ -204,7 +177,7 @@ function toggleModal(action: 'confirm' | 'cancel' | 'modal') {
       } else {
         handleConfirm({
           action: action,
-          value: inputValue.value
+          value: messageState.inputValue
         })
       }
       break
@@ -226,9 +199,9 @@ function toggleModal(action: 'confirm' | 'cancel' | 'modal') {
  * @param result
  */
 function handleConfirm(result: MessageResult) {
-  show.value = false
-  if (isFunction(onConfirm)) {
-    onConfirm(result)
+  messageState.show = false
+  if (isFunction(messageState.success)) {
+    messageState.success(result)
   }
 }
 
@@ -237,74 +210,77 @@ function handleConfirm(result: MessageResult) {
  * @param result
  */
 function handleCancel(result: MessageResult) {
-  show.value = false
-  if (isFunction(onCancel)) {
-    onCancel(result)
+  messageState.show = false
+  if (isFunction(messageState.fail)) {
+    messageState.fail(result)
   }
 }
 
 /**
- * @description 如果存在校验规则行为，则进行判断校验是否通过规则。默认不存在校验直接铜鼓。
- * @return {Boolean} 是否通过校验
+ * 如果存在校验规则行为，则进行判断校验是否通过规则。默认不存在校验直接铜鼓。
  */
 function validate() {
-  if (inputPattern.value && !inputPattern.value.test(String(inputValue.value))) {
-    showErr.value = true
+  if (messageState.inputPattern && !messageState.inputPattern.test(String(messageState.inputValue))) {
+    messageState.showErr = true
     return false
   }
-  if (typeof inputValidate === 'function') {
-    const validateResult = inputValidate(inputValue.value)
+  if (typeof messageState.inputValidate === 'function') {
+    const validateResult = messageState.inputValidate(messageState.inputValue!)
     if (!validateResult) {
-      showErr.value = true
+      messageState.showErr = true
       return false
     }
   }
-  showErr.value = false
+  messageState.showErr = false
   return true
 }
+
 /**
  * @description show关闭时，销毁错误提示
  * @param val
  */
 function resetErr(val: boolean) {
   if (val === false) {
-    showErr.value = false
+    messageState.showErr = false
   }
 }
 function inputValChange({ value }: { value: string | number }) {
   if (value === '') {
-    showErr.value = false
+    messageState.showErr = false
     return
   }
-  inputValue.value = value
+  messageState.inputValue = value
 }
 
 /**
  * 重置message选项值
  * @param option message选项值
  */
-function reset(option: MessageOptions) {
+function reset(option: MessageOptionsWithCallBack) {
   if (option) {
-    title.value = isDef(option.title) ? option.title : ''
-    showCancelButton.value = isDef(option.showCancelButton) ? option.showCancelButton : false
-    show.value = option.show!
-    closeOnClickModal.value = option.closeOnClickModal!
-    confirmButtonText.value = option.confirmButtonText!
-    cancelButtonText.value = option.cancelButtonText!
-    msg.value = option.msg!
-    type.value = option.type!
-    inputType.value = option.inputType!
-    inputValue.value = option.inputValue!
-    inputPlaceholder.value = option.inputPlaceholder!
-    inputPattern.value = option.inputPattern!
-    inputValidate = option.inputValidate!
-    onConfirm = (option as any).onConfirm
-    onCancel = (option as any).onCancel
-    beforeConfirm = option.beforeConfirm!
-    inputError.value = option.inputError!
-    showErr.value = option.showErr!
-    zIndex.value = option.zIndex!
-    lazyRender.value = option.lazyRender!
+    messageState.title = isDef(option.title) ? option.title : ''
+    messageState.showCancelButton = isDef(option.showCancelButton) ? option.showCancelButton : false
+    messageState.show = option.show
+    messageState.closeOnClickModal = option.closeOnClickModal
+    messageState.confirmButtonText = option.confirmButtonText
+    messageState.cancelButtonText = option.cancelButtonText
+    messageState.msg = option.msg
+    messageState.type = option.type
+    messageState.inputType = option.inputType
+    messageState.inputSize = option.inputSize
+    messageState.inputValue = option.inputValue
+    messageState.inputPlaceholder = option.inputPlaceholder
+    messageState.inputPattern = option.inputPattern!
+    messageState.inputValidate = option.inputValidate
+    messageState.success = option.success
+    messageState.fail = option.fail
+    messageState.beforeConfirm = option.beforeConfirm
+    messageState.inputError = option.inputError
+    messageState.showErr = option.showErr
+    messageState.zIndex = option.zIndex
+    messageState.lazyRender = option.lazyRender
+    messageState.confirmButtonProps = option.confirmButtonProps
+    messageState.cancelButtonProps = option.cancelButtonProps
   }
 }
 </script>


### PR DESCRIPTION
✅ Closes: #740

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
#740
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
为 `MessageBox ` 添加 `cancel-button-props` 和 `confirm-button-props`，用于自定义操作按钮样式。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 更新了 `MessageBox` 组件文档，新增 `beforeConfirm` 函数，支持预确认逻辑。
  - 新增 `cancel-button-props` 和 `confirm-button-props` 属性，允许自定义按钮样式。
  - 在 `Index.vue` 中添加了新的演示块，支持自定义按钮属性的确认对话框。
  
- **文档**
  - 扩展了文档示例，展示新特性及用法。
  - 改进了文档结构，提高了可读性。

- **样式**
  - 为动作按钮添加了新的样式规则，优化按钮间距。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->