### PR TITLE
fix: 🐛 修复MessageBox中showCancelButton配置无效问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-message-box/index.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/index.ts
@@ -9,7 +9,7 @@
  */
 import { inject, provide, ref } from 'vue'
 import type { Message, MessageOptions, MessageOptionsWithCallBack, MessageResult, MessageType } from './types'
-import { deepMerge } from '../common/util'
+import { deepMerge, isDef } from '../common/util'
 
 const messageDefaultOptionKey = '__MESSAGE_OPTION__'
 
@@ -42,11 +42,12 @@ export function useMessage(selector: string = ''): Message {
   const createMethod = (type: MessageType) => {
     // 优先级：options->MessageOptions->defaultOptions
     return (options: MessageOptions | string) => {
-      const messageOptions = deepMerge({ type: type }, typeof options === 'string' ? { title: options } : options) as MessageOptions
+      const onlyTitle = typeof options === 'string'
+      const messageOptions = deepMerge({ type: type }, onlyTitle ? { title: options } : options) as MessageOptions
       if (messageOptions.type === 'confirm' || messageOptions.type === 'prompt') {
-        messageOptions.showCancelButton = true
+        messageOptions.showCancelButton = onlyTitle ? true : isDef(options.showCancelButton) ? options.showCancelButton : true
       } else {
-        messageOptions.showCancelButton = false
+        messageOptions.showCancelButton = onlyTitle ? false : isDef(options.showCancelButton) ? options.showCancelButton : false
       }
       return show(messageOptions)
     }


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

没有使用 options中的配置 导致使用者配置了 showCancelButton 无法生效
优先级：options->MessageOptions->defaultOptions

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充