### PR TITLE
fix: 🐛 修复input、textarea组件placeholder样式在微信小程序无效的问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-input/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-input/index.scss
@@ -26,10 +26,6 @@
       }
     }
 
-    @include e(placeholder) {
-      color: $-dark-color3;
-    }
-
     @include e(count) {
       color: $-dark-color3;
       background: transparent;
@@ -317,15 +313,6 @@
     color: $-input-count-current-color;
 
     @include when(error) {
-      color: $-input-error-color;
-    }
-  }
-
-
-  @include e(placeholder) {
-    color: $-input-placeholder-color;
-
-    &.is-error {
       color: $-input-error-color;
     }
   }

--- a/src/uni_modules/wot-design-uni/components/wd-input/placeholder.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-input/placeholder.scss
@@ -1,0 +1,21 @@
+@import "../common/abstracts/variable";
+@import "../common/abstracts/mixin";
+
+.wot-theme-dark {
+  @include b(input) {
+    @include e(placeholder) {
+      color: $-dark-color3;
+    }
+  }
+}
+
+
+@include b(input) {
+  @include e(placeholder) {
+    color: $-input-placeholder-color;
+
+    &.is-error {
+      color: $-input-error-color;
+    }
+  }
+}

--- a/src/uni_modules/wot-design-uni/components/wd-input/wd-input.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-input/wd-input.vue
@@ -293,3 +293,6 @@ function isValueEqual(value1: number | string, value2: number | string) {
 <style lang="scss" scoped>
 @import './index.scss';
 </style>
+<style lang="scss">
+@import './placeholder.scss';
+</style>

--- a/src/uni_modules/wot-design-uni/components/wd-textarea/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-textarea/index.scss
@@ -29,10 +29,6 @@
       }
     }
 
-    @include e(placeholder) {
-      color: $-dark-color3;
-    }
-
     @include e(count) {
       color: $-dark-color3;
       background: transparent;
@@ -217,15 +213,6 @@
       color: $-input-error-color;
     }
   }
-
-  @include e(placeholder) {
-    color: $-input-placeholder-color;
-
-    &.is-error {
-      color: $-input-error-color;
-    }
-  }
-
 
   @include e(readonly-mask) {
     position: absolute;

--- a/src/uni_modules/wot-design-uni/components/wd-textarea/placeholder.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-textarea/placeholder.scss
@@ -1,0 +1,20 @@
+@import "../common/abstracts/variable";
+@import "../common/abstracts/mixin";
+
+.wot-theme-dark {
+  @include b(textarea) {
+    @include e(placeholder) {
+      color: $-dark-color3;
+    }
+  }
+}
+
+@include b(textarea) {
+  @include e(placeholder) {
+    color: $-input-placeholder-color;
+
+    &.is-error {
+      color: $-input-error-color;
+    }
+  }
+}

--- a/src/uni_modules/wot-design-uni/components/wd-textarea/wd-textarea.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-textarea/wd-textarea.vue
@@ -283,3 +283,7 @@ function onClickPrefixIcon() {
 <style lang="scss" scoped>
 @import './index.scss';
 </style>
+
+<style lang="scss">
+@import './placeholder.scss';
+</style>


### PR DESCRIPTION
✅ Closes: #943

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新增功能**
  - 升级了输入框和文本域的占位符样式，以提供更统一、清晰的视觉体验，尤其在暗黑模式与错误状态下展现更佳效果。

- **代码优化**
  - 对样式部分进行微调和整理，提升整体代码整洁度和维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->