### PR TITLE
feat(message-box): 优化 message-box

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-message-box/index.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/index.ts
@@ -59,9 +59,11 @@ export function useMessage(selector: string = ''): Message {
       messageOption.value = deepMerge(options, {
         show: true,
         success: (res: MessageResult) => {
+          close()
           resolve(res)
         },
         fail: (res: MessageResult) => {
+          close()
           reject(res)
         }
       })


### PR DESCRIPTION
message-box 点击后只是页面关闭并没有将 options 中的 show 置为 false，配合 layouts 使用全局 message-box 时，切换页面可能会显示上一次的 message-box 内容

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
![ae9248f7-10ef-4ee8-8f82-7be2881db8a8](https://github.com/user-attachments/assets/fd66a735-9510-4e22-962a-d814559b6fcd)
![PixPin_2025-03-10_10-47-18](https://github.com/user-attachments/assets/cbc45608-b6c5-4fe1-9bc4-256c220385cb)



### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 调整了消息提示框的关闭逻辑，确保在操作成功或失败后均能自动关闭，提升了整体用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->