### PR TITLE
docs: ✏️ 修正 drop-menu-item options 默认数据结构注释

### DIFF
--- a/docs/component/drop-menu.md
+++ b/docs/component/drop-menu.md
@@ -198,7 +198,7 @@ const handleBeforeToggle: DropMenuItemBeforeToggle = ({ status, resolve }) => {
 | ------------- | ---------------------------------------------------------------------- | ----------------------------- | ------ | ---------- | -------- |
 | v-model       | 当前选中项对应选中的 value                                             | string / number               | -      | -          | -        |
 | disabled      | 禁用菜单                                                               | boolean                       | -      | false      | -        |
-| options       | 列表数据，对应数据结构 `[{text: '标题', value: '0', tip: '提示文字'}]` | array                         | -      | -          | -        |
+| options       | 列表数据，对应数据结构 `[{label: '标题', value: '0', tip: '提示文字'}]` | array                         | -      | -          | -        |
 | icon-name     | 选中的图标名称(可选名称在 wd-icon 组件中)                              | string                        | -      | check      | -        |
 | title         | 菜单标题                                                               | string                        | -      | -          | -        |
 | icon          | 菜单图标                                                               | string                        | -      | arrow-down | -        |

--- a/src/uni_modules/wot-design-uni/components/wd-drop-menu-item/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-drop-menu-item/types.ts
@@ -25,7 +25,7 @@ export const dorpMenuItemProps = {
    */
   modelValue: [String, Number],
   /**
-   * 列表数据，对应数据结构 [{text: '标题', value: '0', tip: '提示文字'}]
+   * 列表数据，对应数据结构 [{label: '标题', value: '0', tip: '提示文字'}]
    */
   options: makeArrayProp<Record<string, any>>(),
   /**

--- a/src/uni_modules/wot-design-uni/components/wd-drop-menu/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-drop-menu/types.ts
@@ -1,7 +1,7 @@
 import { type ExtractPropTypes, type InjectionKey, type Ref } from 'vue'
 import { baseProps, makeBooleanProp, makeNumberProp, makeStringProp } from '../common/props'
 
-export type DropDirction = 'up' | 'down'
+export type DropDirection = 'up' | 'down'
 
 export type DropMenuProvide = {
   props: Partial<DropMenuProps>
@@ -20,7 +20,7 @@ export const dropMenuProps = {
   /**
    * 菜单展开方向，可选值为up 或 down
    */
-  direction: makeStringProp<DropDirction>('down'),
+  direction: makeStringProp<DropDirection>('down'),
   /**
    * 是否展示蒙层
    */


### PR DESCRIPTION
text => label

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
无

### 💡 需求背景和解决方案
修正 drop-menu-item options 字段的默认值注释
`[{text: '标题', value: '0', tip: '提示文字'}]` 更改为 `[{label: '标题', value: '0', tip: '提示文字'}]`


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **文档**
  - 更新了 DropMenuItem 组件中 `options` 属性的文档描述，将选项对象的显示文本键由 `text` 更正为 `label`。
  - 修正了 DropMenu 组件中方向属性的类型名称拼写错误，将 `DropDirction` 更正为 `DropDirection`。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->