### PR TITLE
feat: ✨ radio添加iconPlacement属性用于控制图标方向

### DIFF
--- a/docs/component/radio.md
+++ b/docs/component/radio.md
@@ -149,17 +149,17 @@ radio设置的props优先级比radioGroup上设置的props优先级更高
 
 ## RadioGroup Attributes
 
-| 参数           | 说明                        | 类型                       | 可选值               | 默认值  | 最低版本         |
-| -------------- | --------------------------- | -------------------------- | -------------------- | ------- | ---------------- |
-| v-model        | 会自动选中value对应的单选框 | string / number / boolean  | -                    | -       | -                |
-| shape          | 单选框形状                  | string                     | dot / button / check | check   | -                |
-| size           | 设置大小                    | string                     | large                | -       | -                |
-| checked-color  | 选中的颜色                  | string                     | -                    | #4D80F0 | -                |
-| disabled       | 禁用                        | boolean                    | -                    | false   | -                |
-| max-width      | 文字位置最大宽度            | string                     | -                    | -       | -                |
-| inline         | 同行展示                    | boolean                    | -                    | false   | -                |
-| cell           | 表单模式                    | boolean                    | -                    | false   | -                |
-| icon-placement | 勾选图标对齐方式            | string｜left / right/ auto | auto                 |         | $LOWEST_VERSION$ |
+| 参数           | 说明                        | 类型                      | 可选值               | 默认值  | 最低版本         |
+| -------------- | --------------------------- | ------------------------- | -------------------- | ------- | ---------------- |
+| v-model        | 会自动选中value对应的单选框 | string / number / boolean | -                    | -       | -                |
+| shape          | 单选框形状                  | string                    | dot / button / check | check   | -                |
+| size           | 设置大小                    | string                    | large                | -       | -                |
+| checked-color  | 选中的颜色                  | string                    | -                    | #4D80F0 | -                |
+| disabled       | 禁用                        | boolean                   | -                    | false   | -                |
+| max-width      | 文字位置最大宽度            | string                    | -                    | -       | -                |
+| inline         | 同行展示                    | boolean                   | -                    | false   | -                |
+| cell           | 表单模式                    | boolean                   | -                    | false   | -                |
+| icon-placement | 勾选图标对齐方式            | string                    | left / right/ auto   | auto    | $LOWEST_VERSION$ |
 
 ## RadioGroup Events
 

--- a/docs/component/radio.md
+++ b/docs/component/radio.md
@@ -149,28 +149,29 @@ radio设置的props优先级比radioGroup上设置的props优先级更高
 
 ## RadioGroup Attributes
 
-| 参数 | 说明 | 类型 | 可选值 | 默认值 | 最低版本 |
-|-----|------|-----|-------|-------|--------|
-| v-model | 会自动选中value对应的单选框 | string / number / boolean | - | - | - |
-| shape | 单选框形状 | string | dot / button / check | check | - |
-| size | 设置大小 | string | large | - | - |
-| checked-color | 选中的颜色 | string | - | #4D80F0 | - |
-| disabled | 禁用 | boolean | - | false | - |
-| max-width | 文字位置最大宽度 | string | - | - | - |
-| inline | 同行展示 | boolean | - | false | - |
-| cell | 表单模式 | boolean | - | false | - |
+| 参数           | 说明                        | 类型                       | 可选值               | 默认值  | 最低版本         |
+| -------------- | --------------------------- | -------------------------- | -------------------- | ------- | ---------------- |
+| v-model        | 会自动选中value对应的单选框 | string / number / boolean  | -                    | -       | -                |
+| shape          | 单选框形状                  | string                     | dot / button / check | check   | -                |
+| size           | 设置大小                    | string                     | large                | -       | -                |
+| checked-color  | 选中的颜色                  | string                     | -                    | #4D80F0 | -                |
+| disabled       | 禁用                        | boolean                    | -                    | false   | -                |
+| max-width      | 文字位置最大宽度            | string                     | -                    | -       | -                |
+| inline         | 同行展示                    | boolean                    | -                    | false   | -                |
+| cell           | 表单模式                    | boolean                    | -                    | false   | -                |
+| icon-placement | 勾选图标对齐方式            | string｜left / right/ auto | auto                 |         | $LOWEST_VERSION$ |
 
 ## RadioGroup Events
 
-| 事件名称 | 说明 | 参数 | 最低版本 |
-|---------|-----|-----|---------|
-| change | 绑定值变化时触发 | `{ value }`  | - |
+| 事件名称 | 说明             | 参数        | 最低版本 |
+| -------- | ---------------- | ----------- | -------- |
+| change   | 绑定值变化时触发 | `{ value }` | -        |
 
 ## Radio Attributes
 
-| 参数 | 说明 | 类型 | 可选值 | 默认值 | 最低版本 |
-|-----|------|-----|-------|-------|---------|
-| value | 单选框选中时的值。会自动匹配radioGroup的value | string / number / boolean | - | - | - |
-| shape | 单选框形状 | string | dot / button / check | check | - |
-| checked-color | 选中的颜色 | string | - | #4D80F0 | - |
-| disabled | 禁用 | boolean | - | false | - |
+| 参数          | 说明                                          | 类型                      | 可选值               | 默认值  | 最低版本 |
+| ------------- | --------------------------------------------- | ------------------------- | -------------------- | ------- | -------- |
+| value         | 单选框选中时的值。会自动匹配radioGroup的value | string / number / boolean | -                    | -       | -        |
+| shape         | 单选框形状                                    | string                    | dot / button / check | check   | -        |
+| checked-color | 选中的颜色                                    | string                    | -                    | #4D80F0 | -        |
+| disabled      | 禁用                                          | boolean                   | -                    | false   | -        |

--- a/src/uni_modules/wot-design-uni/components/wd-radio-group/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-radio-group/types.ts
@@ -1,5 +1,5 @@
 import { type InjectionKey } from 'vue'
-import type { RadioShape } from '../wd-radio/types'
+import type { RadioShape, RadioIconPlacement } from '../wd-radio/types'
 import { baseProps, makeBooleanProp, makeStringProp } from '../common/props'
 
 export type RadioGroupProvide = {
@@ -11,6 +11,7 @@ export type RadioGroupProvide = {
     cell?: boolean
     size?: string
     inline?: boolean
+    iconPlacement?: RadioIconPlacement
   }
   updateValue: (value: string | number | boolean) => void
 }
@@ -32,5 +33,7 @@ export const radioGroupProps = {
   /** 设置大小，默认为空 */
   size: makeStringProp(''),
   /** 同行展示，默认为 false */
-  inline: makeBooleanProp(false)
+  inline: makeBooleanProp(false),
+  /** 图标位置，默认为 left */
+  iconPlacement: makeStringProp<RadioIconPlacement>('auto')
 }

--- a/src/uni_modules/wot-design-uni/components/wd-radio/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-radio/index.scss
@@ -172,6 +172,10 @@
     }
   }
 
+  &.icon-placement-left {
+    flex-direction: row-reverse;
+  }
+
   @include when(inline) {
     display: inline-block;
     margin-top: 0;
@@ -199,6 +203,14 @@
         .wd-radio__shape {
           margin-top: 0;
         }
+      }
+    }
+
+    &.icon-placement-right {
+      .wd-radio__shape {
+        margin-right: 0;
+        margin-left: 4px;
+        float: right;
       }
     }
   }

--- a/src/uni_modules/wot-design-uni/components/wd-radio/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-radio/types.ts
@@ -8,9 +8,11 @@
  * 记得注释
  */
 import type { PropType } from 'vue'
-import { baseProps, makeRequiredProp } from '../common/props'
+import { baseProps, makeRequiredProp, makeStringProp } from '../common/props'
 
 export type RadioShape = 'dot' | 'button' | 'check'
+
+export type RadioIconPlacement = 'left' | 'right' | 'auto'
 
 export const radioProps = {
   ...baseProps,
@@ -38,5 +40,10 @@ export const radioProps = {
     default: null
   },
   /** 最大宽度 */
-  maxWidth: String
+  maxWidth: String,
+  /** 图标位置，默认为 left */
+  iconPlacement: {
+    type: [String, null] as PropType<RadioIconPlacement>,
+    default: null
+  }
 }

--- a/src/uni_modules/wot-design-uni/components/wd-radio/wd-radio.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-radio/wd-radio.vue
@@ -4,7 +4,7 @@
       sizeValue ? 'is-' + sizeValue : ''
     } ${inlineValue ? 'is-inline' : ''} ${isChecked ? 'is-checked' : ''} ${shapeValue !== 'check' ? 'is-' + shapeValue : ''} ${
       disabledValue ? 'is-disabled' : ''
-    } ${customClass}`"
+    } icon-placement-${iconPlacement} ${customClass}`"
     :style="customStyle"
     @click="handleClick"
   >
@@ -36,7 +36,7 @@ import wdIcon from '../wd-icon/wd-icon.vue'
 import { computed, watch } from 'vue'
 import { useParent } from '../composables/useParent'
 import { RADIO_GROUP_KEY } from '../wd-radio-group/types'
-import { radioProps } from './types'
+import { radioProps, type RadioIconPlacement } from './types'
 import { getPropByPath, isDef } from '../common/util'
 
 const props = defineProps(radioProps)
@@ -84,6 +84,14 @@ const cellValue = computed(() => {
     return props.cell
   } else {
     return getPropByPath(radioGroup, 'props.cell')
+  }
+})
+
+const iconPlacement = computed<RadioIconPlacement>(() => {
+  if (isDef(props.iconPlacement)) {
+    return props.iconPlacement
+  } else {
+    return getPropByPath(radioGroup, 'props.iconPlacement')
   }
 })
 


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
close #371 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 更新了 `wd-radio` 组件文档，新增 `icon-placement` 属性，支持图标位置的自定义（左、右、自动）。
  - 引入 `checked-color` 属性，允许自定义选中颜色。
  - 增加 `disabled` 属性，支持禁用单个或整个 `radio-group`。
  - 改进文档结构，提高可读性。

- **样式**
  - 添加 `.icon-placement-left` 和 `.icon-placement-right` 类，以支持图标位置的样式调整。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->