### PR TITLE
fix: 🐛 修复Card footer或者header没写的时候，不会自动隐藏占位(#822)

### DIFF
--- a/src/pages/card/Index.vue
+++ b/src/pages/card/Index.vue
@@ -1,8 +1,8 @@
 <!--
  * @Author: weisheng
  * @Date: 2023-06-13 11:47:12
- * @LastEditTime: 2023-08-11 18:49:11
- * @LastEditors: weisheng
+ * @LastEditTime: 2025-01-10 14:52:40
+ * @LastEditors: 810505339
  * @Description: 
  * @FilePath: \wot-design-uni\src\pages\card\Index.vue
  * 记得注释
@@ -33,6 +33,49 @@
           </view>
           <template #footer>
             <wd-button size="small" plain>查看详情</wd-button>
+          </template>
+        </wd-card>
+      </demo-block>
+      <demo-block title="去除footer" transparent>
+        <wd-card title="网名" type="rectangle">
+          <view>
+            <image
+              src="https://avatars.githubusercontent.com/u/26426873?v=4"
+              alt="joy"
+              style="width: 40px; height: 40px; border-radius: 4px; margin-right: 12px"
+            />
+            大家好,我叫摸鱼
+          </view>
+        </wd-card>
+        <wd-card type="rectangle">
+          <template #title>
+            <view class="title">
+              <view>2020-02-03服务到期</view>
+              <view class="title-tip">
+                <wd-icon name="warning" size="14px" custom-style="vertical-align: bottom" />
+                您可以去电脑上使用该服务
+              </view>
+            </view>
+          </template>
+
+          <view style="height: 40px" class="content">
+            <image
+              src="https://img11.360buyimg.com/imagetools/jfs/t1/143248/37/5695/265818/5f3a8546E98d998a4/745897ca9c9e474b.jpg"
+              width="40"
+              height="40"
+              alt="joy"
+              style="width: 40px; height: 40px; border-radius: 4px; margin-right: 12px"
+            />
+            <view>
+              <view class="custom-main">智云好客CRM短信_催评营销</view>
+              <view class="custom-sub">高级版-快速吸粉 | 周期一年</view>
+            </view>
+          </view>
+          <template #footer>
+            <view>
+              <wd-button size="small" plain custom-style="margin-right: 8px">评价</wd-button>
+              <wd-button size="small">立即使用</wd-button>
+            </view>
           </template>
         </wd-card>
       </demo-block>
@@ -103,6 +146,7 @@
   .custom-main {
     color: $-dark-color;
   }
+
   .custom-sub {
     color: $-dark-color-gray;
   }
@@ -115,12 +159,15 @@
   justify-content: flex-start;
   align-items: center;
 }
+
 .content {
   justify-content: flex-start;
 }
+
 .title {
   justify-content: space-between;
 }
+
 .title-tip {
   color: rgba(0, 0, 0, 0.25);
   font-size: 12px;
@@ -130,6 +177,7 @@
   color: rgba(0, 0, 0, 0.85);
   font-size: 16px;
 }
+
 .custom-sub {
   color: rgba(0, 0, 0, 0.25);
   font-size: 12px;

--- a/src/uni_modules/wot-design-uni/components/wd-card/wd-card.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-card/wd-card.vue
@@ -1,6 +1,6 @@
 <template>
   <view :class="['wd-card', type == 'rectangle' ? 'is-rectangle' : '', customClass]" :style="customStyle">
-    <view :class="['wd-card__title-content', customTitleClass]">
+    <view :class="['wd-card__title-content', customTitleClass]" v-if="title || $slots.title">
       <view class="wd-card__title">
         <text v-if="title">{{ title }}</text>
         <slot v-else name="title"></slot>
@@ -9,7 +9,7 @@
     <view :class="`wd-card__content ${customContentClass}`">
       <slot></slot>
     </view>
-    <view :class="`wd-card__footer ${customFooterClass}`">
+    <view :class="`wd-card__footer ${customFooterClass}`" v-if="$slots.footer">
       <slot name="footer"></slot>
     </view>
   </view>


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [X] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [X] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [X] 文档已补充或无须补充
- [X] 代码演示已提供或无须提供
- [X] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在卡片组件中新增条件渲染标题和页脚
	- 添加了带有用户头像、服务到期提醒和交互按钮的卡片示例

- **样式调整**
	- 优化了卡片组件的布局和视觉呈现
	- 调整了标题、内容和子标题的样式设计

- **组件增强**
	- 提升了卡片组件的灵活性，现在可以根据内容动态显示标题和页脚

<!-- end of auto-generated comment: release notes by coderabbit.ai -->