### PR TITLE
fix: 🐛 修复center弹窗设置transition无效问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-transition/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-transition/index.scss
@@ -14,57 +14,57 @@
 
 .wd-fade-up-enter,
 .wd-fade-up-leave-to {
-  transform: translate3d(0, 100%, 0);
+  transform: translate3d(0, 100%, 0) !important;
   opacity: 0;
 }
 
 .wd-fade-down-enter,
 .wd-fade-down-leave-to {
-  transform: translate3d(0, -100%, 0);
+  transform: translate3d(0, -100%, 0) !important;
   opacity: 0;
 }
 
 .wd-fade-left-enter,
 .wd-fade-left-leave-to {
-  transform: translate3d(-100%, 0, 0);
+  transform: translate3d(-100%, 0, 0) !important;
   opacity: 0;
 }
 
 .wd-fade-right-enter,
 .wd-fade-right-leave-to {
-  transform: translate3d(100%, 0, 0);
+  transform: translate3d(100%, 0, 0) !important;
   opacity: 0;
 }
 
 .wd-slide-up-enter,
 .wd-slide-up-leave-to {
-  transform: translate3d(0, 100%, 0);
+  transform: translate3d(0, 100%, 0) !important;
 }
 
 .wd-slide-down-enter,
 .wd-slide-down-leave-to {
-  transform: translate3d(0, -100%, 0);
+  transform: translate3d(0, -100%, 0) !important;
 }
 
 .wd-slide-left-enter,
 .wd-slide-left-leave-to {
-  transform: translate3d(-100%, 0, 0);
+  transform: translate3d(-100%, 0, 0) !important;
 }
 
 .wd-slide-right-enter,
 .wd-slide-right-leave-to {
-  transform: translate3d(100%, 0, 0);
+  transform: translate3d(100%, 0, 0) !important;
 }
 
 .wd-zoom-in-enter,
 .wd-zoom-in-leave-to {
   opacity: 0;
-  transform: scale(0.8);
+  transform: scale(0.8) !important;
 }
 
 .wd-zoom-out-enter,
 .wd-zoom-out-leave-to {
-  transform: scale(1.2);
+  transform: scale(1.2) !important;
   opacity: 0;
 }
 


### PR DESCRIPTION
## 复现步骤
<wd-popup v-model="show1" @close="handleClose1" custom-style="border-radius:32rpx;" transition="fade-down">
        <text class="custom-txt">{{ $t('dan-dan-dan') }}</text>
      </wd-popup>
还是居中的动画 没有fade-down的动画效果

## 期望的结果是什么？
期望是设置的transition值的动画效果

## 实际的结果是什么？
实际是center的默认动画效果

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式**
  - 更新了过渡动画的 transform 属性，添加了 `!important`，以确保动画效果在存在样式冲突时依然生效。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->