### PR TITLE
fix: 🐛 修复 wd-img-cropper 组件在微信小程序中旋转图片后操作卡顿的问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-img-cropper/wd-img-cropper.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-img-cropper/wd-img-cropper.vue
@@ -265,8 +265,12 @@ const imageStyle = computed(() => {
 /**
  * 逆转是否使用动画
  */
-function revertIsAnimation(animation: boolean) {
-  isAnimation.value = animation
+function revertIsAnimation(animation: boolean | { value: boolean }) {
+  if (typeof animation === 'boolean') {
+    isAnimation.value = animation
+  } else {
+    isAnimation.value = animation.value
+  }
 }
 
 /**
@@ -642,7 +646,7 @@ defineExpose<ImgCropperExpose>({
 function setAnimation(newValue, oldValue, ownerInstance){
   if (newValue) {
     var id = ownerInstance.setTimeout(function() {
-    ownerInstance.callMethod('revertIsAnimation',false)
+    ownerInstance.callMethod('revertIsAnimation',{value:false})
     ownerInstance.clearTimeout(id)
   },300)
   }


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

在微信小程序环境下使用 wd-img-cropper 组件，将图片旋转90度或270度后，可复现此 bug，手势操作会变得卡顿。
检查 dom 发现，image 元素的 transition-duration 属性在不断发生变化，造成的实际体验效果就是手势操作卡顿：

![bug-img-cropper](https://github.com/user-attachments/assets/7df372a7-5bd3-4d84-bb5e-23eaf84b3c1d)

断点发现 revertIsAnimation 不断被调用，且其中一次接收到的值为空对象 {}：

![Snipaste_2025-06-13_14-41-21](https://github.com/user-attachments/assets/52554447-a730-46b5-abcf-a3f37bfdabb1)

排查发现接收空对象的那次调用来自 wxs 中的 `ownerInstance.callMethod('revertIsAnimation',false)`，查看微信官方文档
[https://developers.weixin.qq.com/miniprogram/dev/framework/view/interactive-animation.html](https://developers.weixin.qq.com/miniprogram/dev/framework/view/interactive-animation.html)，可以看到 callMethod 的第二个参数只能为 object 类型

![image](https://github.com/user-attachments/assets/f9d43068-5f1a-41e8-97c4-17cfe01c1e52)

解决方案是扩大 revertIsAnimation 可接收参数的类型，兼容对象类型参数，对 wxs 中的调用进行特殊处理。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修复了图片裁剪组件在动画处理时的兼容性问题，提升了动画表现的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->