### PR TITLE
feat: ✨ status-tip add bottom slot support

### DIFF
--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -1098,6 +1098,7 @@
   "sortbutton-title": "SortButton",
   "sou-suo": "search for",
   "sou-suo-wu-jie-guo": "No results found in the search",
+  "di-bu-cha-cao": "Bottom slot",
   "sou-suo-zhan-wei-fu-ju-zuo": "Search placeholder on the left",
   "statustip-que-sheng-ti-shi": "StatusTip",
   "statustip-title": "StatusTip",

--- a/src/locale/zh-CN.json
+++ b/src/locale/zh-CN.json
@@ -1098,6 +1098,7 @@
   "sortbutton-title": "SortButton 排序按钮",
   "sou-suo": "搜索",
   "sou-suo-wu-jie-guo": "搜索无结果",
+  "di-bu-cha-cao": "底部插槽",
   "sou-suo-zhan-wei-fu-ju-zuo": "搜索占位符居左",
   "statustip-que-sheng-ti-shi": "StatusTip 缺省提示",
   "statustip-title": "StatusTip 缺省提示",

--- a/src/subPages/statusTip/Index.vue
+++ b/src/subPages/statusTip/Index.vue
@@ -1,5 +1,13 @@
 <template>
   <page-wraper>
+    <demo-block :title="$t('di-bu-cha-cao')">
+      <wd-status-tip image="content" tip="当前搜索无结果">
+        <template #bottom>
+          <wd-button type="info">重新加载</wd-button>
+        </template>
+      </wd-status-tip>
+    </demo-block>
+
     <demo-block :title="$t('sou-suo-wu-jie-guo')">
       <wd-status-tip image="search" tip="当前搜索无结果" />
     </demo-block>

--- a/src/uni_modules/wot-design-uni/components/wd-status-tip/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-status-tip/index.scss
@@ -34,4 +34,10 @@
     text-align: center;
     overflow-wrap: break-word;
   }
+  @include e(bottom) {
+    margin-top: 20px;
+    display: flex;
+    justify-content: center;
+    width: 100%;
+  }
 }

--- a/src/uni_modules/wot-design-uni/components/wd-status-tip/wd-status-tip.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-status-tip/wd-status-tip.vue
@@ -12,6 +12,9 @@
     <slot name="image" v-if="$slots.image"></slot>
     <wd-img v-else-if="imgUrl" :mode="imageMode" :src="imgUrl" custom-class="wd-status-tip__image" :custom-style="imgStyle"></wd-img>
     <view v-if="tip" class="wd-status-tip__text">{{ tip }}</view>
+    <view v-if="$slots.bottom" class="wd-status-tip__bottom">
+      <slot name="bottom" />
+    </view>
   </view>
 </template>
 


### PR DESCRIPTION
为 StatusTip 组件添加底部插槽，支持自定义引导内容

BREAKING CHANGE: 🧨 为 StatusTip 组件添加底部插槽

✅ Closes: #1070

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Moonofweisheng/wot-design-uni/issues/1070

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1.当前 StatusTip 组件缺乏底部扩展能力，开发者无法在缺省提示下方添加操作按钮（如重新加载/跳转等），需要通过此插槽提供扩展能力
2.
- 新增 `bottom` 插槽
- 添加 `.wd-status-tip__bottom` 样式类（带顶部间距和居中布局）
简单用法示例：
<wd-status-tip image="network">
  <template #bottom>
    <wd-button type="primary">重新加载</wd-button>
  </template>
</wd-status-tip>
3.
![image](https://github.com/user-attachments/assets/887cb561-562a-40a4-a697-3d349794f729)

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充