### PR TITLE
fix: 🐛 修复 InputNumber 微信小程序设置了precision后无法输入小数点的问题

### DIFF
--- a/src/pages/inputNumber/Index.vue
+++ b/src/pages/inputNumber/Index.vue
@@ -22,7 +22,7 @@
       </view>
     </demo-block>
     <demo-block title="设置小数精度">
-      <wd-input-number v-model="value6" @change="handleChange6" :precision="2" :step="0.1" />
+      <wd-input-number v-model="value6" @change="handleChange6" :precision="1" :step="0.1" />
     </demo-block>
     <demo-block title="输入严格为步数的倍数">
       <wd-input-number v-model="value7" @change="handleChange7" step-strictly :step="2" />
@@ -49,7 +49,7 @@ const value2 = ref<number>(1)
 const value3 = ref<number>(1)
 const value4 = ref<number>(2)
 const value5 = ref<number>(1)
-const value6 = ref<string>('1.205')
+const value6 = ref<string>('1.2')
 const value7 = ref<number>(1)
 const value8 = ref<number>(2)
 const value9 = ref<string>('')

--- a/src/uni_modules/wot-design-uni/components/wd-input-number/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-input-number/types.ts
@@ -1,7 +1,7 @@
 /*
  * @Author: weisheng
  * @Date: 2024-03-15 20:40:34
- * @LastEditTime: 2025-02-11 18:38:54
+ * @LastEditTime: 2025-02-19 12:47:54
  * @LastEditors: weisheng
  * @Description:
  * @FilePath: /wot-design-uni/src/uni_modules/wot-design-uni/components/wd-input-number/types.ts
@@ -10,7 +10,26 @@
 import type { PropType } from 'vue'
 import { baseProps, makeBooleanProp, makeNumberProp, makeNumericProp, makeRequiredProp, makeStringProp, numericProp } from '../common/props'
 
+/**
+ * 输入框值变化前的回调函数类型定义
+ * @param value 输入框的新值
+ * @returns 返回布尔值或Promise<boolean>，用于控制是否允许值的变化
+ */
 export type InputNumberBeforeChange = (value: number | string) => boolean | Promise<boolean>
+
+/**
+ * 输入数字组件事件类型枚举
+ * Input: 用户输入事件
+ * Blur: 失焦事件
+ * Watch: 监听值变化事件
+ * Button: 按钮点击事件
+ */
+export enum InputNumberEventType {
+  Input = 'input',
+  Blur = 'blur',
+  Watch = 'watch',
+  Button = 'button'
+}
 
 export const inputNumberProps = {
   ...baseProps,


### PR DESCRIPTION
✅ Closes: #878

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
#878

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
`input-number`在更新`modelValue`时，会对绑定值进行格式化，造成例如`1.`被格式化成`1`的现象。估在允许输入小数的场景下，对有且仅在末尾有一个小数点的数字直接更新，不进行格式化。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 更新了数字输入组件的精度设置，默认值与显示精度调整为一位小数。
  - 加强了事件处理逻辑，以便更好地区分不同的交互场景，提升输入体验。

- **重构**
  - 优化了数值更新与验证流程，使输入响应更精准、流畅。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->