### PR TITLE
fix: 🐛 修复 Upload 开启 multiple 后只能成功上传最后一个文件的问题

### DIFF
--- a/src/subPages/upload/Index.vue
+++ b/src/subPages/upload/Index.vue
@@ -43,6 +43,10 @@
     <demo-block :title="$t('jinYong')">
       <wd-upload :file-list="fileList8" disabled :action="action" @change="handleChange8"></wd-upload>
     </demo-block>
+    <demo-block :title="$t('duo-xuan')">
+      <wd-upload :file-list="fileList2" multiple :action="action" @change="handleChange2"></wd-upload>
+    </demo-block>
+
     <demo-block :title="$t('zi-ding-yi-huan-qi-shang-chuan-yang-shi-bing-xian-zhi-shang-chuan-5-zhang')">
       <wd-upload :file-list="fileList9" :action="action" @change="handleChange9" :limit="5">
         <wd-button>{{ $t('zi-ding-yi-huan-qi-yang-shi') }}</wd-button>
@@ -241,16 +245,6 @@ const buildFormData = ({ file, formData, resolve }: any) => {
     success_action_status: success_action_status
   }
   resolve(formData)
-}
-
-const handleSuccess1 = (res: any) => {
-  console.log('成功', res)
-}
-const handleFail1 = (res: any) => {
-  console.log('失败', res)
-}
-const handleProgess1 = (res: any) => {
-  console.log('加载中', res)
 }
 
 function handleSuccess(event: any) {

--- a/src/uni_modules/wot-design-uni/components/wd-upload/wd-upload.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-upload/wd-upload.vue
@@ -288,8 +288,7 @@ function startUploadFiles() {
                 uploadMethod,
                 onSuccess: handleSuccess,
                 onError: handleError,
-                onProgress: handleProgress,
-                abortPrevious: true // 自动中断之前的上传
+                onProgress: handleProgress
               })
           }
         })
@@ -305,8 +304,7 @@ function startUploadFiles() {
           uploadMethod,
           onSuccess: handleSuccess,
           onError: handleError,
-          onProgress: handleProgress,
-          abortPrevious: true
+          onProgress: handleProgress
         })
       }
     }


### PR DESCRIPTION
✅ Closes: #1043

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
#1043
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
修复 Upload 开启 multiple 后只能成功上传最后一个文件的问题，useUpload提供的上传方法，提供了取消上次上传请求的参数，而Upload默认开启了此选项，导致产生此问题。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增“多选”演示块，支持多文件上传示例。

- **修复**
  - 移除了上传组件中自动中止前一次上传的功能，提升多文件上传体验。

- **优化**
  - 清理了未使用的事件处理函数，使代码更简洁。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->