### PR TITLE
feat: ✨ 修复 Switch 组件增加可展示状态文字 (#798)

### DIFF
--- a/docs/component/switch.md
+++ b/docs/component/switch.md
@@ -1,3 +1,11 @@
+<!--
+ * @Author: 810505339
+ * @Date: 2024-12-20 14:11:10
+ * @LastEditors: 810505339
+ * @LastEditTime: 2025-01-07 15:30:02
+ * @FilePath: \wot-design-uni\docs\component\switch.md
+ * 记得注释
+-->
 #  Switch 开关
 
 
@@ -49,21 +57,11 @@ const checked = ref<boolean>(true)
 <wd-switch v-model="checked" :before-change="beforeChange" @change="handleChange" />
 ```
 
-```typescript
-import { useMessage } from '@/uni_modules/wot-design-uni'
+## 文字描述
+通过 `active-text` 属性修改开关打开时的文字，`inactive-text` 属性修改开关关闭时的文字。
 
-const message = useMessage()
-
-const beforeChange = ({ value, resolve }) => {
-  message
-    .confirm('是否切换开关')
-    .then(() => {
-      resolve(true)
-    })
-    .catch(() => {
-      resolve(false)
-    })
-}
+```html
+ <wd-switch  active-text="喜欢摸鱼" inactive-text="讨厌摸鱼"  />
 ```
 
 ## Attributes
@@ -77,6 +75,8 @@ const beforeChange = ({ value, resolve }) => {
 | active-color | 打开时的背景色 | string | - | #4D80F0 | - |
 | inactive-color | 关闭时的背景色，默认为白色，所以有灰色边框，如果设置了该值，则会自动去除灰色边框 | string | - | #fff | - |
 | size | 开关大小，可以为任何单位的字符串尺寸 | string/number | - | 28px | - |
+| active-text   | 打开时的内部文字 | string | - | - | - |
+| inactive-text | 关闭时的内部文字 | string | - | - | - |
 | before-change | 修改前钩子 | function | - | - | - |
 
 ## Events

--- a/src/pages/switch/Index.vue
+++ b/src/pages/switch/Index.vue
@@ -24,6 +24,9 @@
       <demo-block title="before-change 修改前钩子函数">
         <wd-switch v-model="checked7" :before-change="beforeChange" @change="handleChange5" />
       </demo-block>
+      <demo-block title="文字描述">
+        <wd-switch v-model="checked8" active-text="喜欢摸鱼" inactive-text="讨厌摸鱼" @change="handleChange6" />
+      </demo-block>
     </view>
   </page-wraper>
 </template>
@@ -39,6 +42,7 @@ const checked4 = ref<boolean>(true)
 const checked5 = ref<boolean>(true)
 const checked6 = ref<boolean>(false)
 const checked7 = ref<boolean>(false)
+const checked8 = ref<boolean>(true)
 
 const message = useMessage()
 
@@ -65,6 +69,9 @@ function handleChange4({ value }: any) {
   console.log(value)
 }
 function handleChange5({ value }: any) {
+  console.log(value)
+}
+function handleChange6({ value }: any) {
   console.log(value)
 }
 </script>

--- a/src/uni_modules/wot-design-uni/components/wd-switch/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-switch/index.scss
@@ -2,9 +2,10 @@
 @import '../common/abstracts/mixin';
 
 @include b(switch) {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   position: relative;
-  width: $-switch-width;
+  min-width: $-switch-width;
   height: $-switch-height;
   border-radius: $-switch-circle-size;
   background: $-switch-inactive-color;
@@ -22,7 +23,7 @@
     box-sizing: border-box;
     position: absolute;
     display: inline-block;
-    width: $-switch-circle-size;
+    min-width: $-switch-circle-size;
     height: $-switch-circle-size;
     top: 2px;
     left: 2px;
@@ -34,7 +35,7 @@
     &::after {
       position: absolute;
       content: '';
-      width: calc(200% - 2px);
+      min-width: calc(200% - 2px);
       height: calc(200% - 2px);
       top: 50%;
       left: 50%;
@@ -43,13 +44,30 @@
       border-radius: 50%;
     }
   }
+  @include e(inner) {
+    color:#fff;
+    font-size: calc($-switch-circle-size/2.5);
+    width:100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 4px 0 calc($-switch-circle-size * 2 + 8px);
+    user-select: none;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    transition: all 0.3s;
+  }
   @include when(checked) {
     background: $-switch-active-color;
     border-color: $-switch-active-color;
 
     .wd-switch__circle {
-      left: calc($-switch-width - $-switch-circle-size - 2px);
+      left: calc(100% - $-switch-circle-size - 2px);
       box-shadow: 0 2px 4px 0 $-switch-active-shadow-color
+    }
+    .wd-switch__inner{
+      padding: 0 calc($-switch-circle-size * 2 + 8px) 0 4px;
     }
   }
   @include when(disabled) {

--- a/src/uni_modules/wot-design-uni/components/wd-switch/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-switch/types.ts
@@ -1,3 +1,11 @@
+/*
+ * @Author: 810505339
+ * @Date: 2025-01-03 14:09:33
+ * @LastEditors: 810505339
+ * @LastEditTime: 2025-01-07 13:44:45
+ * @FilePath: \wot-design-uni\src\uni_modules\wot-design-uni\components\wd-switch\types.ts
+ * 记得注释
+ */
 import type { ExtractPropTypes, PropType } from 'vue'
 import { baseProps, makeBooleanProp, makeNumberProp, makeNumericProp, numericProp } from '../common/props'
 
@@ -44,6 +52,14 @@ export const switchProps = {
    * 非激活颜色
    */
   inactiveColor: String,
+  /**
+   * 激活的文字
+   */
+  activeText: String,
+  /**
+   * 非激活的文字
+   */
+  inactiveText: String,
   /**
    * 大小
    */

--- a/src/uni_modules/wot-design-uni/components/wd-switch/wd-switch.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-switch/wd-switch.vue
@@ -1,5 +1,8 @@
 <template>
   <view :class="rootClass" :style="rootStyle" @click="switchValue">
+    <view class="wd-switch__inner" v-if="innerText">
+      {{ innerText }}
+    </view>
     <view class="wd-switch__circle" :style="circleStyle"></view>
   </view>
 </template>
@@ -43,6 +46,10 @@ const circleStyle = computed(() => {
       ? 'box-shadow: none;'
       : ''
   return circleStyle
+})
+
+const innerText = computed(() => {
+  return props.modelValue === props.activeValue ? props.activeText : props.inactiveText
 })
 
 function switchValue() {


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 为开关组件添加了文字描述功能
	- 支持在开关的激活和非激活状态显示自定义文本

- **文档更新**
	- 更新了开关组件的文档，新增了文字描述使用说明
	- 在属性表中添加了 `active-text` 和 `inactive-text` 两个新属性的说明

- **样式调整**
	- 优化了开关组件的布局和显示样式
	- 改进了组件的灵活性和响应性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->