### PR TITLE
feat: ✨ 废弃 wd-grid-item 组件插槽开关 use-slot、use-icon-slot、use-text-slot

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-grid-item/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-grid-item/types.ts
@@ -35,18 +35,6 @@ export const gridItemProps = {
    */
   linkType: makeStringProp<LinkType>('navigateTo'),
   /**
-   * 是否开启 GridItem 内容插槽
-   */
-  useSlot: makeBooleanProp(false),
-  /**
-   * 是否开启 GridItem icon 插槽
-   */
-  useIconSlot: makeBooleanProp(false),
-  /**
-   * 是否开启 GridItem text 内容插槽
-   */
-  useTextSlot: makeBooleanProp(false),
-  /**
    * 是否显示图标右上角小红点
    */
   isDot: {

--- a/src/uni_modules/wot-design-uni/components/wd-grid-item/wd-grid-item.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-grid-item/wd-grid-item.vue
@@ -5,19 +5,18 @@
       :style="gutterContentStyle"
       :hover-class="hoverClass"
     >
-      <slot v-if="useSlot" />
-      <block v-else>
+      <slot name="default">
         <view :style="'width:' + iconSize + '; height: ' + iconSize" class="wd-grid-item__wrapper">
           <wd-badge custom-class="badge" v-bind="customBadgeProps">
-            <template v-if="useIconSlot">
-              <slot name="icon" />
-            </template>
-            <wd-icon v-else :name="icon" :size="iconSize" :custom-class="customIcon" />
+            <slot name="icon">
+              <wd-icon :name="icon" :size="iconSize" :custom-class="customIcon" />
+            </slot>
           </wd-badge>
         </view>
-        <slot name="text" v-if="useTextSlot" />
-        <view v-else class="wd-grid-item__text custom-text">{{ text }}</view>
-      </block>
+        <slot name="text">
+          <view class="wd-grid-item__text custom-text">{{ text }}</view>
+        </slot>
+      </slot>
     </view>
   </view>
 </template>


### PR DESCRIPTION
如果使用插槽自动启用，不使用的话使用对应的默认插槽内容

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

尽可能精简使用方法，我感觉多了 use-*-slot 插槽开关纯属多余


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
  - 简化了 GridItem 组件的插槽结构，移除了 useSlot、useIconSlot 和 useTextSlot 属性，统一通过默认插槽及具名插槽实现内容自定义，并为图标和文本区域提供默认回退内容。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->