### PR TITLE
fix: 🐛 修复 Fad App端Fad组件拖动状态下和下拉刷新冲突问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-fab/wd-fab.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-fab/wd-fab.vue
@@ -166,9 +166,24 @@ function initPosition() {
 // 按下时坐标相对于元素的偏移量
 const touchOffset = reactive({ x: 0, y: 0 })
 const attractTransition = ref<boolean>(false)
+
+//解决App端拖动和下拉刷新冲突问题
+// #ifdef APP-PLUS
+const pages = getCurrentPages()
+const page = pages[pages.length - 1]
+const currentWebview = page?.$getAppWebview?.()
+// #endif
+
 function handleTouchStart(e: TouchEvent) {
   if (props.draggable === false) return
-
+  if (currentWebview) {
+    currentWebview.setStyle({
+      pullToRefresh: {
+        support: false,
+        style: plus.os.name === 'Android' ? 'circle' : 'default'
+      }
+    })
+  }
   const touch = e.touches[0]
   touchOffset.x = touch.clientX - left.value
   touchOffset.y = touch.clientY - top.value
@@ -195,7 +210,14 @@ function handleTouchMove(e: TouchEvent) {
 
 function handleTouchEnd() {
   if (props.draggable === false) return
-
+  if (currentWebview) {
+    currentWebview.setStyle({
+      pullToRefresh: {
+        support: true,
+        style: plus.os.name === 'Android' ? 'circle' : 'default'
+      }
+    })
+  }
   const screenCenterX = screen.width / 2
   const fabCenterX = left.value + fabSize.width / 2
   attractTransition.value = true


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
[1. 描述相关需求的来源，如相关的 issue 讨论链接。](https://github.com/Moonofweisheng/wot-design-uni/issues/1092)
-->

### 💡 需求背景和解决方案

<!--
1. 解决app端,fad组件和下拉刷新会冲突问题
2. const page=getCurrentPages()获取当前页面,
const currentWebview = page?.$getAppWebview?.()拿到app当前页面的webview,
handleTouchStart,拖动触发的时候
currentWebview.setStyle({
      pullToRefresh: {
        support: false,
        style: plus.os.name === 'Android' ? 'circle' : 'default'
      }
    })
动态去设置能不能触发下拉刷新
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 针对 App-Plus（原生应用）环境，优化了浮动操作按钮（FAB）拖动与下拉刷新手势的兼容体验，避免两者冲突。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->