### PR TITLE
feat: tabs底部条颜色支持自由设置

### DIFF
--- a/docs/component/tabs.md
+++ b/docs/component/tabs.md
@@ -263,6 +263,7 @@ function handlePopupShow() {
 | autoLineWidth | 底部条宽度跟随文字，指定`lineWidth`时此选项不生效                                        | boolean         | -        | false  | 1.4.0    |
 | lineWidth     | 底部条宽度，单位像素                                                                     | number          | -        | 19     | -        |
 | lineHeight    | 底部条高度，单位像素                                                                     | number          | -        | 3      | -        |
+| lineBgGolor   | 底部条颜色                                                                               | string          | -        | #4d80f0 | $LOWEST_VERSION$  |
 | color         | 文字颜色                                                                                 | string          | -        | -      | -        |
 | inactiveColor | 非活动标签文字颜色                                                                       | string          | -        | -      | -        |
 | animated      | 是否开启切换标签内容时的转场动画                                                         | boolean         | -        | false  | -        |

--- a/src/uni_modules/wot-design-uni/components/wd-tabs/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/types.ts
@@ -60,6 +60,10 @@ export const tabsProps = {
    */
   lineHeight: numericProp,
   /**
+   * 底部条颜色
+   */
+  lineBgGolor: makeStringProp(''),
+  /**
    * 颜色
    */
   color: makeStringProp(''),

--- a/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
@@ -308,7 +308,7 @@ function toggleMap() {
  */
 async function updateLineStyle(animation: boolean = true) {
   if (!state.inited) return
-  const { autoLineWidth, lineWidth, lineHeight } = props
+  const { autoLineWidth, lineWidth, lineHeight, lineBgGolor } = props
   try {
     const lineStyle: CSSProperties = {}
     if (isDef(lineWidth)) {
@@ -319,6 +319,9 @@ async function updateLineStyle(animation: boolean = true) {
         const textWidth = Number(textRects[state.activeIndex].width)
         lineStyle.width = addUnit(textWidth)
       }
+    }
+    if (isDef(lineBgGolor)) {
+      lineStyle.background = addUnit(lineBgGolor)
     }
     if (isDef(lineHeight)) {
       lineStyle.height = addUnit(lineHeight)


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1.使tabs的底部条可以自由设置颜色，不再局限于使用单一颜色
2.tabs 增加lineBgGolor属性，需要修改颜色时将颜色值传给lineBgGolor即可
3.![image](https://github.com/user-attachments/assets/e9a3e2fc-57f0-4eb7-9f69-fc1dc4e16665)



### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
  - 更新了 `wd-tabs` 组件文档，增加了新特性和使用示例。
  - 新增多个属性：`badge-props`、`auto-line-width`、`sticky`、`disabled`、`swipeable`、`animated`、`slidable`。
  - 新增方法 `updateLineStyle`，用于刷新活动标签的样式。
  - 允许自定义活动标签线的背景颜色。
  
- **文档**
  - 扩展了属性、事件和方法部分，包含新参数及其描述。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->