### PR TITLE
fix: 🐛 修复 Toast 英文断行样式错误问题

### DIFF
--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -702,7 +702,7 @@
   "ju-jue": "refuse",
   "ju-ming-cha-cao-zhe-shi-yi-tiao-jian-dan-de-shi-li-wen-zi-zhe-shi-yi-tiao-jian-dan-de-shi-li-wen-zi-zhe-shi-yi-tiao-jian-dan-de-shi-li-wen-zi-zhe-shi-yi-tiao-jian-dan-de-shi-li-wen-zi-zhe-shi-yi-tiao-jian-dan-de-shi-li-wen-zi-zhe-shi-yi-tiao-jian-dan-de-shi-li-wen-zi-zhe-shi-yi-tiao-jian-dan-de-shi-li-wen-zi-zhe-shi-yi-tiao-jian-dan-de-shi-li-wen-zi": "Named slot: This is a simple example text. This is a simple example text. This is a simple example text. This is a simple example text. This is a simple example text. This is a simple example text. This is a simple example text. This is a simple example text.",
   "ju-xing-ka-pian": "Rectangular card",
-  "ju-zhong-toast": "Mid game toast",
+  "ju-zhong-toast": "Center toast",
   "juanZeng": "donate",
   "ka-pi-ba-la": "Card! Pi! Ba! PULL!",
   "ka-pian-yang-shi": "Card style",

--- a/src/locale/zh-CN.json
+++ b/src/locale/zh-CN.json
@@ -702,7 +702,7 @@
   "ju-jue": "拒绝",
   "ju-ming-cha-cao-zhe-shi-yi-tiao-jian-dan-de-shi-li-wen-zi-zhe-shi-yi-tiao-jian-dan-de-shi-li-wen-zi-zhe-shi-yi-tiao-jian-dan-de-shi-li-wen-zi-zhe-shi-yi-tiao-jian-dan-de-shi-li-wen-zi-zhe-shi-yi-tiao-jian-dan-de-shi-li-wen-zi-zhe-shi-yi-tiao-jian-dan-de-shi-li-wen-zi-zhe-shi-yi-tiao-jian-dan-de-shi-li-wen-zi-zhe-shi-yi-tiao-jian-dan-de-shi-li-wen-zi": "具名插槽：这是一条简单的示例文字。这是一条简单的示例文字。这是一条简单的示例文字。这是一条简单的示例文字。这是一条简单的示例文字。这是一条简单的示例文字。这是一条简单的示例文字。这是一条简单的示例文字。",
   "ju-xing-ka-pian": "矩形卡片",
-  "ju-zhong-toast": "局中toast",
+  "ju-zhong-toast": "居中toast",
   "juanZeng": "捐赠",
   "ka-pi-ba-la": "卡！皮！巴！拉！",
   "ka-pian-yang-shi": "卡片样式",

--- a/src/uni_modules/wot-design-uni/components/common/abstracts/variable.scss
+++ b/src/uni_modules/wot-design-uni/components/common/abstracts/variable.scss
@@ -639,16 +639,19 @@ $-tag-close-color: var(--wot-tag-close-color, $-tag-info-color) !default; // 关
 $-tag-close-active-color: var(--wot-tag-close-active-color, rgba(0, 0, 0, 0.45)) !default; // 关闭按钮 active 颜色
 
 /* toast */
+$-toast-color: var(--wot-toast-color, $-color-white) !default; // 文字颜色
 $-toast-padding: var(--wot-toast-padding, 16px 24px) !default; // padding
 $-toast-max-width: var(--wot-toast-max-width, 300px) !default; // 最大宽度
 $-toast-radius: var(--wot-toast-radius, 8px) !default; // 圆角大小
 $-toast-bg: var(--wot-toast-bg, $-overlay-bg) !default; // 背景色
 $-toast-fs: var(--wot-toast-fs, $-fs-content) !default; // 字号
+$-toast-line-height: var(--wot-toast-line-height, 20px) !default; // 行高
 $-toast-with-icon-min-width: var(--wot-toast-with-icon-min-width, 150px) !default; // 有图标的情况下最小宽度
 $-toast-icon-size: var(--wot-toast-icon-size, 32px) !default; // 图标大小
 $-toast-icon-margin-right: var(--wot-toast-icon-margin-right, 12px) !default; // 图标右边距
 $-toast-icon-margin-bottom: var(--wot-toast-icon-margin-bottom, 12px) !default; // 图标下边距
-$-toast-loading-padding: var(--wot-toast-loading-padding, 10px) !default; // loading 下的padding
+$-toast-loading-padding: var(--wot-toast-loading-padding, 10px) !default; // loading状态下的padding
+$-toast-loading-margin-bottom: var(--wot-toast-loading-margin-bottom, 16px) !default; // loading动画的margin-bottom
 $-toast-box-shadow: var(--wot-toast-box-shadow, 0px 6px 16px 0px rgba(0, 0, 0, 0.08)) !default; // 外部阴影
 
 /* loading */

--- a/src/uni_modules/wot-design-uni/components/wd-toast/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-toast/index.scss
@@ -7,7 +7,7 @@
   padding: $-toast-padding;
   background-color: $-toast-bg;
   border-radius: $-toast-radius;
-  color: #fff;
+  color: $-toast-color;
   transition: all 0.2s;
   font-size: $-toast-fs;
   box-sizing: border-box;
@@ -19,7 +19,8 @@
 
   @include e(msg) {
     font-size: $-toast-fs;
-    line-height: 20px;
+    word-break: break-all;
+    line-height: $-toast-line-height;
     text-align: left;
     font-family: "San Francisco", Rotobo, arial, "PingFang SC", "Noto SansCJK", "Microsoft Yahei", sans-serif;
   }
@@ -50,7 +51,7 @@
     background-repeat: no-repeat;
   }
   @include e(loading) {
-    margin-bottom: 16px;
+    margin-bottom: $-toast-loading-margin-bottom;
     display: inline-block;
   }
   @include m(top) {


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
toast信息经常会展示接口异常信息，而其经常为英文，所以添加`word-break:break-all`，以解决此问题。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式**
  - Toast 组件的文本颜色、行高和加载动画底部间距现可通过变量自定义，提升样式灵活性。
  - 优化 Toast 组件长文本显示效果，支持自动换行。

- **文档**
  - 英文和中文界面中 Toast 相关文案进行了修正和优化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->