### PR TITLE
feat: ✨ MessageBox beforeConfirm 传入当前的inputValue

### DIFF
--- a/docs/component/message-box.md
+++ b/docs/component/message-box.md
@@ -189,6 +189,44 @@ function beforeConfirm() {
 }
 ```
 
+## 确认前置处理获取输入的值<el-tag text style="vertical-align: middle;margin-left:8px;" effect="plain">$LOWEST_VERSION$</el-tag>
+
+设置 `beforeConfirm` 函数，在用户点击确认后，会执行 `beforeConfirm` 函数，接收 { resolve, value }，开发者可以在确认前进行处理，并通过 `resolve` 函数告知组件是否确定通过，`resolve` 接受 1 个 `boolean` 值，`resolve(true)` 表示选项通过，`resolve(false)` 表示选项不通过，不通过时不会完成确认操作。
+
+```html
+<wd-toast />
+<wd-message-box />
+<wd-button @click="beforeConfirmWithInputValue">beforeConfirmWithInputValue</wd-button>
+```
+
+```typescript
+import { useMessage, useToast } from '@/uni_modules/wot-design-uni'
+const message = useMessage()
+const toast = useToast()
+
+function beforeConfirmWithInputValue() {
+  message
+    .prompt({
+      title: '请输入邮箱',
+      inputValue: value1.value,
+      beforeConfirm: ({ resolve, value }) => {
+        if (!value) {
+          toast.error('请输入邮箱')
+          resolve(false)
+        } else {
+          resolve(true)
+        }
+      }
+    })
+    .then((resp) => {
+      console.log(resp)
+    })
+    .catch((error) => {
+      console.log(error)
+    })
+}
+```
+
 ## 自定义操作按钮<el-tag text style="vertical-align: middle;margin-left:8px;" effect="plain">1.5.0</el-tag>
 
 可以通过按钮属性 `cancel-button-props` 和 `confirm-button-props` 自定义操作按钮的样式，具体参考 [Button Attributes](/component/button.html#attributes)。

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -1040,6 +1040,7 @@
   "shi-jing-shan-qu": "SHIJINGSHAN",
   "shi-pin-lun-bo": "Video carousel",
   "shi-yong-beforeconfirm-gou-zi-zai-dan-kuang-que-ren-qian-ke-yi-jin-hang-yi-xie-cao-zuo": "Using the before Confirm hook, some operations can be performed before the pop-up confirmation",
+  "shi-yong-beforeconfirm-gou-zi-zai-dan-kuang-que-ren-qian-ke-yi-huo-qu-shu-ru-zhi-jin-xing-yi-xie-cao-zuo": "Using the beforeConfirm hook, you can get the input value and perform some operations before pop-up confirmation",
   "shi-yong-cha-cao": "Using slots",
   "shi-yong-heng-ping-qian-ming": "Use landscape signature",
   "shi-yong-hui-biao": "Use Badge",

--- a/src/locale/zh-CN.json
+++ b/src/locale/zh-CN.json
@@ -1040,6 +1040,7 @@
   "shi-jing-shan-qu": "石景山区",
   "shi-pin-lun-bo": "视频轮播",
   "shi-yong-beforeconfirm-gou-zi-zai-dan-kuang-que-ren-qian-ke-yi-jin-hang-yi-xie-cao-zuo": "使用beforeConfirm钩子，在弹框确认前，可以进行一些操作",
+  "shi-yong-beforeconfirm-gou-zi-zai-dan-kuang-que-ren-qian-ke-yi-huo-qu-shu-ru-zhi-jin-xing-yi-xie-cao-zuo": "使用beforeConfirm钩子，在弹框确认前，可以获取输入值进行一些操作",
   "shi-yong-cha-cao": "使用插槽",
   "shi-yong-heng-ping-qian-ming": "使用横屏签名",
   "shi-yong-hui-biao": "使用徽标",

--- a/src/subPages/messageBox/Index.vue
+++ b/src/subPages/messageBox/Index.vue
@@ -33,6 +33,10 @@
         <wd-button @click="beforeConfirm">beforeConfirm</wd-button>
       </demo-block>
 
+      <demo-block :title="$t('shi-yong-beforeconfirm-gou-zi-zai-dan-kuang-que-ren-qian-ke-yi-huo-qu-shu-ru-zhi-jin-xing-yi-xie-cao-zuo')">
+        <wd-button @click="beforeConfirmWithInputValue">beforeConfirmWithInputValue</wd-button>
+      </demo-block>
+
       <demo-block :title="$t('tong-guo-buttonprops-zi-ding-yi-an-niu')">
         <wd-button @click="withButtonProps">withButtonProps</wd-button>
       </demo-block>
@@ -107,6 +111,28 @@ function beforeConfirm() {
       }
     })
     .then(() => {})
+    .catch((error) => {
+      console.log(error)
+    })
+}
+
+function beforeConfirmWithInputValue() {
+  message
+    .prompt({
+      title: t('qing-shu-ru-you-xiang'),
+      inputValue: value1.value,
+      beforeConfirm: ({ resolve, value }) => {
+        if (!value) {
+          toast.error(t('qing-shu-ru-you-xiang'))
+          resolve(false)
+        } else {
+          resolve(true)
+        }
+      }
+    })
+    .then((resp) => {
+      console.log(resp)
+    })
     .catch((error) => {
       console.log(error)
     })

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/types.ts
@@ -15,6 +15,7 @@ export type MessageType = 'alert' | 'confirm' | 'prompt'
 
 export type MessageBeforeConfirmOption = {
   resolve: (isPass: boolean) => void
+  value: MessageOptions['inputValue']
 }
 
 export type MessageOptions = {

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
@@ -172,7 +172,8 @@ function toggleModal(action: 'confirm' | 'cancel' | 'modal') {
                 value: messageState.inputValue
               })
             }
-          }
+          },
+          value: messageState.inputValue
         })
       } else {
         handleConfirm({


### PR DESCRIPTION
✅ Closes: #961

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
https://github.com/Moonofweisheng/wot-design-uni/issues/961
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充