### PR TITLE
Fix wd-picker empty columns issue and extend wd-fab with new positions

### DIFF
--- a/docs/component/fab.md
+++ b/docs/component/fab.md
@@ -36,7 +36,14 @@
 import { useToast } from '@/uni_modules/wot-design-uni'
 const { show: showToast } = useToast()
 const type = ref<'primary' | 'success' | 'info' | 'warning' | 'error' | 'default'>('primary')
-const position = ref<'left-top' | 'right-top' | 'left-bottom' | 'right-bottom'>('left-bottom')
+const position = ref<'left-top'
+  | 'right-top'
+  | 'left-bottom'
+  | 'right-bottom'
+  | 'left-center'
+  | 'right-center'
+  | 'top-center'
+  | 'bottom-center'>('left-bottom')
 const direction = ref<'top' | 'right' | 'bottom' | 'left'>('top')
 const disabled = ref<boolean>(false)
 ```
@@ -100,20 +107,20 @@ const handleClick = () => {
 
 ## Attributes
 
-| 参数           | 说明                                                  | 类型         | 可选值                                                                                    | 默认值                                         | 最低版本         |
-| -------------- | ----------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------- | ---------------------------------------------- | ---------------- |
-| v-model:active | 是否激活                                              | boolean      | -                                                                                         | false                                          | 0.1.57           |
-| type           | 类型                                                  | FabType      | 'primary' &#124; 'success' &#124; 'info' &#124; 'warning' &#124; 'error' &#124; 'default' | 'primary'                                      | 0.1.57           |
-| position       | 悬浮按钮位置                                          | FabPosition  | 'left-top' &#124; 'right-top' &#124; 'left-bottom' &#124; 'right-bottom'                  | 'right-bottom'                                 | 0.1.57           |
-| draggable      | 按钮能否拖动                                          | boolean      |                                                                                           | false                                          | 1.2.19           |
-| direction      | 悬浮按钮菜单弹出方向                                  | FabDirection | 'top' &#124; 'right' &#124; 'bottom' &#124; 'left'                                        | 'top'                                          | 0.1.57           |
-| disabled       | 是否禁用                                              | boolean      | -                                                                                         | false                                          | 0.1.57           |
-| inactiveIcon   | 悬浮按钮未展开时的图标                                | string       | -                                                                                         | 'add'                                          | 0.1.57           |
-| activeIcon     | 悬浮按钮展开时的图标                                  | string       | -                                                                                         | 'close'                                        | 0.1.57           |
-| zIndex         | 自定义悬浮按钮层级                                    | number       | -                                                                                         | 99                                             | 0.1.57           |
-| gap            | 自定义悬浮按钮与可视区域边缘的间距                    | FabGap       | -                                                                                         | \{ top: 16, left: 16, right: 16, bottom: 16 \} | 1.2.26           |
-| customStyle    | 自定义样式                                            | string       | -                                                                                         | ''                                             | 0.1.57           |
-| expandable     | 用于控制点击时是否展开菜单，设置为 false 时触发 click | boolean      | -                                                                                         | true                                           | 1.3.11 |
+| 参数           | 说明                                                  | 类型         | 可选值                                                                                                                                       | 默认值                                         | 最低版本         |
+| -------------- | ----------------------------------------------------- | ------------ |-------------------------------------------------------------------------------------------------------------------------------------------| ---------------------------------------------- | ---------------- |
+| v-model:active | 是否激活                                              | boolean      | -                                                                                                                                         | false                                          | 0.1.57           |
+| type           | 类型                                                  | FabType      | 'primary' &#124; 'success' &#124; 'info' &#124; 'warning' &#124; 'error' &#124; 'default'                                                 | 'primary'                                      | 0.1.57           |
+| position       | 悬浮按钮位置                                          | FabPosition  | 'left-top' &#124; 'right-top' &#124; 'left-bottom' &#124; 'right-bottom' &#124; left-center &#124; right-center &#124; top-center &#124; bottom-center | 'right-bottom'                                 | 0.1.57           |
+| draggable      | 按钮能否拖动                                          | boolean      |                                                                                                                                           | false                                          | 1.2.19           |
+| direction      | 悬浮按钮菜单弹出方向                                  | FabDirection | 'top' &#124; 'right' &#124; 'bottom' &#124; 'left'                                                                                        | 'top'                                          | 0.1.57           |
+| disabled       | 是否禁用                                              | boolean      | -                                                                                                                                         | false                                          | 0.1.57           |
+| inactiveIcon   | 悬浮按钮未展开时的图标                                | string       | -                                                                                                                                         | 'add'                                          | 0.1.57           |
+| activeIcon     | 悬浮按钮展开时的图标                                  | string       | -                                                                                                                                         | 'close'                                        | 0.1.57           |
+| zIndex         | 自定义悬浮按钮层级                                    | number       | -                                                                                                                                         | 99                                             | 0.1.57           |
+| gap            | 自定义悬浮按钮与可视区域边缘的间距                    | FabGap       | -                                                                                                                                         | \{ top: 16, left: 16, right: 16, bottom: 16 \} | 1.2.26           |
+| customStyle    | 自定义样式                                            | string       | -                                                                                                                                         | ''                                             | 0.1.57           |
+| expandable     | 用于控制点击时是否展开菜单，设置为 false 时触发 click | boolean      | -                                                                                                                                         | true                                           | 1.3.11 |
 
 ## Events
 

--- a/src/pages/fab/Index.vue
+++ b/src/pages/fab/Index.vue
@@ -15,6 +15,10 @@
         <wd-radio-group v-model="position" inline shape="dot">
           <wd-radio value="left-top" custom-class="custom-radio">左上</wd-radio>
           <wd-radio value="right-top" custom-class="custom-radio">右上</wd-radio>
+          <wd-radio value="left-center" custom-class="custom-radio">左中</wd-radio>
+          <wd-radio value="right-center" custom-class="custom-radio">右中</wd-radio>
+          <wd-radio value="top-center" custom-class="custom-radio">上中</wd-radio>
+          <wd-radio value="bottom-center" custom-class="custom-radio">下中</wd-radio>
           <wd-radio value="left-bottom" custom-class="custom-radio">左下</wd-radio>
           <wd-radio value="right-bottom" custom-class="custom-radio">右下</wd-radio>
         </wd-radio-group>
@@ -88,7 +92,9 @@ import { ref } from 'vue'
 const { show: showToast } = useToast()
 const active = ref<boolean>(false)
 const type = ref<'primary' | 'success' | 'info' | 'warning' | 'error' | 'default'>('primary')
-const position = ref<'left-top' | 'right-top' | 'left-bottom' | 'right-bottom'>('left-bottom')
+const position = ref<'left-top' | 'right-top' | 'left-bottom' | 'right-bottom' | 'left-center' | 'right-center' | 'top-center' | 'bottom-center'>(
+  'left-bottom'
+)
 const direction = ref<'top' | 'right' | 'bottom' | 'left'>('top')
 const disabled = ref<boolean>(false)
 const draggable = ref<boolean>(false)

--- a/src/uni_modules/wot-design-uni/components/wd-fab/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-fab/types.ts
@@ -3,7 +3,7 @@ import { baseProps, makeBooleanProp, makeNumberProp, makeStringProp } from '../c
 import type { PropType } from 'vue'
 
 export type FabType = 'primary' | 'success' | 'info' | 'warning' | 'error' | 'default'
-export type FabPosition = 'left-top' | 'right-top' | 'left-bottom' | 'right-bottom'
+export type FabPosition = 'left-top' | 'right-top' | 'left-bottom' | 'right-bottom' | 'left-center' | 'right-center' | 'top-center' | 'bottom-center'
 export type FabDirection = 'top' | 'right' | 'bottom' | 'left'
 export type FabGap = Partial<Record<FabDirection, number>>
 export const fabProps = {
@@ -17,7 +17,7 @@ export const fabProps = {
    */
   type: makeStringProp<FabType>('primary'),
   /**
-   * 悬浮按钮位置，可选值为 left-top right-top left-bottom right-bottom
+   * 悬浮按钮位置，可选值为 left-top right-top left-bottom right-bottom left-center right-center top-center bottom-center
    */
   position: makeStringProp<FabPosition>('right-bottom'),
   /**

--- a/src/uni_modules/wot-design-uni/components/wd-fab/wd-fab.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-fab/wd-fab.vue
@@ -124,18 +124,42 @@ async function getBounding() {
 function initPosition() {
   const pos = props.position
   const { minLeft, minTop, maxLeft, maxTop } = bounding
-  if (pos === 'left-top') {
-    top.value = minTop
-    left.value = minLeft
-  } else if (pos === 'right-top') {
-    top.value = minTop
-    left.value = maxLeft
-  } else if (pos === 'left-bottom') {
-    top.value = maxTop
-    left.value = minLeft
-  } else if (pos === 'right-bottom') {
-    top.value = maxTop
-    left.value = maxLeft
+  const centerY = (maxTop + minTop) / 2
+  const centerX = (maxLeft + minLeft) / 2
+
+  switch (pos) {
+    case 'left-top':
+      top.value = minTop
+      left.value = minLeft
+      break
+    case 'right-top':
+      top.value = minTop
+      left.value = maxLeft
+      break
+    case 'left-bottom':
+      top.value = maxTop
+      left.value = minLeft
+      break
+    case 'right-bottom':
+      top.value = maxTop
+      left.value = maxLeft
+      break
+    case 'left-center':
+      top.value = centerY
+      left.value = minLeft
+      break
+    case 'right-center':
+      top.value = centerY
+      left.value = maxLeft
+      break
+    case 'top-center':
+      top.value = minTop
+      left.value = centerX
+      break
+    case 'bottom-center':
+      top.value = maxTop
+      left.value = centerX
+      break
   }
 }
 

--- a/src/uni_modules/wot-design-uni/components/wd-picker-view/wd-picker-view.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-picker-view/wd-picker-view.vue
@@ -58,8 +58,14 @@ const selectedIndex = ref<Array<number>>([]) // 格式化之后，每列选中�
 watch(
   [() => props.modelValue, () => props.columns],
   (newValue, oldValue) => {
-    if (!isEqual(oldValue[1], newValue[1]) && isArray(newValue[1]) && newValue[1].length > 0) {
-      formatColumns.value = formatArray(newValue[1], props.valueKey, props.labelKey)
+    if (!isEqual(oldValue[1], newValue[1])) {
+      if (isArray(newValue[1]) && newValue[1].length > 0) {
+        formatColumns.value = formatArray(newValue[1], props.valueKey, props.labelKey)
+      } else {
+        // 当 columns 变为空时，清空 formatColumns 和 selectedIndex
+        formatColumns.value = []
+        selectedIndex.value = []
+      }
     }
     if (isDef(newValue[0])) {
       selectWithValue(newValue[0])
@@ -79,7 +85,10 @@ const { proxy } = getCurrentInstance() as any
  * @param {String|Number|Boolean|Array<String|Number|Boolean|Array<any>>}value
  */
 function selectWithValue(value: string | number | boolean | number[] | string[] | boolean[]) {
-  if (formatColumns.value.length === 0) return
+  if (formatColumns.value.length === 0) {
+    selectedIndex.value = [] // 如果列为空，直接清空选中索引
+    return
+  }
   // 使其默认选中首项
   if (value === '' || !isDef(value) || (isArray(value) && value.length === 0)) {
     value = formatColumns.value.map((col) => {

--- a/src/uni_modules/wot-design-uni/components/wd-picker/wd-picker.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-picker/wd-picker.vue
@@ -152,8 +152,14 @@ watch(
   (newValue) => {
     displayColumns.value = deepClone(newValue)
     resetColumns.value = deepClone(newValue)
-    // 获取初始选中项,并展示初始选中文案
-    handleShowValueUpdate(props.modelValue)
+    if (newValue.length === 0) {
+      // 当 columns 变为空时，清空 pickerValue 和 showValue
+      pickerValue.value = isArray(props.modelValue) ? [] : ''
+      showValue.value = ''
+    } else {
+      // 非空时正常更新显示值
+      handleShowValueUpdate(props.modelValue)
+    }
   },
   {
     deep: true,


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [x] 新特性提交
- [x] 站点、文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
https://github.com/Moonofweisheng/wot-design-uni/issues/935
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
Fixed issue where selected value and picker options were not cleared when columns became empty
and
extend wd-fab component with 4 new positions and update docs


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 扩展了悬浮按钮的定位选项，新增居中对齐（左中、右中、上中、下中），为页面布局提供更多灵活性。

- **文档**
  - 更新了悬浮按钮位置属性的说明，展示新增的对齐方式。

- **错误修复**
  - 优化了选择器的更新逻辑，在列表为空时可正确重置显示和选项，提升了整体使用体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->