### PR TITLE
fix(wd-drop-menu-item): 修复有选项值为空字符串时导致新值错误并触发组件内部警告的问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-drop-menu-item/wd-drop-menu-item.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-drop-menu-item/wd-drop-menu-item.vue
@@ -128,9 +128,10 @@ function choose(index: number) {
   if (props.disabled) return
   const { valueKey } = props
   const item = props.options[index]
-  emit('update:modelValue', item[valueKey] !== '' && item[valueKey] !== undefined ? item[valueKey] : item)
+  const newValue = item[valueKey] !== undefined ? item[valueKey] : item
+  emit('update:modelValue', newValue)
   emit('change', {
-    value: item[valueKey] !== '' && item[valueKey] !== undefined ? item[valueKey] : item,
+    value: newValue,
     selectedItem: item
   })
   close()


### PR DESCRIPTION

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

当有一个选项对象的值为空字符串 `''` 时，更新了整个选项对象作为新值，这样会导致业务代码逻辑错误，同时对象类型的值会导致组件内部抛出警告信息 `'[wot-design] warning(wd-drop-menu-item): the type of value should be a number or a string.'`

实际场景中，空字符串很多时候在业务代码中是一个合法的选项值，比如一个选项列表是这样：

```js
// 当值为空字符时，表示选择全部状态
const options = [
  { label: '全部状态', value: '' },
  { label: '成功', value: 'success' },
  { label: '失败', value: 'failed' },
]
```

所以，修改为允许空字符串作为合法的选项值用于更新 modelValue 的值。

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
  - 简化了下拉菜单项的值更新逻辑，直接使用默认值处理选项变更，提高了操作的一致性和稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->