### PR TITLE
feat: ✨ 修复 InputNumber 在设置为 allow-null 时被赋值为空时未触发更新的问题并支持异步更新

### DIFF
--- a/docs/component/input-number.md
+++ b/docs/component/input-number.md
@@ -96,6 +96,34 @@ function handleChange1({ value }) {
 }
 ```
 
+## 异步变更
+通过 `before-change` 可以在输入值变化前进行校验和拦截。
+
+```html
+<wd-input-number v-model="value" :before-change="beforeChange" />
+```
+
+```typescript
+import { ref } from 'vue'
+import { useToast } from '@/uni_modules/wot-design-uni'
+import type { InputNumberBeforeChange } from '@/uni_modules/wot-design-uni/components/wd-input-number/types'
+const { loading, close } = useToast()
+
+const value = ref<number>(1)
+ 
+const beforeChange: InputNumberBeforeChange = (value) => {
+  loading({ msg: `正在更新到${value}...` })
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      close()
+      resolve(true)
+    }, 500)
+  })
+}
+```
+
+ 
+
 ## Attributes
 
 | 参数 | 说明 | 类型 | 可选值 | 默认值 | 最低版本 |
@@ -109,12 +137,13 @@ function handleChange1({ value }) {
 | disabled | 禁用 | boolean | - | false | - |
 | without-input | 不显示输入框 | boolean | - | false | - |
 | input-width | 输入框宽度 | string | - | 36px | - |
-| allow-null | 允许空值 | boolean | - | false | - |
+| allow-null | 是否允许输入的值为空，设置为 `true` 后允许传入空字符串 | boolean | - | false | - |
 | placeholder | 占位文本 | string | - | - | - |
 | disable-input | 禁用输入框 | boolean | - | false | 0.2.14 |
 | disable-plus | 禁用增加按钮 | boolean | - | false | 0.2.14 |
 | disable-minus | 禁用减少按钮 | boolean | - | false | 0.2.14 |
 | adjustPosition | 原生属性，键盘弹起时，是否自动上推页面 | boolean | - | true | 1.3.11 |
+| before-change | 输入框值改变前触发，返回 false 会阻止输入框值改变，支持返回 `Promise` | `(value: number \| string) => boolean \| Promise<boolean>` | - | - | $LOWEST_VERSION$ |
 
 
 ## Events

--- a/src/pages/inputNumber/Index.vue
+++ b/src/pages/inputNumber/Index.vue
@@ -33,10 +33,16 @@
     <demo-block title="允许空值，并设置 placeholder">
       <wd-input-number v-model="value9" allow-null placeholder="不限" input-width="70px" @change="handleChange9" />
     </demo-block>
+    <demo-block title="异步变更">
+      <wd-input-number v-model="value11" :before-change="beforeChange" />
+    </demo-block>
   </page-wraper>
 </template>
 <script lang="ts" setup>
+import { useToast } from '@/uni_modules/wot-design-uni'
+import type { InputNumberBeforeChange } from '@/uni_modules/wot-design-uni/components/wd-input-number/types'
 import { ref } from 'vue'
+const { loading, close } = useToast()
 
 const value1 = ref<number>(1)
 const value2 = ref<number>(1)
@@ -48,6 +54,7 @@ const value7 = ref<number>(1)
 const value8 = ref<number>(2)
 const value9 = ref<string>('')
 const value10 = ref<number>(1)
+const value11 = ref<number>(1)
 
 function handleChange1({ value }: any) {
   console.log(value)
@@ -75,6 +82,16 @@ function handleChange8({ value }: any) {
 }
 function handleChange9({ value }: any) {
   console.log(value)
+}
+
+const beforeChange: InputNumberBeforeChange = (value) => {
+  loading({ msg: `正在更新到${value}...` })
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      close()
+      resolve(true)
+    }, 500)
+  })
 }
 </script>
 <style lang="scss" scoped>

--- a/src/uni_modules/wot-design-uni/components/common/interceptor.ts
+++ b/src/uni_modules/wot-design-uni/components/common/interceptor.ts
@@ -1,0 +1,43 @@
+import { isPromise } from './util'
+
+function noop() {}
+
+export type Interceptor = (...args: any[]) => Promise<boolean> | boolean | undefined | void
+
+export function callInterceptor(
+  interceptor: Interceptor | undefined,
+  {
+    args = [],
+    done,
+    canceled,
+    error
+  }: {
+    args?: unknown[]
+    done: () => void
+    canceled?: () => void
+    error?: () => void
+  }
+) {
+  if (interceptor) {
+    // eslint-disable-next-line prefer-spread
+    const returnVal = interceptor.apply(null, args)
+
+    if (isPromise(returnVal)) {
+      returnVal
+        .then((value) => {
+          if (value) {
+            done()
+          } else if (canceled) {
+            canceled()
+          }
+        })
+        .catch(error || noop)
+    } else if (returnVal) {
+      done()
+    } else if (canceled) {
+      canceled()
+    }
+  } else {
+    done()
+  }
+}

--- a/src/uni_modules/wot-design-uni/components/wd-input-number/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-input-number/types.ts
@@ -1,13 +1,16 @@
 /*
  * @Author: weisheng
  * @Date: 2024-03-15 20:40:34
- * @LastEditTime: 2024-09-18 09:49:12
+ * @LastEditTime: 2024-12-31 00:33:21
  * @LastEditors: weisheng
  * @Description:
- * @FilePath: \wot-design-uni\src\uni_modules\wot-design-uni\components\wd-input-number\types.ts
+ * @FilePath: /wot-design-uni/src/uni_modules/wot-design-uni/components/wd-input-number/types.ts
  * 记得注释
  */
+import type { PropType } from 'vue'
 import { baseProps, makeBooleanProp, makeNumberProp, makeNumericProp, makeRequiredProp, makeStringProp, numericProp } from '../common/props'
+
+export type InputNumberBeforeChange = (value: number | string) => boolean | Promise<boolean>
 
 export const inputNumberProps = {
   ...baseProps,
@@ -70,5 +73,9 @@ export const inputNumberProps = {
   /**
    * 原生属性，键盘弹起时，是否自动上推页面
    */
-  adjustPosition: makeBooleanProp(true)
+  adjustPosition: makeBooleanProp(true),
+  /**
+   * 输入值变化前的回调函数，返回 `false` 可阻止输入，支持返回 `Promise`
+   */
+  beforeChange: Function as PropType<InputNumberBeforeChange>
 }


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
修复 InputNumber 在设置为 allow-null 时被赋值为空时未触发更新的问题并支持异步更新
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 为 `wd-input-number` 组件新增异步变更拦截功能
	- 支持通过 `before-change` 属性在输入值变更前进行验证和拦截

- **文档更新**
	- 更新 `wd-input-number` 组件文档
	- 新增异步变更使用示例
	- 调整 `allow-null` 属性描述

- **改进**
	- 优化输入数字组件的值变更逻辑
	- 增强组件交互性和灵活性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->