### PR TITLE
fix: 🐛 修复微信小程序警告 `wx.getSystemInfoSync is deprecated. `

### DIFF
--- a/docs/component/floating-panel.md
+++ b/docs/component/floating-panel.md
@@ -42,7 +42,7 @@ const handleHeightChange = ({ height }: { height: number }) => {
 }
 
 onLoad(() => {
-  windowHeight.value = uni.getSystemInfoSync().windowHeight
+  windowHeight.value = uni.getWindowInfo().windowHeight
   anchors.value = [100, Math.round(0.4 * windowHeight.value), Math.round(0.7 * windowHeight.value)]
   height.value = anchors.value[1]
 })
@@ -78,30 +78,30 @@ onLoad(() => {
 
 ## Attributes
 
-| 参数                | 说明                                        | 类型     | 可选值 | 默认值                      | 最低版本         |
-| ------------------- | ------------------------------------------- | -------- | ------ | --------------------------- | ---------------- |
-| v-model:height      | 当前面板的显示高度                          | number   | -      | `0`                         | 1.3.12 |
-| anchors             | 设置自定义锚点, 单位 `px`                   | number[] | -      | `[100, windowHeight * 0.6]` | 1.3.12 |
-| duration            | 动画时长，单位`ms`，设置为 `0` 可以禁用动画 | number   | -      | `300`                       | 1.3.12 |
-| contentDraggable    | 允许拖拽内容容器                            | boolean  | -      | `true`                      | 1.3.12 |
-| safeAreaInsetBottom | 是否开启底部安全区适配                      | boolean  | -      | `false`                     | 1.3.12 |
-| showScrollbar       | 是否开启滚动条                              | boolean  | -      | `true`                      | 1.3.12 |
+| 参数                | 说明                                        | 类型     | 可选值 | 默认值                      | 最低版本 |
+| ------------------- | ------------------------------------------- | -------- | ------ | --------------------------- | -------- |
+| v-model:height      | 当前面板的显示高度                          | number   | -      | `0`                         | 1.3.12   |
+| anchors             | 设置自定义锚点, 单位 `px`                   | number[] | -      | `[100, windowHeight * 0.6]` | 1.3.12   |
+| duration            | 动画时长，单位`ms`，设置为 `0` 可以禁用动画 | number   | -      | `300`                       | 1.3.12   |
+| contentDraggable    | 允许拖拽内容容器                            | boolean  | -      | `true`                      | 1.3.12   |
+| safeAreaInsetBottom | 是否开启底部安全区适配                      | boolean  | -      | `false`                     | 1.3.12   |
+| showScrollbar       | 是否开启滚动条                              | boolean  | -      | `true`                      | 1.3.12   |
 
 ## Slots
 
-| 名称 | 说明     | 最低版本         |
-| ---- | -------- | ---------------- |
-| —    | 默认插槽 | 1.3.12 |
+| 名称 | 说明     | 最低版本 |
+| ---- | -------- | -------- |
+| —    | 默认插槽 | 1.3.12   |
 
 ## Events
 
-| 方法名       | 说明                             | 参数                 | 最低版本         |
-| ------------ | -------------------------------- | -------------------- | ---------------- |
-| heightChange | 面板显示高度改变且结束拖动后触发 | `{ height: number }` | 1.3.12 |
+| 方法名       | 说明                             | 参数                 | 最低版本 |
+| ------------ | -------------------------------- | -------------------- | -------- |
+| heightChange | 面板显示高度改变且结束拖动后触发 | `{ height: number }` | 1.3.12   |
 
 ## 外部样式类
 
-| 类名         | 说明         | 最低版本         |
-| ------------ | ------------ | ---------------- |
-| custom-class | 根节点样式类 | 1.3.12 |
-| custom-style | 根节点样式   | 1.3.12 |
+| 类名         | 说明         | 最低版本 |
+| ------------ | ------------ | -------- |
+| custom-class | 根节点样式类 | 1.3.12   |
+| custom-style | 根节点样式   | 1.3.12   |

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,8 +17,8 @@ onThemeChange((option) => {
 })
 
 onLaunch(() => {
-  const systemInfo = uni.getSystemInfoSync()
-  darkMode.setDark(systemInfo.theme === 'dark')
+  const appBaseInfo = uni.getAppBaseInfo()
+  darkMode.setDark(appBaseInfo.hostTheme === 'dark')
 
   // #ifdef H5
 

--- a/src/pages/floatingPanel/Index.vue
+++ b/src/pages/floatingPanel/Index.vue
@@ -45,7 +45,7 @@ const handleHeightChange = ({ height }: { height: number }) => {
 }
 
 onLoad(() => {
-  windowHeight.value = uni.getSystemInfoSync().windowHeight
+  windowHeight.value = uni.getWindowInfo().windowHeight
   anchors.value = [100, Math.round(0.4 * windowHeight.value), Math.round(0.7 * windowHeight.value)]
   height.value = anchors.value[1]
 })

--- a/src/uni_modules/wot-design-uni/components/wd-circle/wd-circle.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-circle/wd-circle.vue
@@ -114,7 +114,7 @@ watch(
 )
 
 onBeforeMount(() => {
-  pixelRatio.value = uni.getSystemInfoSync().pixelRatio
+  pixelRatio.value = uni.getDeviceInfo().devicePixelRatio
 })
 
 onMounted(() => {

--- a/src/uni_modules/wot-design-uni/components/wd-drop-menu/wd-drop-menu.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-drop-menu/wd-drop-menu.vue
@@ -65,7 +65,7 @@ watch(
 )
 
 onBeforeMount(() => {
-  windowHeight.value = uni.getSystemInfoSync().windowHeight
+  windowHeight.value = uni.getWindowInfo().windowHeight
 })
 
 function noop(event: Event) {

--- a/src/uni_modules/wot-design-uni/components/wd-fab/wd-fab.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-fab/wd-fab.vue
@@ -103,7 +103,7 @@ const bounding = reactive({
 })
 
 async function getBounding() {
-  const sysInfo = uni.getSystemInfoSync()
+  const winInfo = uni.getWindowInfo()
   try {
     const trigerInfo = await getRect('#trigger', false, proxy)
     fabSize.width = trigerInfo.width || 56
@@ -113,9 +113,9 @@ async function getBounding() {
   }
 
   const { top = 16, left = 16, right = 16, bottom = 16 } = props.gap
-  screen.width = sysInfo.windowWidth
-  screen.height = isH5 ? sysInfo.windowTop + sysInfo.windowHeight : sysInfo.windowHeight
-  bounding.minTop = isH5 ? sysInfo.windowTop + top : top
+  screen.width = winInfo.windowWidth
+  screen.height = isH5 ? winInfo.windowTop + winInfo.windowHeight : winInfo.windowHeight
+  bounding.minTop = isH5 ? winInfo.windowTop + top : top
   bounding.minLeft = left
   bounding.maxLeft = screen.width - fabSize.width - right
   bounding.maxTop = screen.height - fabSize.height - bottom

--- a/src/uni_modules/wot-design-uni/components/wd-floating-panel/wd-floating-panel.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-floating-panel/wd-floating-panel.vue
@@ -130,7 +130,7 @@ watch(
 )
 
 onBeforeMount(() => {
-  const { windowHeight: _windowHeight } = uni.getSystemInfoSync()
+  const { windowHeight: _windowHeight } = uni.getWindowInfo()
   windowHeight.value = _windowHeight
 })
 </script>

--- a/src/uni_modules/wot-design-uni/components/wd-img-cropper/wd-img-cropper.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-img-cropper/wd-img-cropper.vue
@@ -130,11 +130,12 @@ const imgScale = ref<number>(1)
 // imgWidth: null,
 // imgHeight: null,
 // 图片中心轴点距左的距离
-const imgLeft = ref<number>(uni.getSystemInfoSync().windowWidth / 2)
-const imgTop = ref<number>((uni.getSystemInfoSync().windowHeight / 2) * TOP_PERCENT)
+const imgLeft = ref<number>(uni.getWindowInfo().windowWidth / 2)
+const imgTop = ref<number>((uni.getWindowInfo().windowHeight / 2) * TOP_PERCENT)
 
 const imgInfo = ref<UniApp.GetImageInfoSuccessData | null>(null)
-const info = ref<UniApp.GetSystemInfoResult>(uni.getSystemInfoSync())
+const windowInfo = ref<UniApp.GetWindowInfoResult>(uni.getWindowInfo())
+const deviceInfo = ref<UniApp.GetDeviceInfoResult>(uni.getDeviceInfo())
 
 // 是否移动中设置 同时控制背景颜色是否高亮
 const IS_TOUCH_END = ref<boolean>(true)
@@ -162,11 +163,12 @@ watch(
     if (newValue) {
       INIT_IMGWIDTH = props.imgWidth
       INIT_IMGHEIGHT = props.imgHeight
-      info.value = uni.getSystemInfoSync()
-      const tempCutSize = info.value.windowWidth - offset.value * 2
+      windowInfo.value = uni.getWindowInfo()
+      deviceInfo.value = uni.getDeviceInfo()
+      const tempCutSize = windowInfo.value.windowWidth - offset.value * 2
       cutWidth.value = tempCutSize
       cutHeight.value = tempCutSize
-      cutTop.value = (info.value.windowHeight * TOP_PERCENT - tempCutSize) / 2
+      cutTop.value = (windowInfo.value.windowHeight * TOP_PERCENT - tempCutSize) / 2
       cutLeft.value = offset.value
       canvasScale.value = props.exportScale
       canvasHeight.value = tempCutSize
@@ -276,7 +278,7 @@ function setRoate(angle: number) {
  * 初始化图片的大小和角度以及距离
  */
 function resetImg() {
-  const { windowHeight, windowWidth } = uni.getSystemInfoSync()
+  const { windowHeight, windowWidth } = uni.getWindowInfo()
   imgScale.value = 1
   imgAngle.value = 0
   imgLeft.value = windowWidth / 2
@@ -357,7 +359,7 @@ function initImageSize() {
   // 处理宽高特殊单位 %>px
   if (INIT_IMGWIDTH && typeof INIT_IMGWIDTH === 'string' && INIT_IMGWIDTH.indexOf('%') !== -1) {
     const width: string = INIT_IMGWIDTH.replace('%', '')
-    INIT_IMGWIDTH = (info.value.windowWidth / 100) * Number(width)
+    INIT_IMGWIDTH = (windowInfo.value.windowWidth / 100) * Number(width)
     picWidth.value = INIT_IMGWIDTH
   } else if (INIT_IMGWIDTH && typeof INIT_IMGWIDTH === 'number') {
     picWidth.value = INIT_IMGWIDTH
@@ -365,7 +367,7 @@ function initImageSize() {
   if (INIT_IMGHEIGHT && typeof INIT_IMGHEIGHT === 'string' && INIT_IMGHEIGHT.indexOf('%') !== -1) {
     const height = (props.imgHeight as string).replace('%', '')
     // INIT_IMGHEIGHT = this.data.imgHeight = (info.value.windowHeight / 100) * Number(height)
-    INIT_IMGHEIGHT = (info.value.windowHeight / 100) * Number(height)
+    INIT_IMGHEIGHT = (windowInfo.value.windowHeight / 100) * Number(height)
     picWidth.value = INIT_IMGHEIGHT
   } else if (INIT_IMGHEIGHT && typeof INIT_IMGHEIGHT === 'number') {
     picWidth.value = Number(INIT_IMGWIDTH)
@@ -435,7 +437,7 @@ function detectImgScaleIsEdge() {
  *  节流
  */
 function throttle() {
-  if (info.value.platform === 'android') {
+  if (deviceInfo.value.platform === 'android') {
     MOVE_THROTTLE && clearTimeout(MOVE_THROTTLE)
     MOVE_THROTTLE = setTimeout(() => {
       MOVE_THROTTLE_FLAG = true

--- a/src/uni_modules/wot-design-uni/components/wd-navbar/wd-navbar.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-navbar/wd-navbar.vue
@@ -52,7 +52,7 @@ const emit = defineEmits(['click-left', 'click-right'])
 
 const height = ref<number | ''>('') // 占位高度
 
-const { statusBarHeight } = uni.getSystemInfoSync()
+const { statusBarHeight } = uni.getWindowInfo()
 
 watch(
   [() => props.fixed, () => props.placeholder],

--- a/src/uni_modules/wot-design-uni/components/wd-popup/wd-popup.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-popup/wd-popup.vue
@@ -100,7 +100,7 @@ const rootClass = computed(() => {
 
 onBeforeMount(() => {
   if (props.safeAreaInsetBottom) {
-    const { safeArea, screenHeight, safeAreaInsets } = uni.getSystemInfoSync()
+    const { safeArea, screenHeight, safeAreaInsets } = uni.getWindowInfo()
 
     if (safeArea) {
       // #ifdef MP-WEIXIN

--- a/src/uni_modules/wot-design-uni/components/wd-signature/wd-signature.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-signature/wd-signature.vue
@@ -169,7 +169,7 @@ onMounted(() => {
 
 onBeforeMount(() => {
   // #ifdef MP
-  pixelRatio.value = uni.getSystemInfoSync().pixelRatio
+  pixelRatio.value = uni.getDeviceInfo().devicePixelRatio
   // #endif
 })
 

--- a/src/uni_modules/wot-design-uni/components/wd-watermark/wd-watermark.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-watermark/wd-watermark.vue
@@ -48,7 +48,7 @@ watch(
 const canvasId = ref<string>(`water${uuid()}`) // canvas 组件的唯一标识符
 const waterMarkUrl = ref<string>('') // canvas生成base64水印
 const canvasOffScreenable = ref<boolean>(uni.canIUse('createOffscreenCanvas') && Boolean(uni.createOffscreenCanvas)) // 是否可以使用离屏canvas
-const pixelRatio = ref<number>(uni.getSystemInfoSync().pixelRatio) // 像素比
+const pixelRatio = ref<number>(uni.getDeviceInfo().devicePixelRatio) // 像素比
 const canvasHeight = ref<number>((props.height + props.gutterY) * pixelRatio.value) // canvas画布高度
 const canvasWidth = ref<number>((props.width + props.gutterX) * pixelRatio.value) // canvas画布宽度
 const showCanvas = ref<boolean>(true) // 是否展示canvas


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

无.

### 💡 需求背景和解决方案

解决微信小程序下，控制台报警告 `wx.getSystemInfoSync is deprecated. ` 的问题。
全部采用对应最新的 API 调用。


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 无新功能

- **性能优化**
	- 更新了多个组件中系统信息获取方法，使用更新的 `uni.getWindowInfo()` 和 `uni.getDeviceInfo()` 替代 `uni.getSystemInfoSync()`
	- 优化了窗口高度、像素比和设备信息的获取方式

- **文档更新**
	- 调整了浮动面板文档中的属性、插槽、事件和外部样式类表格的格式，提高了文档的可读性

- **修复**
	- 修复了应用深色模式设置的获取方法，现在使用 `uni.getAppBaseInfo()` 获取主题信息

总体而言，这些更改主要集中在系统信息获取方法的更新和文档格式的优化，以提高应用的兼容性和可读性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->