### PR TITLE
fix: 🐛 修复 DateTimePicker 区域选择时边界值处理错误的问题

### DIFF
--- a/docs/component/datetime-picker.md
+++ b/docs/component/datetime-picker.md
@@ -204,10 +204,10 @@ function handleConfirm({ value }) {
 
 ## 唤起项插槽
 
-开启 `use-default-slot` ，设置默认插槽修改唤起picker组件的形式。
+设置默认插槽修改唤起picker组件的形式。
 
 ```html
-<wd-datetime-picker  v-model="value" use-default-slot>
+<wd-datetime-picker  v-model="value">
   <wd-button>插槽唤起</wd-button>
 </wd-datetime-picker>
 ```
@@ -285,8 +285,8 @@ const displayFormatTabLabel = (items) => {
 | label-width | 设置左侧标题宽度 | string | - | 33% | - |
 | error | 是否为错误状态，错误状态时右侧内容为红色 | boolean | - | false | - |
 | align-right | 选择器的值靠右展示 | boolean | - | false | - |
-| use-label-slot | label 使用插槽 | boolean | - | false | - |
-| use-default-slot | 使用默认插槽 | boolean | - | false | - |
+| <s>use-label-slot</s> | <s>label 使用插槽</s>，已废弃，直接使用label插槽即可 | boolean | - | false | - |
+| <s>use-default-slot</s> | <s>使用默认插槽</s>，已废弃，直接使用默认插槽即可 | boolean | - | false | - |
 | before-confirm | 确定前校验函数，接收 (value, resolve, picker) 参数，通过 resolve 继续执行 picker，resolve 接收1个boolean参数 | function | - | - | - |
 | close-on-click-modal | 点击遮罩是否关闭 | boolean | - | true | - |
 | z-index | 弹窗层级 | number | - | 15 | - |


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 💡 需求背景和解决方案
现状：当前date-time-picker设置为区间选择时未处理picker-view选中值变化时的边界问题，导致可能出现起始值大于结束值的情况。  

解决办法：列格式化方法、起始时间change事件和结束时间change事件调整为使用相同的边界值处理逻辑，保证最终值正确且处理逻辑一致。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 改进了日期时间选择器的内容展示逻辑：组件仅在提供自定义内容时显示对应插槽，提升了自定义显示的灵活性。
  - 优化了选择内容的有效性检查：新增边界检测，确保用户选择的日期和时间维持在合理范围内，并对超出范围的选项进行自动调整。

- **文档更新**
  - 移除了已弃用的属性：`use-label-slot` 和 `use-default-slot`，更新了使用说明，简化了开发者的使用指导。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->