### PR TITLE
feat: wd-text组件支持传入字符串时间时,也格式化为Y-M-D时间

### DIFF
--- a/src/uni_modules/wot-design-uni/components/common/dayjs.ts
+++ b/src/uni_modules/wot-design-uni/components/common/dayjs.ts
@@ -100,6 +100,10 @@ class Dayjs {
     return this.add(-1 * amount, unit)
   }
 
+  isValid() {
+    return !isNaN(this.date.getTime())
+  }
+
   format(formatStr = 'YYYY-MM-DDTHH:mm:ssZ') {
     const weekdays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
     return formatStr.replace(/Y{2,4}|M{1,2}|D{1,2}|d{1,4}|H{1,2}|m{1,2}|s{1,2}|Z{1,2}/g, (match) => {

--- a/src/uni_modules/wot-design-uni/components/wd-text/wd-text.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-text/wd-text.vue
@@ -120,7 +120,10 @@ function formatNumber(num: number | string): string {
 const formattedText = computed(() => {
   const { text, mode, format } = props
   if (mode === 'date') {
-    return dayjs(Number(text)).format('YYYY-MM-DD')
+    // 判断是否为纯数字字符串，优先当作时间戳处理
+    const isTimestamp = /^\d+$/.test(`${text}`)
+    const date = isTimestamp ? dayjs(Number(text)) : dayjs(text)
+    return date.format('YYYY-MM-DD')
   }
   if (mode === 'price') {
     return formatNumber(text)

--- a/src/uni_modules/wot-design-uni/components/wd-text/wd-text.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-text/wd-text.vue
@@ -123,6 +123,11 @@ const formattedText = computed(() => {
     // 判断是否为纯数字字符串，优先当作时间戳处理
     const isTimestamp = /^\d+$/.test(`${text}`)
     const date = isTimestamp ? dayjs(Number(text)) : dayjs(text)
+    // 若为无效日期则返回占位符 "-"
+    if (!date.isValid()) {
+      return '-'
+    }
+    // 返回格式化后的日期
     return date.format('YYYY-MM-DD')
   }
   if (mode === 'price') {


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

未提相关issue

### 💡 需求背景和解决方案

解决了若接口返回的时间格式非timestamp时,mode为date时也能生效展示日期。
例如返回2022-05-10 10:10:10这样格式的时间也可以快速通过wd-text组件来展示2022-05-10这样的日期。
这样方便大家不用再使用dayjs来转一遍再传入wd-text组件做展示 算是拓展了mode=date时的功能。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **优化**
  - 改进日期模式下的文本格式化逻辑，支持时间戳和日期字符串输入，并新增日期有效性校验，格式统一为“YYYY-MM-DD”，无效日期显示为“-”。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->