### PR TITLE
fix: 🐛 修复NumberKeyboard组件mode=custom时 title插槽和closeText不显示的问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-number-keyboard/wd-number-keyboard.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-number-keyboard/wd-number-keyboard.vue
@@ -50,6 +50,7 @@ import type { NumberKeyType } from './key/types'
 
 const props = defineProps(numberKeyboardProps)
 const emit = defineEmits(['update:visible', 'input', 'close', 'delete', 'update:modelValue'])
+const slots = defineSlots()
 
 const show = ref(props.visible)
 watch(
@@ -62,11 +63,11 @@ watch(
 const keys = computed(() => (props.mode === 'custom' ? genCustomKeys() : genDefaultKeys()))
 
 const showClose = computed(() => {
-  return props.closeText && props.mode === 'default'
+  return props.closeText
 })
 
 const showTitle = computed(() => {
-  return props.title || showClose.value
+  return props.title || slots.title || showClose.value
 })
 
 /**


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
1. NumberKeyboard在custom情况下无法直接使用title插槽，closeText配置后不生效；
2. 增加title插槽使用判断，去掉只有default情况下才可以配置closeText，让使用者自行选择是否要配置；
3. 不影响原来的使用，能更方便用户配置。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 优化数字键盘组件的插槽和标题显示逻辑
	- 增加了更灵活的内容插入和渲染方式

- **改进**
	- 简化了关闭按钮和标题的显示条件
	- 提供更多自定义内容的可能性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->