### PR TITLE
feat: ✨ Swiper 轮播项type字段的处理逻辑限制在可选值范围内

### DIFF
--- a/src/pages/swiper/Index.vue
+++ b/src/pages/swiper/Index.vue
@@ -212,7 +212,6 @@ const current6 = ref<number>(0)
 const current7 = ref<number>(0)
 const current8 = ref<number>(0)
 const current9 = ref<number>(0)
-const current10 = ref<number>(0)
 
 const isLoop = ref(false)
 

--- a/src/uni_modules/wot-design-uni/components/wd-swiper/wd-swiper.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-swiper/wd-swiper.vue
@@ -20,16 +20,8 @@
       @animationfinish="handleAnimationfinish"
     >
       <swiper-item v-for="(item, index) in list" :key="index" class="wd-swiper__item">
-        <image
-          v-if="isImage(item)"
-          :src="isObj(item) ? item[valueKey] : item"
-          :class="`wd-swiper__image ${customImageClass} ${customItemClass} ${getCustomItemClass(currentValue, index, list)}`"
-          :style="{ height: addUnit(height) }"
-          :mode="imageMode"
-          @click="handleClick(index, item)"
-        />
         <video
-          v-else-if="isVideo(item)"
+          v-if="isVideo(item)"
           :id="`video-${index}-${uid}`"
           :style="{ height: addUnit(height) }"
           :src="isObj(item) ? item[valueKey] : item"
@@ -44,6 +36,15 @@
           objectFit="cover"
           @click="handleClick(index, item)"
         />
+        <image
+          v-else
+          :src="isObj(item) ? item[valueKey] : item"
+          :class="`wd-swiper__image ${customImageClass} ${customItemClass} ${getCustomItemClass(currentValue, index, list)}`"
+          :style="{ height: addUnit(height) }"
+          :mode="imageMode"
+          @click="handleClick(index, item)"
+        />
+
         <text v-if="isObj(item) && item[textKey]" :class="`wd-swiper__text ${customTextClass}`" :style="customTextStyle">{{ item[textKey] }}</text>
       </swiper-item>
     </swiper>
@@ -137,10 +138,12 @@ const swiperIndicator = computed(() => {
 })
 
 const getMediaType = (item: string | SwiperList, type: 'video' | 'image') => {
+  const checkType = (url: string) => (type === 'video' ? isVideoUrl(url) : isImageUrl(url))
+
   if (isObj(item)) {
-    return item.type ? item.type === type : type === 'video' ? isVideoUrl(item[props.valueKey]) : isImageUrl(item[props.valueKey])
+    return item.type && ['video', 'image'].includes(item.type) ? item.type === type : checkType(item[props.valueKey])
   } else {
-    return type === 'video' ? isVideoUrl(item) : isImageUrl(item)
+    return checkType(item)
   }
 }
 


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [x] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
当前，如果`Swiper`轮播项的`type`被指定为`image`、`video`之外的值，仍会使用其结果作为文件类型，这显然可能会造成显示异常。所以调整为轮播项的`type`被指定为`image`、`video`之外的值时，使用从资源url中取得文件类型的方案。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 添加了多个 `wd-swiper` 组件，支持不同配置和指示器类型（如 'dots', 'dots-bar', 'fraction'）。
  - 新增视频 swiper 的条件渲染，支持在特定平台下播放视频。
  - 增加了自定义值和文本的 swiper 演示块。
  - 新增切换 swiper 循环行为的控制机制。

- **Bug 修复**
  - 简化了媒体项的渲染逻辑，提高了可维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->