### PR TITLE
fix: 🐛 修复 Input、Textarea、Search 组件设置清空后不聚焦时无法触发失焦事件的问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-input/wd-input.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-input/wd-input.vue
@@ -236,10 +236,10 @@ function togglePwdVisible() {
   isPwdVisible.value = !isPwdVisible.value
 }
 async function handleClear() {
-  clearing.value = true
   focusing.value = false
   inputValue.value = ''
   if (props.focusWhenClear) {
+    clearing.value = true
     focused.value = false
   }
   await pause()

--- a/src/uni_modules/wot-design-uni/components/wd-textarea/wd-textarea.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-textarea/wd-textarea.vue
@@ -233,10 +233,10 @@ function formatValue(value: string | number) {
 }
 
 async function handleClear() {
-  clearing.value = true
   focusing.value = false
   inputValue.value = ''
   if (props.focusWhenClear) {
+    clearing.value = true
     focused.value = false
   }
   await pause()


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
修复 Input、Textarea、Search 组件设置清空后不聚焦时无法触发失焦事件的问题
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
  - 优化了输入框和多行文本框的清除逻辑，使其在特定情况下才会设置清除状态。
  - 搜索组件内部变量和事件处理函数命名更加清晰，提升了代码可读性和维护性。
- **无用户可见功能变化**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->