### PR TITLE
fix: 🐛 修复Form组件rules属性，没有按照顺序执行问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-form/wd-form.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-form/wd-form.vue
@@ -148,12 +148,8 @@ function getMergeRules() {
 }
 
 function showMessage(errors: ErrorMessage[]) {
-  const childrenProps = children.map((e) => e.prop).filter(Boolean)
-  const messages = errors.filter((error) => error.message && childrenProps.includes(error.prop))
+  const messages = errors.filter((error) => error.message)
   if (messages.length) {
-    messages.sort((a, b) => {
-      return childrenProps.indexOf(a.prop) - childrenProps.indexOf(b.prop)
-    })
     if (props.errorType === 'toast') {
       showToast(messages[0].message)
     } else if (props.errorType === 'message') {

--- a/src/uni_modules/wot-design-uni/components/wd-form/wd-form.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-form/wd-form.vue
@@ -148,8 +148,12 @@ function getMergeRules() {
 }
 
 function showMessage(errors: ErrorMessage[]) {
-  const messages = errors.filter((error) => error.message)
+  const childrenProps = children.map((e) => e.prop).filter(Boolean)
+  const messages = errors.filter((error) => error.message && childrenProps.includes(error.prop))
   if (messages.length) {
+    messages.sort((a, b) => {
+      return childrenProps.indexOf(a.prop) - childrenProps.indexOf(b.prop)
+    })
     if (props.errorType === 'toast') {
       showToast(messages[0].message)
     } else if (props.errorType === 'message') {


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

form组件在校验规则时，并不是按照rules属性的顺序提示错误信息的，解决方案是对showMessage方法中messages变量进行排序

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 改进了错误消息的显示逻辑，确保错误消息按照特定顺序呈现。
	- 增加了过滤步骤，以确保错误属性包含在子组件属性列表中。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->