### PR TITLE
fix: 🐛 修复 Form 表单 validator 校验不通过且未指定错误信息时无法显示校验信息的问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-form/wd-form.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-form/wd-form.vue
@@ -19,7 +19,7 @@ export default {
 <script lang="ts" setup>
 import wdToast from '../wd-toast/wd-toast.vue'
 import { reactive, watch } from 'vue'
-import { deepClone, getPropByPath, isDef, isPromise } from '../common/util'
+import { deepClone, getPropByPath, isDef, isPromise, isString } from '../common/util'
 import { useChildren } from '../composables/useChildren'
 import { useToast } from '../wd-toast'
 import { type FormRules, FORM_KEY, type ErrorMessage, formProps, type FormExpose } from './types'
@@ -94,12 +94,9 @@ async function validate(prop?: string): Promise<{ valid: boolean; errors: ErrorM
                     valid = false
                   }
                 })
-                .catch((error: string | Error) => {
-                  const message = typeof error === 'string' ? error : error.message
-                  errors.push({
-                    prop,
-                    message: message || rule.message
-                  })
+                .catch((error?: string | Error) => {
+                  const message = isDef(error) ? (isString(error) ? error : error.message || rule.message) : rule.message
+                  errors.push({ prop, message })
                   valid = false
                 })
             )


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
修复 Form 表单 validator 校验不通过且未指定错误信息时无法显示校验信息的问题
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 增强了表单组件的错误处理逻辑，确保更可靠的错误消息生成和显示。
  
- **方法更新**
  - 公开了 `validate` 和 `reset` 方法，供外部使用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->