### PR TITLE
fix: 修复input-number组件无法清空值由用户输入的bug

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-input-number/wd-input-number.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-input-number/wd-input-number.vue
@@ -145,9 +145,12 @@ function toStrictlyStep(value: number | string) {
 }
 
 // 内部更新处理函数
-function doUpdate(value: string | number) {
+function doUpdate(value: string | number, eventType: InputNumberEventType) {
   inputValue.value = value
-  const formatted = formatValue(value)
+  let formatted = value
+  if (eventType !== InputNumberEventType.Input) {
+    formatted = formatValue(value)
+  }
   nextTick(() => {
     inputValue.value = formatted
     emit('update:modelValue', inputValue.value)
@@ -201,7 +204,7 @@ function updateValue(value: string | number, eventType: InputNumberEventType = I
     return
   }
 
-  const update = () => doUpdate(value)
+  const update = () => doUpdate(value, eventType)
 
   if (fromUser) {
     callInterceptor(props.beforeChange, {


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->



### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/Moonofweisheng/wot-design-uni/issues/950

### 💡 需求背景和解决方案
需求背景：假设之前有一个值为200的数值，用户现在需要将这个数值删除到450，就会有一个问题。用户在将值删除完时，此组件会立马格式化将1赋值过去，导致用户想将值清空需要先在1后面加上‘450’再将前面的‘1’删除。
解决方案：我认为输入的时候无需格式化，type为number时uniapp已经规定了相应格式。而应在组件失焦时再将值进行格式化

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复问题**
  - 优化了数字输入组件在不同事件类型下的数值格式化逻辑，提升了输入体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->