### PR TITLE
feat: ✨ MessageBox 确认按钮增加 `confirmButtonLoading` 属性

### DIFF
--- a/docs/component/message-box.md
+++ b/docs/component/message-box.md
@@ -211,17 +211,12 @@ function beforeConfirmLoading() {
       title: '提示',
       confirmButtonLoading: true,
       beforeConfirm: ({ resolve }) => {
-        try {
-          toast.loading('删除中...')
-          setTimeout(() => {
-            toast.close()
-            resolve(true)
-            toast.success('删除成功')
-          }, 2000)
-        } finally {
-          // 只要调用了 resolve 则会自动停止加载状态
-          resolve()
-        }
+        toast.loading('删除中...')
+        setTimeout(() => {
+          toast.close()
+          resolve(true)
+          toast.success('删除成功')
+        }, 3000)
       }
     })
     .then(() => {})

--- a/docs/component/message-box.md
+++ b/docs/component/message-box.md
@@ -189,6 +189,48 @@ function beforeConfirm() {
 }
 ```
 
+## 确认前置加载<el-tag text style="vertical-align: middle;margin-left:8px;" effect="plain">1.6.2</el-tag>
+
+设置属性 `confirmButtonLoading` 搭配 `beforeConfirm` 函数，在用户选择图片点击确认后，会将确认按钮置为 Loading 状态，并设置禁止点击蒙层关闭，执行 `beforeConfirm` 函数后，接收 { resolve }，开发者可以在确认前进行处理，并通过 `resolve` 函数告知组件是否确定通过，`resolve` 接受 1 个 `boolean` 值，`resolve(true)` 表示选项通过，`resolve(false)` 表示选项不通过，不通过时不会完成确认操作。
+
+```html
+<wd-toast />
+<wd-message-box />
+<wd-button @click="beforeConfirmLoading">beforeConfirmLoading</wd-button>
+```
+
+```typescript
+import { useMessage, useToast } from '@/uni_modules/wot-design-uni'
+const message = useMessage()
+const toast = useToast()
+
+function beforeConfirmLoading() {
+  message
+    .confirm({
+      msg: '是否删除',
+      title: '提示',
+      confirmButtonLoading: true,
+      beforeConfirm: ({ resolve }) => {
+        try {
+          toast.loading('删除中...')
+          setTimeout(() => {
+            toast.close()
+            resolve(true)
+            toast.success('删除成功')
+          }, 2000)
+        } finally {
+          // 只要调用了 resolve 则会自动停止加载状态
+          resolve()
+        }
+      }
+    })
+    .then(() => {})
+    .catch((error) => {
+      console.log(error)
+    })
+}
+```
+
 ## 自定义操作按钮<el-tag text style="vertical-align: middle;margin-left:8px;" effect="plain">1.5.0</el-tag>
 
 可以通过按钮属性 `cancel-button-props` 和 `confirm-button-props` 自定义操作按钮的样式，具体参考 [Button Attributes](/component/button.html#attributes)。
@@ -250,25 +292,26 @@ MessageBox.prompt(options)
 
 ## Options Attributes
 
-| 参数                 | 说明                                                                            | 类型            | 可选值                   | 默认值           | 最低版本         |
-| -------------------- | ------------------------------------------------------------------------------- | --------------- | ------------------------ | ---------------- | ---------------- |
-| title                | 标题                                                                            | string          | -                        | -                | -                |
-| msg                  | 消息文案                                                                        | string          | -                        | -                | -                |
-| type                 | 弹框类型                                                                        | string          | alert / confirm / prompt | alert            | -                |
-| closeOnClickModal    | 是否支持点击蒙层进行关闭，点击蒙层回调传入的 action 为'modal'                   | boolean         | -                        | true             | -                |
-| inputType            | 当 type 为 prompt 时，输入框类型                                                | string          | -                        | text             | -                |
-| inputValue           | 当 type 为 prompt 时，输入框初始值                                              | string / number | -                        | -                | -                |
-| inputPlaceholder     | 当 type 为 prompt 时，输入框 placeholder                                        | string          | -                        | 请输入内容       | -                |
-| inputPattern         | 当 type 为 prompt 时，输入框正则校验，点击确定按钮时进行校验                    | regex           | -                        | -                | -                |
-| inputValidate        | 当 type 为 prompt 时，输入框校验函数，点击确定按钮时进行校验                    | function        | -                        | -                | -                |
-| inputError           | 当 type 为 prompt 时，输入框检验不通过时的错误提示文案                          | string          | -                        | 输入的数据不合法 | -                |
-| confirmButtonText    | 确定按钮文案                                                                    | string          | -                        | 确定             | -                |
-| cancelButtonText     | 取消按钮文案                                                                    | string          | -                        | 取消             | -                |
-| selector             | 指定唯一标识                                                                    | string          | -                        | #wd-message-box  | -                |
-| zIndex               | 弹窗层级                                                                        | number          | -                        | 99               | -                |
-| lazyRender           | 弹层内容懒渲染，触发展示时才渲染内容                                            | boolean         | -                        | true             | -                |
-| cancel-button-props  | 取消按钮的属性，具体参考 [Button Attributes](/component/button.html#attributes) | object          | -                        | -                | 1.5.0 |
-| confirm-button-props | 确定按钮的属性，具体参考 [Button Attributes](/component/button.html#attributes) | object          | -                        | -                | 1.5.0 |
+| 参数                 | 说明                                                                            | 类型            | 可选值                   | 默认值           | 最低版本 |
+| -------------------- | ------------------------------------------------------------------------------- | --------------- | ------------------------ | ---------------- | -------- |
+| title                | 标题                                                                            | string          | -                        | -                | -        |
+| msg                  | 消息文案                                                                        | string          | -                        | -                | -        |
+| type                 | 弹框类型                                                                        | string          | alert / confirm / prompt | alert            | -        |
+| closeOnClickModal    | 是否支持点击蒙层进行关闭，点击蒙层回调传入的 action 为'modal'                   | boolean         | -                        | true             | -        |
+| inputType            | 当 type 为 prompt 时，输入框类型                                                | string          | -                        | text             | -        |
+| inputValue           | 当 type 为 prompt 时，输入框初始值                                              | string / number | -                        | -                | -        |
+| inputPlaceholder     | 当 type 为 prompt 时，输入框 placeholder                                        | string          | -                        | 请输入内容       | -        |
+| inputPattern         | 当 type 为 prompt 时，输入框正则校验，点击确定按钮时进行校验                    | regex           | -                        | -                | -        |
+| inputValidate        | 当 type 为 prompt 时，输入框校验函数，点击确定按钮时进行校验                    | function        | -                        | -                | -        |
+| inputError           | 当 type 为 prompt 时，输入框检验不通过时的错误提示文案                          | string          | -                        | 输入的数据不合法 | -        |
+| confirmButtonText    | 确定按钮文案                                                                    | string          | -                        | 确定             | -        |
+| cancelButtonText     | 取消按钮文案                                                                    | string          | -                        | 取消             | -        |
+| selector             | 指定唯一标识                                                                    | string          | -                        | #wd-message-box  | -        |
+| zIndex               | 弹窗层级                                                                        | number          | -                        | 99               | -        |
+| lazyRender           | 弹层内容懒渲染，触发展示时才渲染内容                                            | boolean         | -                        | true             | -        |
+| cancel-button-props  | 取消按钮的属性，具体参考 [Button Attributes](/component/button.html#attributes) | object          | -                        | -                | 1.5.0    |
+| confirm-button-props | 确定按钮的属性，具体参考 [Button Attributes](/component/button.html#attributes) | object          | -                        | -                | 1.5.0    |
+| confirmButtonLoading | 确认按钮是否加载，当设置 beforeConfirm 时才会生效                               | boolean         | -                        | false            | 1.6.2    |
 
 ## 外部样式类
 

--- a/src/pages/messageBox/Index.vue
+++ b/src/pages/messageBox/Index.vue
@@ -120,16 +120,12 @@ function beforeConfirmLoading() {
       title: '提示',
       confirmButtonLoading: true,
       beforeConfirm: ({ resolve }) => {
-        try {
-          toast.loading('删除中...')
-          setTimeout(() => {
-            toast.close()
-            resolve(true)
-            toast.success('删除成功')
-          }, 3000)
-        } finally {
-          resolve()
-        }
+        toast.loading('删除中...')
+        setTimeout(() => {
+          toast.close()
+          resolve(true)
+          toast.success('删除成功')
+        }, 3000)
       }
     })
     .then(() => {})

--- a/src/pages/messageBox/Index.vue
+++ b/src/pages/messageBox/Index.vue
@@ -33,6 +33,10 @@
         <wd-button @click="beforeConfirm">beforeConfirm</wd-button>
       </demo-block>
 
+      <demo-block title="使用confirmButtonLoading搭配beforeConfirm钩子，在弹框确认前，可以进行加载操作">
+        <wd-button @click="beforeConfirmLoading">beforeConfirm</wd-button>
+      </demo-block>
+
       <demo-block title="通过button-props自定义按钮">
         <wd-button @click="withButtonProps">withButtonProps</wd-button>
       </demo-block>
@@ -101,6 +105,31 @@ function beforeConfirm() {
           resolve(true)
           toast.success('删除成功')
         }, 3000)
+      }
+    })
+    .then(() => {})
+    .catch((error) => {
+      console.log(error)
+    })
+}
+
+function beforeConfirmLoading() {
+  message
+    .confirm({
+      msg: '是否删除',
+      title: '提示',
+      confirmButtonLoading: true,
+      beforeConfirm: ({ resolve }) => {
+        try {
+          toast.loading('删除中...')
+          setTimeout(() => {
+            toast.close()
+            resolve(true)
+            toast.success('删除成功')
+          }, 3000)
+        } finally {
+          resolve()
+        }
       }
     })
     .then(() => {})

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/types.ts
@@ -14,7 +14,7 @@ import { type InputSize, type InputType } from '../wd-input/types'
 export type MessageType = 'alert' | 'confirm' | 'prompt'
 
 export type MessageBeforeConfirmOption = {
-  resolve: (isPass: boolean) => void
+  resolve: (isPass?: boolean) => void
 }
 
 export type MessageOptions = {
@@ -98,6 +98,10 @@ export type MessageOptions = {
    * 确认按钮Props
    */
   confirmButtonProps?: Partial<ButtonProps>
+  /**
+   * 确认按钮加载
+   */
+  confirmButtonLoading?: boolean
 }
 
 export type MessageOptionsWithCallBack = MessageOptions & {

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
@@ -35,7 +35,7 @@
           <wd-button v-bind="customCancelProps" v-if="messageState.showCancelButton" @click="toggleModal('cancel')">
             {{ messageState.cancelButtonText || translate('cancel') }}
           </wd-button>
-          <wd-button v-bind="customConfirmProps" @click="toggleModal('confirm')">
+          <wd-button v-bind="customConfirmProps" :loading="messageState.confirmButtonLoading" @click="toggleModal('confirm')">
             {{ messageState.confirmButtonText || translate('confirm') }}
           </wd-button>
         </view>
@@ -95,7 +95,8 @@ const messageState = reactive<MessageOptionsWithCallBack>({
   inputError: '', // 输入框错误提示文案
   showErr: false, // 是否显示错误提示
   zIndex: 99, // 弹窗层级
-  lazyRender: true // 弹层内容懒渲染
+  lazyRender: true, // 弹层内容懒渲染
+  confirmButtonLoading: false // 确认按钮加载
 })
 
 /**
@@ -164,9 +165,19 @@ function toggleModal(action: 'confirm' | 'cancel' | 'modal') {
   switch (action) {
     case 'confirm':
       if (messageState.beforeConfirm) {
+        const localConfirmButtonText = messageState.confirmButtonText
+        const localShowCancelButton = messageState.showCancelButton
+        const localCloseOnClickModal = messageState.closeOnClickModal
+        messageState.confirmButtonLoading = true
+        messageState.showCancelButton = false
+        messageState.confirmButtonText = translate('loading')
         messageState.beforeConfirm({
           resolve: (isPass) => {
-            if (isPass) {
+            if (isPass === null || isPass === undefined || isPass) {
+              messageState.confirmButtonLoading = false
+              messageState.showCancelButton = localShowCancelButton
+              messageState.confirmButtonText = localConfirmButtonText
+              messageState.closeOnClickModal = localCloseOnClickModal
               handleConfirm({
                 action: action,
                 value: messageState.inputValue
@@ -281,6 +292,7 @@ function reset(option: MessageOptionsWithCallBack) {
     messageState.lazyRender = option.lazyRender
     messageState.confirmButtonProps = option.confirmButtonProps
     messageState.cancelButtonProps = option.cancelButtonProps
+    messageState.confirmButtonLoading = option.confirmButtonLoading
   }
 }
 </script>

--- a/src/uni_modules/wot-design-uni/locale/lang/ar-SA.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/ar-SA.ts
@@ -71,7 +71,8 @@ export default {
     inputPlaceholder: 'الرجاء إدخال المعلومات',
     confirm: 'تأكيد',
     cancel: 'إلغاء',
-    inputNoValidate: 'الرجاء التأكد من إدخال المعلومات الصحيحة'
+    inputNoValidate: 'الرجاء التأكد من إدخال المعلومات الصحيحة',
+    loading: 'جارٍ التحميل...'
   },
   numberKeyboard: {
     confirm: 'إنهاء'

--- a/src/uni_modules/wot-design-uni/locale/lang/de-DE.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/de-DE.ts
@@ -71,7 +71,8 @@ export default {
     inputPlaceholder: 'Bitte geben Sie Informationen ein',
     confirm: 'OK',
     cancel: 'Stornieren',
-    inputNoValidate: 'Bitte geben Sie gültige Informationen ein'
+    inputNoValidate: 'Bitte geben Sie gültige Informationen ein',
+    loading: 'Wird geladen...'
   },
   numberKeyboard: {
     confirm: 'OK'

--- a/src/uni_modules/wot-design-uni/locale/lang/en-US.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/en-US.ts
@@ -71,7 +71,8 @@ export default {
     inputPlaceholder: 'Please input information',
     confirm: 'OK',
     cancel: 'Cancel',
-    inputNoValidate: 'Please ensure you input correct information'
+    inputNoValidate: 'Please ensure you input correct information',
+    loading: 'Loading...'
   },
   numberKeyboard: {
     confirm: 'done'

--- a/src/uni_modules/wot-design-uni/locale/lang/es-ES.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/es-ES.ts
@@ -67,7 +67,8 @@ export default {
     inputPlaceholder: 'Por favor ingrese información',
     confirm: 'Confirmar',
     cancel: 'Cancelar',
-    inputNoValidate: 'Por favor ingrese información válida'
+    inputNoValidate: 'Por favor ingrese información válida',
+    loading: 'Cargando...'
   },
   numberKeyboard: {
     confirm: 'Confirmar'

--- a/src/uni_modules/wot-design-uni/locale/lang/fr-FR.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/fr-FR.ts
@@ -67,7 +67,8 @@ export default {
     inputPlaceholder: 'Veuillez entrer des informations',
     confirm: 'Confirmer',
     cancel: 'Annuler',
-    inputNoValidate: 'Veuillez entrer des informations valides'
+    inputNoValidate: 'Veuillez entrer des informations valides',
+    loading: 'Chargement...'
   },
   numberKeyboard: {
     confirm: 'Confirmer'

--- a/src/uni_modules/wot-design-uni/locale/lang/ja-JP.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/ja-JP.ts
@@ -67,7 +67,8 @@ export default {
     inputPlaceholder: '入力してください',
     confirm: '確認',
     cancel: 'キャンセル',
-    inputNoValidate: '無効なデータが入力されました'
+    inputNoValidate: '無効なデータが入力されました',
+    loading: '読み込み中...'
   },
   numberKeyboard: {
     confirm: '完了'

--- a/src/uni_modules/wot-design-uni/locale/lang/ko-KR.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/ko-KR.ts
@@ -67,7 +67,8 @@ export default {
     inputPlaceholder: '정보를 입력해주세요',
     confirm: '확인',
     cancel: '취소',
-    inputNoValidate: '유효한 정보를 입력해주세요'
+    inputNoValidate: '유효한 정보를 입력해주세요',
+    loading: '로딩 중...'
   },
   numberKeyboard: {
     confirm: '확인'

--- a/src/uni_modules/wot-design-uni/locale/lang/pt-PT.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/pt-PT.ts
@@ -67,7 +67,8 @@ export default {
     inputPlaceholder: 'Por favor insira',
     confirm: 'Confirmar',
     cancel: 'Cancelar',
-    inputNoValidate: 'Dados inseridos inválidos'
+    inputNoValidate: 'Dados inseridos inválidos',
+    loading: 'Carregando...'
   },
   numberKeyboard: {
     confirm: 'Concluir'

--- a/src/uni_modules/wot-design-uni/locale/lang/ru-RU.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/ru-RU.ts
@@ -67,7 +67,8 @@ export default {
     inputPlaceholder: 'Введите, пожалуйста',
     confirm: 'Ок',
     cancel: 'Отмена',
-    inputNoValidate: 'Неверные данные'
+    inputNoValidate: 'Неверные данные',
+    loading: 'Загружается...'
   },
   numberKeyboard: {
     confirm: 'Готово'

--- a/src/uni_modules/wot-design-uni/locale/lang/th-TH.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/th-TH.ts
@@ -71,7 +71,8 @@ export default {
     inputPlaceholder: 'กรุณาใส่ข้อมูล',
     confirm: 'ยืนยัน',
     cancel: 'ยกเลิก',
-    inputNoValidate: 'กรุณาตรวจสอบว่าคุณได้ใส่ข้อมูลที่ถูกต้อง'
+    inputNoValidate: 'กรุณาตรวจสอบว่าคุณได้ใส่ข้อมูลที่ถูกต้อง',
+    loading: 'กำลังโหลด...'
   },
   numberKeyboard: {
     confir: 'ตกลง'

--- a/src/uni_modules/wot-design-uni/locale/lang/tr-TR.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/tr-TR.ts
@@ -67,7 +67,8 @@ export default {
     inputPlaceholder: 'Lütfen girin',
     confirm: 'Tamam',
     cancel: 'İptal',
-    inputNoValidate: 'Girilen veriler geçerli değil'
+    inputNoValidate: 'Girilen veriler geçerli değil',
+    loading: 'Yükleniyor...'
   },
   numberKeyboard: {
     confirm: 'Tamam'

--- a/src/uni_modules/wot-design-uni/locale/lang/vi-VN.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/vi-VN.ts
@@ -43,7 +43,13 @@ export default {
     cancel: 'Hủy bỏ'
   },
   loadmore: { loading: 'Đang tải...', finished: 'Đã tải xong', error: 'Tải thất bại', retry: 'Nhấp để thử lại' },
-  messageBox: { inputPlaceholder: 'Vui lòng nhập', confirm: 'Xác nhận', cancel: 'Hủy bỏ', inputNoValidate: 'Dữ liệu không hợp lệ' },
+  messageBox: {
+    inputPlaceholder: 'Vui lòng nhập',
+    confirm: 'Xác nhận',
+    cancel: 'Hủy bỏ',
+    inputNoValidate: 'Dữ liệu không hợp lệ',
+    loading: 'Đang tải...'
+  },
   numberKeyboard: { confirm: 'Hoàn thành' },
   pagination: {
     prev: 'Trang trước',

--- a/src/uni_modules/wot-design-uni/locale/lang/zh-CN.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/zh-CN.ts
@@ -67,7 +67,8 @@ export default {
     inputPlaceholder: '请输入',
     confirm: '确定',
     cancel: '取消',
-    inputNoValidate: '输入的数据不合法'
+    inputNoValidate: '输入的数据不合法',
+    loading: '加载中...'
   },
   numberKeyboard: {
     confirm: '完成'

--- a/src/uni_modules/wot-design-uni/locale/lang/zh-HK.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/zh-HK.ts
@@ -36,7 +36,7 @@ export default {
   colPicker: { title: '請選擇', placeholder: '請選擇', select: '請選擇' },
   datetimePicker: { start: '開始時間', end: '結束時間', to: '至', placeholder: '請選擇', confirm: '完成', cancel: '取消' },
   loadmore: { loading: '正在努力加載中...', finished: '已加載完畢', error: '加載失敗', retry: '點擊重試' },
-  messageBox: { inputPlaceholder: '請輸入', confirm: '確定', cancel: '取消', inputNoValidate: '輸入的數據不合法' },
+  messageBox: { inputPlaceholder: '請輸入', confirm: '確定', cancel: '取消', inputNoValidate: '輸入的數據不合法', loading: '加載中...' },
   numberKeyboard: { confirm: '完成' },
   pagination: {
     prev: '上一頁',

--- a/src/uni_modules/wot-design-uni/locale/lang/zh-TW.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/zh-TW.ts
@@ -36,7 +36,7 @@ export default {
   colPicker: { title: '請選擇', placeholder: '請選擇', select: '請選擇' },
   datetimePicker: { start: '開始時間', end: '結束時間', to: '至', placeholder: '請選擇', confirm: '完成', cancel: '取消' },
   loadmore: { loading: '正在努力加載中...', finished: '已加載完畢', error: '加載失敗', retry: '點擊重試' },
-  messageBox: { inputPlaceholder: '請輸入', confirm: '確定', cancel: '取消', inputNoValidate: '輸入的數據不合法' },
+  messageBox: { inputPlaceholder: '請輸入', confirm: '確定', cancel: '取消', inputNoValidate: '輸入的數據不合法', loading: '加載中...' },
   numberKeyboard: { confirm: '完成' },
   pagination: {
     prev: '上一頁',


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [x] 站点、文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [x] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无。

### 💡 需求背景和解决方案

当我们使用 `MessageBox` 组件做一些确认提示的时候，因要请求API接口，如果接口未配置 Loading，并且接口延迟比较高，会导致用户立即点击 `取消` 按钮关闭弹窗，会使后续流程或逻辑错乱。
所以 `MessageBox` 组件增加 `confirmButtonLoading` 属性，当设置为 `true` 的时候，会自动隐藏 `取消` 按钮，并且禁止点击蒙层关闭。


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 为消息框添加了确认按钮加载状态功能
	- 支持在确认前显示加载状态，防止用户重复点击

- **本地化**
	- 为多语言版本添加了加载状态文案，包括中文、英文、日文等多个语言

- **文档**
	- 更新了文档，详细说明了`confirmButtonLoading`属性的使用方法

- **版本**
	- 最低支持版本：1.6.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->