### PR TITLE
fix(picker): resolve text ellipsis not working properly

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-picker/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-picker/index.scss
@@ -134,6 +134,7 @@
     margin-right: $-cell-padding;
     color: $-cell-title-color;
     box-sizing: border-box;
+    flex-shrink: 0;
 
     @include when(required) {
       padding-left: 12px;
@@ -152,13 +153,16 @@
 
   @include e(value-wraper) {
     display: flex;
+    min-width: 0;
+    overflow: hidden;
   }
 
   @include e(value) {
     flex: 1;
     margin-right: 10px;
     color: $-cell-value-color;
-    
+    min-width: 0;
+
     @include when(ellipsis) {
       @include lineEllipsis;
     }
@@ -166,6 +170,8 @@
 
   @include e(body) {
     flex: 1;
+    min-width: 0;
+    overflow: hidden;
   }
 
   @include e(placeholder) {


### PR DESCRIPTION
Fix issue where long text with ellipsis property would squeeze the label instead of properly truncating with ellipsis. Add min-width:0 to flex containers to ensure proper text truncation behavior.
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->
<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->
### 🤔 这个 PR 的性质是？(至少选择一个)
- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）
### 🔗 相关 Issue
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
N/A
### 💡 需求背景和解决方案
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. **问题描述**: 在 picker 组件中，当选项文本过长且启用 ellipsis 属性时，文本并不会正确地显示省略号，而是会挤压左侧的 label 元素。

2. **解决方案**: 修改了相关的 flex 布局样式，为以下元素添加了必要的 CSS 属性：
   - 为 wd-picker__body 添加 min-width: 0 和 overflow: hidden
   - 为 wd-picker__value-wraper 添加 min-width: 0 和 overflow: hidden
   - 为 wd-picker__value 添加 min-width: 0
   - 为 wd-picker__label 添加 flex-shrink: 0

3. **效果**: 现在长文本将正确地在空间不足时截断并显示省略号，而不会挤压左侧的 label。

### ☑️ 请求合并前的自查清单
⚠️ 请自检并全部**勾选全部选项**。⚠️
- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式**
  - 优化了选择器组件的布局表现，确保标签与内容在响应式环境下能更好地保持适当尺寸，同时自动隐藏溢出内容，从而提升整体界面显示效果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->