### PR TITLE
车牌号虚拟键盘支持自动切换汉字/字母布局

### DIFF
--- a/docs/component/keyboard.md
+++ b/docs/component/keyboard.md
@@ -70,24 +70,39 @@ const onDelete = () => showToast('删除')
 
 ## 车牌号键盘
 
-将 `mode` 属性设置为 `car` 来展示车牌号键盘，常用于输入车牌号的场景。
+将 `mode` 属性设置为 `car` 来展示车牌号键盘，常用于输入车牌号的场景。 通过设置 `carLang` 属性可以控制车牌号键盘的键盘布局，默认为 `zh`，可以设置为 `en`。
 
 ```html
 <wd-cell title="车牌号键盘" is-link @click="showKeyBoard" />
 
-<wd-keyboard v-model:visible="visible" mode="car" @input="onInput" @delete="onDelete"></wd-keyboard>
+<wd-keyboard v-model:visible="visible" mode="car" @input="onInputCar" @delete="onDeleteCar" :carLang="carLang"></wd-keyboard>
 ```
 
 ```ts
 const { show: showToast } = useToast()
 const visible = ref<boolean>(false)
+const carLang = ref<'zh' | 'en'>('zh');
+const carNum = ref<string>('');
 
 function showKeyBoard() {
   visible.value = true
 }
 
-const onInput = (value) => showToast(`${value}`)
-const onDelete = () => showToast('删除')
+const onInputCar = (value: string) => {
+  carNum.value = carNum.value + value
+  showToast(`${carNum.value}`)
+  carLang.value = carNum.value.length > 0 ? 'en' : 'zh'
+}
+const onDeleteCar = () => {
+  carNum.value = carNum.value.slice(0, -1)
+  if (carNum.value.length === 0) {
+    showToast("删除")
+    carLang.value = "zh"
+  } else {
+    showToast(`${carNum.value}`)
+    carLang.value = carNum.value.length > 0 ? 'en' : 'zh'
+  }
+}
 ```
 
 ## 带标题的键盘
@@ -239,24 +254,25 @@ const onDelete = () => showToast('删除')
 
 ## Attributes
 
-| 参数                | 说明                     | 类型                  | 可选值                     | 默认值     | 最低版本         |
-| ------------------- | ------------------------ | --------------------- | -------------------------- | ---------- | ---------------- |
-| v-model:visible     | 是否展开                 | `boolean`             | -                          | `false`    | 1.3.10           |
-| v-model             | 绑定的值                 | `string`              | -                          | -          | 1.3.10           |
-| title               | 标题                     | `string`              | -                          | -          | 1.3.10           |
-| mode                | 键盘模式                 | `string`              | `default`, `car`, `custom` | `default`  | 1.3.10 |
-| zIndex              | 层级                     | `number`              | -                          | `100`      | 1.3.10           |
-| maxlength           | 最大长度                 | `number`              | -                          | `Infinity` | 1.3.10           |
-| showDeleteKey       | 是否显示删除键           | `boolean`             | -                          | `true`     | 1.3.10           |
-| randomKeyOrder      | 是否随机键盘按键顺序     | `boolean`             | -                          | `false`    | 1.3.10           |
-| closeText           | 确认按钮文本             | `string`              | -                          | -          | 1.3.10           |
-| deleteText          | 删除按钮文本             | `string`              | -                          | -          | 1.3.10           |
-| closeButtonLoading  | 关闭按钮是否显示加载状态 | `boolean`             | -                          | `false`    | 1.3.10           |
-| modal               | 是否显示蒙层遮罩         | `boolean`             | -                          | `false`    | 1.3.10           |
-| hideOnClickOutside  | 是否在点击外部时收起键盘 | `boolean`             | -                          | `true`     | 1.3.10           |
-| lockScroll          | 是否锁定滚动             | `boolean`             | -                          | `true`     | 1.3.10           |
-| safeAreaInsetBottom | 是否在底部安全区域内     | `boolean`             | -                          | `true`     | 1.3.10           |
-| extraKey            | 额外按键                 | `string` / `string[]` | -                          | -          | 1.3.10           |
+| 参数                  | 说明           | 类型                    | 可选值                      | 默认值     | 最低版本   |
+|---------------------|--------------|-----------------------|--------------------------| --------- |--------|
+| v-model:visible     | 是否展开         | `boolean`             | -                        | `false`   | 1.3.10 |
+| v-model             | 绑定的值         | `string`              | -                        | -         | 1.3.10 |
+| title               | 标题           | `string`              | -                        | -         | 1.3.10 |
+| mode                | 键盘模式         | `string`              | `default`, `car`, `custom` | `default` | 1.3.10 |
+| zIndex              | 层级           | `number`              | -                        | `100`     | 1.3.10 |
+| maxlength           | 最大长度         | `number`              | -                        | `Infinity` | 1.3.10 |
+| showDeleteKey       | 是否显示删除键      | `boolean`             | -                        | `true`    | 1.3.10 |
+| randomKeyOrder      | 是否随机键盘按键顺序   | `boolean`             | -                        | `false`   | 1.3.10 |
+| closeText           | 确认按钮文本       | `string`              | -                        | -         | 1.3.10 |
+| deleteText          | 删除按钮文本       | `string`              | -                        | -         | 1.3.10 |
+| closeButtonLoading  | 关闭按钮是否显示加载状态 | `boolean`             | -                        | `false`   | 1.3.10 |
+| modal               | 是否显示蒙层遮罩     | `boolean`             | -                        | `false`   | 1.3.10 |
+| hideOnClickOutside  | 是否在点击外部时收起键盘 | `boolean`             | -                        | `true`    | 1.3.10 |
+| lockScroll          | 是否锁定滚动       | `boolean`             | -                        | `true`    | 1.3.10 |
+| safeAreaInsetBottom | 是否在底部安全区域内   | `boolean`             | -                        | `true`    | 1.3.10 |
+| extraKey            | 额外按键         | `string` / `string[]` | -                        | -         | 1.3.10 |
+| carLang             | 车牌号键盘布局，仅适用于 `mode="car"` 模式    | `string`              |     `zh`, `en`           |   `zh`       | 1.5.2  |
 
 ## Slot
 

--- a/docs/component/keyboard.md
+++ b/docs/component/keyboard.md
@@ -272,7 +272,7 @@ const onDelete = () => showToast('删除')
 | lockScroll          | 是否锁定滚动       | `boolean`             | -                        | `true`    | 1.3.10 |
 | safeAreaInsetBottom | 是否在底部安全区域内   | `boolean`             | -                        | `true`    | 1.3.10 |
 | extraKey            | 额外按键         | `string` / `string[]` | -                        | -         | 1.3.10 |
-| carLang             | 车牌号键盘布局，仅适用于 `mode="car"` 模式    | `string`              |     `zh`, `en`           |   `zh`       | 1.5.2  |
+| carLang             | 车牌号键盘布局，仅适用于 `mode="car"` 模式    | `string`              |     `zh`, `en`           |   `zh`       | $LOWEST_VERSION$  |
 
 ## Slot
 

--- a/src/pages/keyboard/Index.vue
+++ b/src/pages/keyboard/Index.vue
@@ -44,7 +44,7 @@
 
     <wd-keyboard :modal="true" v-model:visible="visible8" @input="onInput" @delete="onDelete" />
 
-    <wd-keyboard v-model:visible="visible10" mode="car" @input="onInput" @delete="onDelete" />
+    <wd-keyboard v-model:visible="visible10" mode="car" @input="onInputCar" @delete="onDeleteCar" :carLang="carLang" />
   </page-wraper>
 </template>
 <script lang="ts" setup>
@@ -66,11 +66,29 @@ const visibleArr = [visible1, visible2, visible3, visible4, visible5, visible6, 
 
 const value1 = ref<string>('')
 
+const carLang = ref<'zh' | 'en'>('zh')
+const carNum = ref<string>('')
+
 function showKeyBoard(index: number) {
   visibleArr.forEach((item, i) => (i === index - 1 ? (item.value = true) : (item.value = false)))
 }
 
 const onInput = (value: string) => showToast(`${value}`)
+const onInputCar = (value: string) => {
+  carNum.value = carNum.value + value
+  showToast(`${carNum.value}`)
+  carLang.value = carNum.value.length > 0 ? 'en' : 'zh'
+}
 const onDelete = () => showToast('删除')
+const onDeleteCar = () => {
+  carNum.value = carNum.value.slice(0, -1)
+  if (carNum.value.length === 0) {
+    showToast('删除')
+    carLang.value = 'zh'
+  } else {
+    showToast(`${carNum.value}`)
+    carLang.value = carNum.value.length > 0 ? 'en' : 'zh'
+  }
+}
 </script>
 <style lang="scss" scoped></style>

--- a/src/uni_modules/wot-design-uni/components/wd-keyboard/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-keyboard/types.ts
@@ -3,6 +3,7 @@ import { baseProps, makeBooleanProp, makeNumberProp, makeStringProp } from '../c
 
 export type KeyboardMode = 'default' | 'custom' | 'car'
 export type KeyType = '' | 'delete' | 'extra' | 'close'
+export type CarKeyboardLang = '' | 'zh' | 'en'
 
 export interface Key {
   text?: number | string // key文本
@@ -75,5 +76,9 @@ export const keyboardProps = {
   /**
    * 额外按键
    */
-  extraKey: [String, Array] as PropType<string | Array<string>>
+  extraKey: [String, Array] as PropType<string | Array<string>>,
+  /**
+   * 车牌键盘中/英文模式，在 `mode` 为 `car` 时生效
+   */
+  carLang: makeStringProp<CarKeyboardLang>('zh')
 }

--- a/src/uni_modules/wot-design-uni/components/wd-keyboard/wd-keyboard.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-keyboard/wd-keyboard.vue
@@ -70,6 +70,14 @@ watch(
 )
 
 const carKeyboardLang = ref('zh')
+
+watch(
+  () => props.carLang,
+  (newValue) => {
+    carKeyboardLang.value = newValue
+  }
+)
+
 const keys = computed(() => (props.mode !== 'car' ? (props.mode === 'custom' ? genCustomKeys() : genDefaultKeys()) : genCarKeys()))
 
 const showClose = computed(() => {
@@ -135,7 +143,7 @@ function genCarKeys(): Array<Key> {
   const [keys, remainKeys] = splitCarKeys()
   return [
     ...keys,
-    { text: carKeyboardLang.value === 'zh' ? 'ABC' : '返回', type: 'extra', wider: true },
+    { text: carKeyboardLang.value === 'zh' ? 'ABC' : '汉字', type: 'extra', wider: true },
     ...remainKeys,
     { text: props.deleteText, type: 'delete', wider: true }
   ]
@@ -155,7 +163,7 @@ const handlePress = (text: string, type: NumberKeyType) => {
   if (type === 'extra') {
     if (text === '') {
       return handleClose()
-    } else if (text === 'ABC' || text === '返回') {
+    } else if (text === 'ABC' || text === '汉字') {
       carKeyboardLang.value = carKeyboardLang.value === 'zh' ? 'en' : 'zh'
       return
     }


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ x] 站点、文档改进
- [ x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ x] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

车牌号虚拟键盘，选择省份后，应自动切换至字母/数字布局，不需要用户手动点击切换。所以新增一个prop来指定键盘布局，以便页面使用该组件时可根据具体业务自动切换汉字或者字母数字。
同时将"返回"修改为"汉字"，更加合适一些。

### ☑️ 请求合并前的自查清单

- [ x ] 文档已补充或无须补充
- [ x ] 代码演示已提供或无须提供
- [ x] TypeScript 定义已补充或无须补充