### PR TITLE
fix: 🐛 修复 wd-slider 滑块不跟手的问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-slider/wd-slider.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-slider/wd-slider.vue
@@ -1,10 +1,10 @@
 <template>
-  <view :class="rootClass" :style="customStyle" :id="sliderId">
+  <view :class="rootClass" :style="customStyle">
     <!-- #ifdef MP-DINGTALK -->
-    <view :id="sliderId" style="flex: 1" :class="rootClass">
+    <view style="flex: 1" :class="rootClass">
       <!-- #endif -->
       <view :class="`wd-slider__label-min ${customMinClass}`" v-if="!hideMinMax">{{ minProp }}</view>
-      <view class="wd-slider__bar-wrapper" :style="wrapperStyle">
+      <view class="wd-slider__bar-wrapper" :style="wrapperStyle" :id="sliderBarWrapperId">
         <view class="wd-slider__bar" :style="barStyle">
           <template v-if="isRange">
             <!-- 左边滑块 -->
@@ -76,7 +76,7 @@ const props = defineProps(sliderProps)
 const emit = defineEmits<SliderEmits>()
 
 // ----------- 基础状态 -----------
-const sliderId = ref<string>(`sliderId${uuid()}`)
+const sliderBarWrapperId = ref<string>(`sliderBarWrapperId${uuid()}`)
 const touch = useTouch()
 const touchIndex = ref<number>(0)
 const { proxy } = getCurrentInstance() as any
@@ -232,7 +232,7 @@ function clamp(value: number, min: number, max: number): number {
  * 初始化滑块宽度
  */
 function initSlider() {
-  getRect(`#${sliderId.value}`, false, proxy).then((data) => {
+  getRect(`#${sliderBarWrapperId.value}`, false, proxy).then((data) => {
     trackWidth.value = Number(data.width)
     trackLeft.value = Number(data.left)
   })


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

slider 错误的使用了根元素计算滑块移动的百分比，当滑轨两侧存在文字时，滑轨的长度小于根元素宽度，产生了移动滑块时不跟手的现象：

![fix-wd-slider](https://github.com/user-attachments/assets/572d226b-a540-4c79-8f1a-30ed7543e79e)

改为获取 wd-slider__bar-wrapper 节点的信息初始化滑块，同时移除了无用的 sliderId

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **优化**
  - 优化滑块组件的尺寸与位置测量方式，提升组件的稳定性和兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->