### PR TITLE
feat: ✨ Input、Textarea在APP-VUE和H5端支持inputmode

### DIFF
--- a/docs/component/input.md
+++ b/docs/component/input.md
@@ -171,9 +171,26 @@ function handleChange(event) {
 | clearTrigger | 显示清除图标的时机，always 表示输入框不为空时展示，focus 表示输入框聚焦且不为空时展示	 | `InputClearTrigger`	 | `focus` / `always` | `always` | 1.3.7 |
 | focusWhenClear | 是否在点击清除按钮时聚焦输入框 | boolean | -      | true  | 1.3.7   |
 | ignoreCompositionEvent | 是否忽略组件内对文本合成系统事件的处理。为 false 时将触发 compositionstart、compositionend、compositionupdate 事件，且在文本合成期间会触发 input 事件。 | boolean | -      | true  | 1.3.11|
+| inputmode | 提供用户在编辑元素或其内容时可能输入的数据类型的提示。 | InputMode | -      | text  | $LOWEST_VERSION$ |
 
+### InputMode 可选值
 
-### FormItemRule 数据结构
+>新增于 uni-app 3.6.16+ inputmode是html规范后期更新的内容。各家小程序还未支持此属性。
+
+在符合条件的高版本webview里，uni-app的web和app-vue平台中可使用本属性，参见[inputmode](https://uniapp.dcloud.net.cn/component/input.html#inputmode)。
+
+| 值      | 说明                                                                                                                 |
+|---------|----------------------------------------------------------------------------------------------------------------------|
+| none    | 无虚拟键盘。在应用程序或者站点需要实现自己的键盘输入控件时很有用。                                                   |
+| text    | 使用用户本地区域设置的标准文本输入键盘。                                                                             |
+| decimal | 小数输入键盘，包含数字和分隔符（通常是“ . ”或者“ , ”），设备可能也可能不显示减号键。                                 |
+| numeric | 数字输入键盘，所需要的就是 0 到 9 的数字，设备可能也可能不显示减号键。                                               |
+| tel     | 电话输入键盘，包含 0 到 9 的数字、星号（*）和井号（#）键。表单输入里面的电话输入通常应该使用 <input type="tel"> 。   |
+| search  | 为搜索输入优化的虚拟键盘，比如，返回键可能被重新标记为“搜索”，也可能还有其他的优化。                                 |
+| email   | 为邮件地址输入优化的虚拟键盘，通常包含"@"符号和其他优化。表单里面的邮件地址输入应该使用 <input type="email">。       |
+| url     | 为网址输入优化的虚拟键盘，比如，“/”键会更加明显、历史记录访问等。表单里面的网址输入通常应该使用 <input type="url">。 |
+
+## FormItemRule
 
 | 键名 | 说明 | 类型 |
 | --- | --- | --- |

--- a/docs/component/textarea.md
+++ b/docs/component/textarea.md
@@ -161,6 +161,25 @@ const value = ref<string>('')
 | clearTrigger | 显示清除图标的时机，always 表示输入框不为空时展示，focus 表示输入框聚焦且不为空时展示	 | `InputClearTrigger`	 | `focus` / `always` | `always` | 1.3.7 |
 | focusWhenClear | 是否在点击清除按钮时聚焦输入框 | boolean | -      | true  | 1.3.7   |
 | ignoreCompositionEvent | 是否忽略组件内对文本合成系统事件的处理。为 false 时将触发 compositionstart、compositionend、compositionupdate 事件，且在文本合成期间会触发 input 事件。 | boolean | -      | true  | 1.3.11|
+| inputmode | 提供用户在编辑元素或其内容时可能输入的数据类型的提示。 | InputMode | -      | text  | $LOWEST_VERSION$ |
+
+### InputMode 可选值
+
+>新增于 uni-app 3.6.16+ inputmode是html规范后期更新的内容。各家小程序还未支持此属性。
+
+在符合条件的高版本webview里，uni-app的web和app-vue平台中可使用本属性，参见[inputmode](https://uniapp.dcloud.net.cn/component/input.html#inputmode)。
+
+| 值      | 说明                                                                                                                 |
+|---------|----------------------------------------------------------------------------------------------------------------------|
+| none    | 无虚拟键盘。在应用程序或者站点需要实现自己的键盘输入控件时很有用。                                                   |
+| text    | 使用用户本地区域设置的标准文本输入键盘。                                                                             |
+| decimal | 小数输入键盘，包含数字和分隔符（通常是“ . ”或者“ , ”），设备可能也可能不显示减号键。                                 |
+| numeric | 数字输入键盘，所需要的就是 0 到 9 的数字，设备可能也可能不显示减号键。                                               |
+| tel     | 电话输入键盘，包含 0 到 9 的数字、星号（*）和井号（#）键。表单输入里面的电话输入通常应该使用 <input type="tel"> 。   |
+| search  | 为搜索输入优化的虚拟键盘，比如，返回键可能被重新标记为“搜索”，也可能还有其他的优化。                                 |
+| email   | 为邮件地址输入优化的虚拟键盘，通常包含"@"符号和其他优化。表单里面的邮件地址输入应该使用 <input type="email">。       |
+| url     | 为网址输入优化的虚拟键盘，比如，“/”键会更加明显、历史记录访问等。表单里面的网址输入通常应该使用 <input type="url">。 |
+
 
 ### FormItemRule 数据结构
 

--- a/src/uni_modules/wot-design-uni/components/wd-input/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-input/types.ts
@@ -10,6 +10,8 @@ export type InputConfirmType = 'send' | 'search' | 'next' | 'go' | 'done'
 
 export type InputSize = 'large'
 
+export type InputMode = 'none' | 'text' | 'decimal' | 'numeric' | 'tel' | 'search' | 'email' | 'url'
+
 export const inputProps = {
   ...baseProps,
   customInputClass: makeStringProp(''),
@@ -182,5 +184,12 @@ export const inputProps = {
    * 类型: boolean
    * 默认值: true
    */
-  ignoreCompositionEvent: makeBooleanProp(true)
+  ignoreCompositionEvent: makeBooleanProp(true),
+  /**
+   * 它提供了用户在编辑元素或其内容时可能输入的数据类型的提示。在符合条件的高版本webview里，uni-app的web和app-vue平台中可使用本属性。
+   * 类型: InputMode
+   * 可选值: "none" | "text" | "tel" | "url" | "email" | "numeric" | "decimal" | "search" | "password"
+   * 默认值: "text"
+   */
+  inputmode: makeStringProp<InputMode>('text')
 }

--- a/src/uni_modules/wot-design-uni/components/wd-input/wd-input.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-input/wd-input.vue
@@ -43,6 +43,7 @@
           :always-embed="alwaysEmbed"
           :placeholder-class="inputPlaceholderClass"
           :ignoreCompositionEvent="ignoreCompositionEvent"
+          :inputmode="inputmode"
           @input="handleInput"
           @focus="handleFocus"
           @blur="handleBlur"

--- a/src/uni_modules/wot-design-uni/components/wd-textarea/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-textarea/types.ts
@@ -1,7 +1,7 @@
 import type { ExtractPropTypes, PropType } from 'vue'
 import { baseProps, makeArrayProp, makeBooleanProp, makeNumberProp, makeNumericProp, makeStringProp } from '../common/props'
 import type { FormItemRule } from '../wd-form/types'
-import type { InputClearTrigger } from '../wd-input/types'
+import type { InputClearTrigger, InputMode } from '../wd-input/types'
 
 export type ConfirmType = 'send' | 'search' | 'next' | 'go' | 'done'
 
@@ -288,7 +288,14 @@ export const textareaProps = {
    * 类型: boolean
    * 默认值: true
    */
-  ignoreCompositionEvent: makeBooleanProp(true)
+  ignoreCompositionEvent: makeBooleanProp(true),
+  /**
+   * 它提供了用户在编辑元素或其内容时可能输入的数据类型的提示。在符合条件的高版本webview里，uni-app的web和app-vue平台中可使用本属性。
+   * 类型: InputMode
+   * 可选值: "none" | "text" | "tel" | "url" | "email" | "numeric" | "decimal" | "search" | "password"
+   * 默认值: "text"
+   */
+  inputmode: makeStringProp<InputMode>('text')
 }
 
 export type TextareaProps = ExtractPropTypes<typeof textareaProps>

--- a/src/uni_modules/wot-design-uni/components/wd-textarea/wd-textarea.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-textarea/wd-textarea.vue
@@ -37,6 +37,7 @@
         :confirm-hold="confirmHold"
         :disable-default-padding="disableDefaultPadding"
         :ignoreCompositionEvent="ignoreCompositionEvent"
+        :inputmode="inputmode"
         @input="handleInput"
         @focus="handleFocus"
         @blur="handleBlur"


### PR DESCRIPTION
✅ Closes: #743

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
#743
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
Input、Textarea在H5和APP-VUE平台支持inputmode。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- `Input` 组件和 `wd-textarea` 组件文档更新，新增 `inputmode` 属性，支持多种输入类型提示。
	- `FormItemRule` 结构描述更新，提供更清晰的表单验证规则指导。
	- `wd-textarea` 组件新增 `clearTrigger`、`focusWhenClear` 和 `ignoreCompositionEvent` 属性。
  
- **文档**
	- 更新了 `Input` 和 `wd-textarea` 组件的文档，增强了对新特性的说明和用法指导。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->