### PR TITLE
feat: ✨ MessageBox 增加 showConfirmButton 配置

### DIFF
--- a/docs/component/message-box.md
+++ b/docs/component/message-box.md
@@ -262,6 +262,8 @@ MessageBox.prompt(options)
 | inputPattern         | 当 type 为 prompt 时，输入框正则校验，点击确定按钮时进行校验                    | regex           | -                        | -                | -                |
 | inputValidate        | 当 type 为 prompt 时，输入框校验函数，点击确定按钮时进行校验                    | function        | -                        | -                | -                |
 | inputError           | 当 type 为 prompt 时，输入框检验不通过时的错误提示文案                          | string          | -                        | 输入的数据不合法 | -                |
+| showConfirmButton    | 是否展示确定按钮                                                                    | boolean          | -                        | true             |
+| showCancelButton    | 是否展示取消按钮                                                                    | boolean          | -                        | 当 type 为 confirm 或 prompt 时默认为 true，其它调用类型默认为 false             |
 | confirmButtonText    | 确定按钮文案                                                                    | string          | -                        | 确定             | -                |
 | cancelButtonText     | 取消按钮文案                                                                    | string          | -                        | 取消             | -                |
 | selector             | 指定唯一标识                                                                    | string          | -                        | #wd-message-box  | -                |

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/types.ts
@@ -23,6 +23,10 @@ export type MessageOptions = {
    */
   title?: string
   /**
+   * 是否展示确定按钮
+   */
+  showConfirmButton?: boolean
+  /**
    * 是否展示取消按钮
    */
   showCancelButton?: boolean

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
@@ -35,7 +35,7 @@
           <wd-button v-bind="customCancelProps" v-if="messageState.showCancelButton" @click="toggleModal('cancel')">
             {{ messageState.cancelButtonText || translate('cancel') }}
           </wd-button>
-          <wd-button v-bind="customConfirmProps" @click="toggleModal('confirm')">
+          <wd-button v-bind="customConfirmProps" v-if="messageState.showConfirmButton" @click="toggleModal('confirm')">
             {{ messageState.confirmButtonText || translate('confirm') }}
           </wd-button>
         </view>
@@ -84,6 +84,7 @@ const messageState = reactive<MessageOptionsWithCallBack>({
   msg: '', // 消息内容
   show: false, // 是否显示弹框
   title: '', // 标题
+  showConfirmButton: false, // 是否展示确定按钮
   showCancelButton: false, // 是否展示取消按钮
   closeOnClickModal: true, // 是否支持点击蒙层关闭
   confirmButtonText: '', // 确定按钮文案
@@ -259,6 +260,7 @@ function inputValChange({ value }: { value: string | number }) {
 function reset(option: MessageOptionsWithCallBack) {
   if (option) {
     messageState.title = isDef(option.title) ? option.title : ''
+    messageState.showConfirmButton = isDef(option.showConfirmButton) ? option.showConfirmButton : true
     messageState.showCancelButton = isDef(option.showCancelButton) ? option.showCancelButton : false
     messageState.show = option.show
     messageState.closeOnClickModal = option.closeOnClickModal


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

参考其它UI库，应允许不展示确认按钮，同时完善了showConfirmButton和showCancelButton两个配置项的文档说明。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 为 `MessageBox` 组件添加了 `showConfirmButton` 和 `showCancelButton` 选项
	- 可以更精细地控制确认和取消按钮的显示

- **改进**
	- 增加了消息框按钮的配置灵活性
	- 允许根据使用场景自定义按钮显示状态

<!-- end of auto-generated comment: release notes by coderabbit.ai -->