### PR TITLE
fix(drop-menu-item): 修复wd-drop-menu-item组件在popup数据较多在滚动区下拉时和页面onPullDownRefresh之间的冲突

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-drop-menu-item/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-drop-menu-item/types.ts
@@ -13,6 +13,10 @@ export type DropMenuItemBeforeToggle = (option: DropMenuItemBeforeToggleOption) 
 export const dorpMenuItemProps = {
   ...baseProps,
   /**
+   * 弹出层高度  这里设置了 就取这里的
+   */
+  popupHeight: makeStringProp(''),
+  /**
    * DropMenuItem 左侧文字样式
    */
   customTitle: makeStringProp(''),

--- a/src/uni_modules/wot-design-uni/components/wd-drop-menu-item/wd-drop-menu-item.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-drop-menu-item/wd-drop-menu-item.vue
@@ -9,7 +9,7 @@
       :z-index="zIndex"
       :duration="duration"
       :position="position"
-      :custom-style="`position: absolute; pointer-events: auto; max-height: 80%;${customPopupStyle}`"
+      :custom-style="`position: absolute; pointer-events: auto; max-height: ${popupHeight ? popupHeight : '80%'}; ${customPopupStyle}`"
       :custom-class="customPopupClass"
       :modal="false"
       :close-on-click-modal="false"
@@ -18,7 +18,7 @@
       @before-leave="beforeLeave"
       @after-leave="afterLeave"
     >
-      <view v-if="options.length">
+      <scroll-view v-if="options.length" :style="popupHeight ? { height: popupHeight } : ''" scroll-y scroll-with-animation :show-scrollbar="true">
         <view
           v-for="(item, index) in options"
           :key="index"
@@ -36,7 +36,7 @@
             :class="`wd-drop-item__icon ${customIcon}`"
           />
         </view>
-      </view>
+      </scroll-view>
       <slot v-else />
     </wd-popup>
   </view>


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
https://github.com/Moonofweisheng/wot-design-uni/issues/1107
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
##### 发现问题：
是 h5项目我在使用 咱们组件时 页面pages 设置了 enablePullDownRefrese: true 也就是启用下拉刷新 那么当在 wd-drop-menu-item 里面选项数据较多 滚动选择 滑下去 没问题 ，滑上来 会和 onPullDownRefresh 事件冲突 出发了 事件， 期望是 不触发的
![正常滚动下去](https://sp-open-read.oss-cn-beijing.aliyuncs.com/cus/11749785609_.pic.jpg)
![正常滚动下去](https://sp-open-read.oss-cn-beijing.aliyuncs.com/cus/21749785611_.pic.jpg)
![下拉有问题](https://sp-open-read.oss-cn-beijing.aliyuncs.com/cus/31749785612_.pic.jpg)

##### 解决过程：
根据经验和deepseek 得出 诸如 可以禁用相关touch事件 会有新问题 设置dom的属性等方法，均无法解决也不是合理的方案；
查阅uni-app 官方文档想 在组件 open时 禁用相关事件 close 恢复相关事件 但非app运用暂时不支持，且是一个存在7年之久的问题，uni官方支持、修复遥遥无期，因此无法寄希望与此， 相关内容
https://uniapp.dcloud.net.cn/api/ui/pulldown.html#onpulldownrefresh
https://ask.dcloud.net.cn/article/35134
https://ask.dcloud.net.cn/article/41446
各显神通但解决方案不尽人意

##### 我的最终解决方案：
1.将popup数据原来由view包裹 改为 scroll-view
2.参数添加 支持设置 popupHeight

##### 结果和影响：
总体改动较小
如果不设置popupHeight 那么表现还是和原来一致
如果设置了popupHeight 那么弹出层高度就会和 设置的popupHeight 高度一致 比如设置了 500rpx
那么 内容高度不够 500也是 500rpx 因为是设置了的容器高度  如果内容较多 那么就会在这500rpx范围内来回滚动 不会和 页面onPullDownRefresh 冲突

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 下拉菜单项新增 `popupHeight` 属性，可自定义弹出层高度。
- **优化**
  - 弹出层内容支持滚动显示，提升长列表的可用性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->