### PR TITLE
fix: 🐛 优化 InputNumbe 处理中间状态值的逻辑，支持配置不立即响应输入变化

### DIFF
--- a/docs/component/input-number.md
+++ b/docs/component/input-number.md
@@ -49,6 +49,17 @@ function handleChange({ value }) {
 <wd-input-number v-model="value" @change="handleChange" disable-input />
 ```
 
+## 禁用按钮
+
+可以单独禁用增加或减少按钮。
+
+```html
+<!-- 禁用减号按钮 -->
+<wd-input-number v-model="value" @change="handleChange" disable-minus />
+
+<!-- 禁用加号按钮 -->
+<wd-input-number v-model="value" @change="handleChange" disable-plus />
+```
 
 ## 无输入框
 
@@ -92,6 +103,46 @@ function handleChange({ value }) {
 
 ```typescript
 const value = ref<number|string>('')
+function handleChange({ value }) {
+  console.log(value)
+}
+```
+
+## 非立即更新模式
+
+设置 `immediate-change` 为 `false`，输入框内容变化时不会立即触发 `change` 事件，仅在失焦或点击按钮时触发。
+
+```html
+<!-- 立即更新模式（默认） -->
+<wd-input-number v-model="value1" @change="handleChange" :immediate-change="true" />
+
+<!-- 非立即更新模式 -->
+<wd-input-number v-model="value2" @change="handleChange" :immediate-change="false" />
+```
+
+```typescript
+const value1 = ref<number>(1)
+const value2 = ref<number>(1)
+function handleChange({ value }) {
+  console.log(value)
+}
+```
+
+## 初始化时自动修正
+
+设置 `format-on-init` 属性控制是否在初始化时自动修正值到有效范围。
+
+```html
+<!-- 自动修正初始值（默认） -->
+<wd-input-number v-model="value1" @change="handleChange" :format-on-init="true" :min="3" :max="15" :step="2" step-strictly />
+
+<!-- 不修正初始值 -->
+<wd-input-number v-model="value2" @change="handleChange" :format-on-init="false" :min="3" :max="15" :step="2" step-strictly />
+```
+
+```typescript
+const value1 = ref<number>(1) // 会自动修正为4（≥3的最小2的倍数）
+const value2 = ref<number>(1) // 不会自动修正
 function handleChange({ value }) {
   console.log(value)
 }
@@ -153,6 +204,8 @@ const beforeChange: InputNumberBeforeChange = (value) => {
 | adjustPosition | 原生属性，键盘弹起时，是否自动上推页面 | boolean | - | true | 1.3.11 |
 | before-change | 输入框值改变前触发，返回 false 会阻止输入框值改变，支持返回 `Promise` | `(value: number \| string) => boolean \| Promise<boolean>` | - | - | 1.6.0 |
 | long-press | 是否允许长按进行加减 | boolean | - | false | 1.8.0 |
+| immediate-change | 是否立即响应输入变化，false 时仅在失焦和按钮点击时更新 | boolean | - | true | $LOWEST_VERSION$ |
+| format-on-init | 是否在初始化时自动修正值到有效范围 | boolean | - | true | $LOWEST_VERSION$ |
 
 
 ## Events

--- a/docs/component/input-number.md
+++ b/docs/component/input-number.md
@@ -128,21 +128,24 @@ function handleChange({ value }) {
 }
 ```
 
-## 初始化时自动修正
+## 初始化时自动更新
 
-设置 `format-on-init` 属性控制是否在初始化时自动修正值到有效范围。
+设置 `update-on-init` 属性控制是否在初始化时更新 `v-model` 为修正后的值。
+
+- 当 `update-on-init="true"`（默认）时，会将初始值修正到符合 `min`、`max`、`step`、`precision` 等规则的有效值，并同步更新 `v-model`
+- 当 `update-on-init="false"` 时，保持初始值不变，仅进行显示格式化（如精度处理），不更新 `v-model`
 
 ```html
-<!-- 自动修正初始值（默认） -->
-<wd-input-number v-model="value1" @change="handleChange" :format-on-init="true" :min="3" :max="15" :step="2" step-strictly />
+<!-- 自动更新初始值（默认） -->
+<wd-input-number v-model="value1" @change="handleChange" :update-on-init="true" :min="3" :max="15" :step="2" step-strictly />
 
-<!-- 不修正初始值 -->
-<wd-input-number v-model="value2" @change="handleChange" :format-on-init="false" :min="3" :max="15" :step="2" step-strictly />
+<!-- 不更新初始值，保持原始值 -->
+<wd-input-number v-model="value2" @change="handleChange" :update-on-init="false" :min="3" :max="15" :step="2" step-strictly />
 ```
 
 ```typescript
 const value1 = ref<number>(1) // 会自动修正为4（≥3的最小2的倍数）
-const value2 = ref<number>(1) // 不会自动修正
+const value2 = ref<number>(1) // 保持为1，不会自动修正，但会按精度格式化显示
 function handleChange({ value }) {
   console.log(value)
 }
@@ -205,7 +208,7 @@ const beforeChange: InputNumberBeforeChange = (value) => {
 | before-change | 输入框值改变前触发，返回 false 会阻止输入框值改变，支持返回 `Promise` | `(value: number \| string) => boolean \| Promise<boolean>` | - | - | 1.6.0 |
 | long-press | 是否允许长按进行加减 | boolean | - | false | 1.8.0 |
 | immediate-change | 是否立即响应输入变化，false 时仅在失焦和按钮点击时更新 | boolean | - | true | $LOWEST_VERSION$ |
-| format-on-init | 是否在初始化时自动修正值到有效范围 | boolean | - | true | $LOWEST_VERSION$ |
+| update-on-init | 是否在初始化时更新 v-model 为修正后的值 | boolean | - | true | $LOWEST_VERSION$ |
 
 
 ## Events

--- a/docs/component/input-number.md
+++ b/docs/component/input-number.md
@@ -133,7 +133,7 @@ function handleChange({ value }) {
 设置 `update-on-init` 属性控制是否在初始化时更新 `v-model` 为修正后的值。
 
 - 当 `update-on-init="true"`（默认）时，会将初始值修正到符合 `min`、`max`、`step`、`precision` 等规则的有效值，并同步更新 `v-model`
-- 当 `update-on-init="false"` 时，保持初始值不变，仅进行显示格式化（如精度处理），不更新 `v-model`
+- 当 `update-on-init="false"` 时，保持初始值不修正（不改变 `v-model`），但仍会进行显示格式化（如精度处理）
 
 ```html
 <!-- 自动更新初始值（默认） -->
@@ -145,7 +145,7 @@ function handleChange({ value }) {
 
 ```typescript
 const value1 = ref<number>(1) // 会自动修正为4（≥3的最小2的倍数）
-const value2 = ref<number>(1) // 保持为1，不会自动修正，但会按精度格式化显示
+const value2 = ref<number>(1) // 保持为1，不会修正但会格式化显示
 function handleChange({ value }) {
   console.log(value)
 }
@@ -209,6 +209,7 @@ const beforeChange: InputNumberBeforeChange = (value) => {
 | long-press | 是否允许长按进行加减 | boolean | - | false | 1.8.0 |
 | immediate-change | 是否立即响应输入变化，false 时仅在失焦和按钮点击时更新 | boolean | - | true | $LOWEST_VERSION$ |
 | update-on-init | 是否在初始化时更新 v-model 为修正后的值 | boolean | - | true | $LOWEST_VERSION$ |
+| input-type | 输入框类型 | string | number / digit | digit | $LOWEST_VERSION$ |
 
 
 ## Events

--- a/docs/en-US/component/input-number.md
+++ b/docs/en-US/component/input-number.md
@@ -128,21 +128,24 @@ function handleChange({ value }) {
 }
 ```
 
-## Auto-format on Initialization
+## Auto-update on Initialization
 
-Set the `format-on-init` property to control whether to automatically correct the value to the valid range during initialization.
+Set the `update-on-init` property to control whether to update the `v-model` with the corrected value during initialization.
+
+- When `update-on-init="true"` (default), the initial value will be corrected to comply with `min`, `max`, `step`, `precision` and other rules, and the `v-model` will be updated synchronously
+- When `update-on-init="false"`, the initial value remains unchanged, only display formatting (such as precision processing) is performed, without updating the `v-model`
 
 ```html
-<!-- Auto-format initial value (default) -->
-<wd-input-number v-model="value1" @change="handleChange" :format-on-init="true" :min="3" :max="15" :step="2" step-strictly />
+<!-- Auto-update initial value (default) -->
+<wd-input-number v-model="value1" @change="handleChange" :update-on-init="true" :min="3" :max="15" :step="2" step-strictly />
 
-<!-- Don't format initial value -->
-<wd-input-number v-model="value2" @change="handleChange" :format-on-init="false" :min="3" :max="15" :step="2" step-strictly />
+<!-- Don't update initial value, keep original value -->
+<wd-input-number v-model="value2" @change="handleChange" :update-on-init="false" :min="3" :max="15" :step="2" step-strictly />
 ```
 
 ```typescript
 const value1 = ref<number>(1) // Will be auto-corrected to 4 (minimum multiple of 2 that is ≥3)
-const value2 = ref<number>(1) // Will not be auto-corrected
+const value2 = ref<number>(1) // Remains 1, will not be auto-corrected, but will be formatted for display according to precision
 function handleChange({ value }) {
   console.log(value)
 }
@@ -205,7 +208,7 @@ Set the `long-press` property to allow long press for increment/decrement.
 | before-change | Triggered before input box value changes, returning false will prevent input box value from changing, supports returning `Promise` | `(value: number \| string) => boolean \| Promise<boolean>` | - | - | 1.6.0 |
 | long-press | Whether to allow long press for increment/decrement | boolean | - | false | 1.8.0 |
 | immediate-change | Whether to respond to input changes immediately, false will only update on blur and button clicks | boolean | - | true | $LOWEST_VERSION$ |
-| format-on-init | Whether to automatically correct value to valid range during initialization | boolean | - | true | $LOWEST_VERSION$ |
+| update-on-init | Whether to update v-model with corrected value during initialization | boolean | - | true | $LOWEST_VERSION$ |
 
 ## Events
 

--- a/docs/en-US/component/input-number.md
+++ b/docs/en-US/component/input-number.md
@@ -49,6 +49,18 @@ Set the `disable-input` property.
 <wd-input-number v-model="value" @change="handleChange" disable-input />
 ```
 
+## Disable Buttons
+
+You can disable the increase or decrease buttons individually.
+
+```html
+<!-- Disable minus button -->
+<wd-input-number v-model="value" @change="handleChange" disable-minus />
+
+<!-- Disable plus button -->
+<wd-input-number v-model="value" @change="handleChange" disable-plus />
+```
+
 ## Without Input Box
 
 Set `without-input` to hide the input box.
@@ -91,6 +103,46 @@ Set the `allow-null` property to allow empty values, set `placeholder` to prompt
 
 ```typescript
 const value = ref<number|string>('')
+function handleChange({ value }) {
+  console.log(value)
+}
+```
+
+## Non-Immediate Update Mode
+
+Set `immediate-change` to `false`, the `change` event will not be triggered immediately when the input box content changes, only when it loses focus or buttons are clicked.
+
+```html
+<!-- Immediate update mode (default) -->
+<wd-input-number v-model="value1" @change="handleChange" :immediate-change="true" />
+
+<!-- Non-immediate update mode -->
+<wd-input-number v-model="value2" @change="handleChange" :immediate-change="false" />
+```
+
+```typescript
+const value1 = ref<number>(1)
+const value2 = ref<number>(1)
+function handleChange({ value }) {
+  console.log(value)
+}
+```
+
+## Auto-format on Initialization
+
+Set the `format-on-init` property to control whether to automatically correct the value to the valid range during initialization.
+
+```html
+<!-- Auto-format initial value (default) -->
+<wd-input-number v-model="value1" @change="handleChange" :format-on-init="true" :min="3" :max="15" :step="2" step-strictly />
+
+<!-- Don't format initial value -->
+<wd-input-number v-model="value2" @change="handleChange" :format-on-init="false" :min="3" :max="15" :step="2" step-strictly />
+```
+
+```typescript
+const value1 = ref<number>(1) // Will be auto-corrected to 4 (minimum multiple of 2 that is ≥3)
+const value2 = ref<number>(1) // Will not be auto-corrected
 function handleChange({ value }) {
   console.log(value)
 }
@@ -152,6 +204,8 @@ Set the `long-press` property to allow long press for increment/decrement.
 | adjustPosition | Native property, whether to automatically push up the page when keyboard pops up | boolean | - | true | 1.3.11 |
 | before-change | Triggered before input box value changes, returning false will prevent input box value from changing, supports returning `Promise` | `(value: number \| string) => boolean \| Promise<boolean>` | - | - | 1.6.0 |
 | long-press | Whether to allow long press for increment/decrement | boolean | - | false | 1.8.0 |
+| immediate-change | Whether to respond to input changes immediately, false will only update on blur and button clicks | boolean | - | true | $LOWEST_VERSION$ |
+| format-on-init | Whether to automatically correct value to valid range during initialization | boolean | - | true | $LOWEST_VERSION$ |
 
 ## Events
 

--- a/docs/en-US/component/input-number.md
+++ b/docs/en-US/component/input-number.md
@@ -133,7 +133,7 @@ function handleChange({ value }) {
 Set the `update-on-init` property to control whether to update the `v-model` with the corrected value during initialization.
 
 - When `update-on-init="true"` (default), the initial value will be corrected to comply with `min`, `max`, `step`, `precision` and other rules, and the `v-model` will be updated synchronously
-- When `update-on-init="false"`, the initial value remains unchanged, only display formatting (such as precision processing) is performed, without updating the `v-model`
+- When `update-on-init="false"`, the initial value will not be corrected (v-model unchanged), but display formatting (such as precision) will still be applied
 
 ```html
 <!-- Auto-update initial value (default) -->
@@ -145,7 +145,7 @@ Set the `update-on-init` property to control whether to update the `v-model` wit
 
 ```typescript
 const value1 = ref<number>(1) // Will be auto-corrected to 4 (minimum multiple of 2 that is ≥3)
-const value2 = ref<number>(1) // Remains 1, will not be auto-corrected, but will be formatted for display according to precision
+const value2 = ref<number>(1) // Remains 1, will not be corrected but will be formatted for display
 function handleChange({ value }) {
   console.log(value)
 }
@@ -209,6 +209,7 @@ Set the `long-press` property to allow long press for increment/decrement.
 | long-press | Whether to allow long press for increment/decrement | boolean | - | false | 1.8.0 |
 | immediate-change | Whether to respond to input changes immediately, false will only update on blur and button clicks | boolean | - | true | $LOWEST_VERSION$ |
 | update-on-init | Whether to update v-model with corrected value during initialization | boolean | - | true | $LOWEST_VERSION$ |
+| input-type | Input field type | string | number / digit | digit | $LOWEST_VERSION$ |
 
 ## Events
 

--- a/src/subPages/inputNumber/Index.vue
+++ b/src/subPages/inputNumber/Index.vue
@@ -76,9 +76,9 @@
     <demo-block title="初始化时自动修正">
       <view class="format-init-demo">
         <view class="demo-title">自动修正初始值 - 值：{{ value20 }}</view>
-        <wd-input-number v-model="value20" @change="handleChange20" :format-on-init="true" :min="3" :max="15" :step="2" step-strictly />
+        <wd-input-number v-model="value20" @change="handleChange20" :update-on-init="true" :min="3" :max="15" :step="2" step-strictly />
         <view class="demo-title">不修正初始值 - 值：{{ value21 }}</view>
-        <wd-input-number v-model="value21" @change="handleChange21" :format-on-init="false" :min="3" :max="15" :step="2" step-strictly />
+        <wd-input-number v-model="value21" @change="handleChange21" :update-on-init="false" :min="3" :max="15" :step="2" step-strictly />
         <view class="demo-note">上方组件会在初始化时自动将值1修正为4（≥3的最小2的倍数），下方组件不会自动修正</view>
       </view>
     </demo-block>

--- a/src/subPages/inputNumber/Index.vue
+++ b/src/subPages/inputNumber/Index.vue
@@ -120,61 +120,61 @@ const value19 = ref<number>(4)
 const value20 = ref<number>(1)
 const value21 = ref<number>(1)
 
-function handleChange1({ value }: any) {
+function handleChange1({ value }: { value: number | string }) {
   console.log(value)
 }
-function handleChange2({ value }: any) {
+function handleChange2({ value }: { value: number | string }) {
   console.log(value)
 }
-function handleChange3({ value }: any) {
+function handleChange3({ value }: { value: number | string }) {
   console.log(value)
 }
-function handleChange4({ value }: any) {
+function handleChange4({ value }: { value: number | string }) {
   console.log(value)
 }
-function handleChange5({ value }: any) {
+function handleChange5({ value }: { value: number | string }) {
   console.log(value)
 }
-function handleChange6({ value }: any) {
+function handleChange6({ value }: { value: number | string }) {
   console.log(value)
 }
-function handleChange7({ value }: any) {
+function handleChange7({ value }: { value: number | string }) {
   console.log(value)
 }
-function handleChange8({ value }: any) {
+function handleChange8({ value }: { value: number | string }) {
   console.log(value)
 }
-function handleChange9({ value }: any) {
+function handleChange9({ value }: { value: number | string }) {
   console.log(value)
 }
-function handleChange12({ value }: any) {
+function handleChange12({ value }: { value: number | string }) {
   console.log(value)
 }
-function handleChange13({ value }: any) {
+function handleChange13({ value }: { value: number | string }) {
   console.log(value)
 }
-function handleChange14({ value }: any) {
+function handleChange14({ value }: { value: number | string }) {
   console.log(value)
 }
-function handleChange15({ value }: any) {
+function handleChange15({ value }: { value: number | string }) {
   console.log(value)
 }
-function handleChange16({ value }: any) {
+function handleChange16({ value }: { value: number | string }) {
   console.log(value)
 }
-function handleChange17({ value }: any) {
+function handleChange17({ value }: { value: number | string }) {
   console.log(value)
 }
-function handleChange18({ value }: any) {
+function handleChange18({ value }: { value: number | string }) {
   console.log(value)
 }
-function handleChange19({ value }: any) {
+function handleChange19({ value }: { value: number | string }) {
   console.log(value)
 }
-function handleChange20({ value }: any) {
+function handleChange20({ value }: { value: number | string }) {
   console.log(value)
 }
-function handleChange21({ value }: any) {
+function handleChange21({ value }: { value: number | string }) {
   console.log(value)
 }
 

--- a/src/subPages/inputNumber/Index.vue
+++ b/src/subPages/inputNumber/Index.vue
@@ -15,6 +15,12 @@
     <demo-block :title="$t('jin-yong-shu-ru-kuang')">
       <wd-input-number v-model="value10" @change="handleChange4" disable-input />
     </demo-block>
+    <demo-block title="禁用减号按钮">
+      <wd-input-number v-model="value13" @change="handleChange13" disable-minus />
+    </demo-block>
+    <demo-block title="禁用加号按钮">
+      <wd-input-number v-model="value14" @change="handleChange14" disable-plus />
+    </demo-block>
     <demo-block :title="$t('wu-shu-ru-kuang')">
       <view class="flex">
         <view>{{ $t('shu-liang-value5') }}{{ value5 }}</view>
@@ -27,11 +33,54 @@
     <demo-block :title="$t('shu-ru-yan-ge-wei-bu-shu-de-bei-shu')">
       <wd-input-number v-model="value7" @change="handleChange7" step-strictly :step="2" />
     </demo-block>
+    <demo-block title="严格步进+边界限制">
+      <view class="strict-bounds-demo">
+        <view class="demo-description">值：{{ value19 }}（步进值2，最小值3，最大值15，严格步进模式）</view>
+        <wd-input-number v-model="value19" @change="handleChange19" step-strictly :step="2" :min="3" :max="15" />
+        <view class="demo-note">
+          尝试输入各种值：
+          <br />
+          • 输入1 → 自动调整为4（≥3的最小2的倍数）
+          <br />
+          • 输入5 → 自动调整为4（最接近的2的倍数）
+          <br />
+          • 输入17 → 自动调整为14（≤15的最大2的倍数）
+        </view>
+      </view>
+    </demo-block>
     <demo-block :title="$t('xiu-gai-shu-ru-kuang-kuan-du')">
       <wd-input-number v-model="value8" input-width="70px" @change="handleChange8" />
     </demo-block>
     <demo-block :title="$t('yun-xu-kong-zhi-bing-she-zhi-placeholder')">
       <wd-input-number v-model="value9" allow-null :placeholder="$t('bu-xian')" input-width="70px" @change="handleChange9" />
+    </demo-block>
+    <demo-block title="非允许空值但可临时删除">
+      <view class="temp-empty-demo">
+        <view class="demo-description">值：{{ value18 }}（可以删除为空，但失焦时会自动修正为最小值）</view>
+        <wd-input-number v-model="value18" @change="handleChange18" :allow-null="false" :min="1" />
+        <view class="demo-note">尝试删除输入框中的所有内容，然后点击其他地方失焦，会自动修正为最小值1</view>
+      </view>
+    </demo-block>
+    <demo-block title="键盘弹起不上推页面">
+      <wd-input-number v-model="value15" @change="handleChange15" :adjust-position="false" />
+    </demo-block>
+    <demo-block title="非立即更新模式">
+      <view class="immediate-demo">
+        <view class="demo-title">立即更新模式（默认）- 值：{{ value16 }}</view>
+        <wd-input-number v-model="value16" @change="handleChange16" :immediate-change="true" />
+        <view class="demo-title">非立即更新模式 - 值：{{ value17 }}</view>
+        <wd-input-number v-model="value17" @change="handleChange17" :immediate-change="false" />
+        <view class="demo-note">在输入框中输入内容时，上方的值会立即更新，下方的值仅在失焦或点击按钮时更新</view>
+      </view>
+    </demo-block>
+    <demo-block title="初始化时自动修正">
+      <view class="format-init-demo">
+        <view class="demo-title">自动修正初始值 - 值：{{ value20 }}</view>
+        <wd-input-number v-model="value20" @change="handleChange20" :format-on-init="true" :min="3" :max="15" :step="2" step-strictly />
+        <view class="demo-title">不修正初始值 - 值：{{ value21 }}</view>
+        <wd-input-number v-model="value21" @change="handleChange21" :format-on-init="false" :min="3" :max="15" :step="2" step-strictly />
+        <view class="demo-note">上方组件会在初始化时自动将值1修正为4（≥3的最小2的倍数），下方组件不会自动修正</view>
+      </view>
     </demo-block>
     <demo-block :title="$t('yi-bu-bian-geng')">
       <wd-input-number v-model="value11" :before-change="beforeChange" />
@@ -43,7 +92,7 @@
 </template>
 <script lang="ts" setup>
 import { useToast } from '@/uni_modules/wot-design-uni'
-import type { InputNumberBeforeChange } from '@/uni_modules/wot-design-uni/components/wd-input-number/types'
+import { type InputNumberBeforeChange } from '@/uni_modules/wot-design-uni/components/wd-input-number/types'
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 const { loading, close } = useToast()
@@ -61,6 +110,15 @@ const value9 = ref<string>('')
 const value10 = ref<number>(1)
 const value11 = ref<number>(1)
 const value12 = ref<number>(1)
+const value13 = ref<number>(1)
+const value14 = ref<number>(1)
+const value15 = ref<number>(1)
+const value16 = ref<number>(1)
+const value17 = ref<number>(1)
+const value18 = ref<number>(1)
+const value19 = ref<number>(4)
+const value20 = ref<number>(1)
+const value21 = ref<number>(1)
 
 function handleChange1({ value }: any) {
   console.log(value)
@@ -92,6 +150,33 @@ function handleChange9({ value }: any) {
 function handleChange12({ value }: any) {
   console.log(value)
 }
+function handleChange13({ value }: any) {
+  console.log(value)
+}
+function handleChange14({ value }: any) {
+  console.log(value)
+}
+function handleChange15({ value }: any) {
+  console.log(value)
+}
+function handleChange16({ value }: any) {
+  console.log(value)
+}
+function handleChange17({ value }: any) {
+  console.log(value)
+}
+function handleChange18({ value }: any) {
+  console.log(value)
+}
+function handleChange19({ value }: any) {
+  console.log(value)
+}
+function handleChange20({ value }: any) {
+  console.log(value)
+}
+function handleChange21({ value }: any) {
+  console.log(value)
+}
 
 const beforeChange: InputNumberBeforeChange = (value) => {
   loading({ msg: t('zheng-zai-geng-xin-dao-value') + value })
@@ -108,5 +193,97 @@ const beforeChange: InputNumberBeforeChange = (value) => {
   display: flex;
   justify-content: space-between;
   align-items: center;
+}
+
+.immediate-demo {
+  .demo-title {
+    font-size: 14px;
+    color: #333;
+    margin-bottom: 8px;
+    font-weight: 500;
+  }
+
+  .demo-note {
+    font-size: 12px;
+    color: #999;
+    margin-top: 12px;
+    line-height: 1.4;
+    padding: 8px;
+    background: #f5f5f5;
+    border-radius: 4px;
+  }
+
+  .wd-input-number {
+    margin-bottom: 16px;
+  }
+}
+
+.temp-empty-demo {
+  .demo-description {
+    font-size: 14px;
+    color: #333;
+    margin-bottom: 8px;
+    font-weight: 500;
+  }
+
+  .demo-note {
+    font-size: 12px;
+    color: #999;
+    margin-top: 12px;
+    line-height: 1.4;
+    padding: 8px;
+    background: #f5f5f5;
+    border-radius: 4px;
+  }
+
+  .wd-input-number {
+    margin-bottom: 16px;
+  }
+}
+
+.strict-bounds-demo {
+  .demo-description {
+    font-size: 14px;
+    color: #333;
+    margin-bottom: 8px;
+    font-weight: 500;
+  }
+
+  .demo-note {
+    font-size: 12px;
+    color: #999;
+    margin-top: 12px;
+    line-height: 1.4;
+    padding: 8px;
+    background: #f5f5f5;
+    border-radius: 4px;
+  }
+
+  .wd-input-number {
+    margin-bottom: 16px;
+  }
+}
+
+.format-init-demo {
+  .demo-title {
+    font-size: 14px;
+    color: #333;
+    margin-bottom: 8px;
+    font-weight: 500;
+  }
+
+  .demo-note {
+    font-size: 12px;
+    color: #999;
+    margin-top: 12px;
+    line-height: 1.4;
+    padding: 8px;
+    background: #f5f5f5;
+    border-radius: 4px;
+  }
+
+  .wd-input-number {
+    margin-bottom: 16px;
+  }
 }
 </style>

--- a/src/uni_modules/wot-design-uni/components/wd-input-number/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-input-number/types.ts
@@ -94,9 +94,11 @@ export const inputNumberProps = {
    */
   immediateChange: makeBooleanProp(true),
   /**
-   * 是否在初始化时自动修正值到有效范围
+   * 是否在初始化时更新 v-model 为修正后的值
+   * true: 自动修正并更新 v-model
+   * false: 保持原始值不变，仅做显示格式化
    */
-  formatOnInit: makeBooleanProp(true)
+  updateOnInit: makeBooleanProp(true)
 }
 
 export type InputNumberProps = ExtractPropTypes<typeof inputNumberProps>

--- a/src/uni_modules/wot-design-uni/components/wd-input-number/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-input-number/types.ts
@@ -1,13 +1,13 @@
 /*
  * @Author: weisheng
  * @Date: 2024-03-15 20:40:34
- * @LastEditTime: 2025-02-19 12:47:54
+ * @LastEditTime: 2025-06-13 12:35:59
  * @LastEditors: weisheng
  * @Description:
  * @FilePath: /wot-design-uni/src/uni_modules/wot-design-uni/components/wd-input-number/types.ts
  * 记得注释
  */
-import type { PropType } from 'vue'
+import type { ExtractPropTypes, PropType } from 'vue'
 import { baseProps, makeBooleanProp, makeNumberProp, makeNumericProp, makeRequiredProp, makeStringProp, numericProp } from '../common/props'
 
 /**
@@ -18,20 +18,6 @@ import { baseProps, makeBooleanProp, makeNumberProp, makeNumericProp, makeRequir
 export type InputNumberBeforeChange = (value: number | string) => boolean | Promise<boolean>
 
 export type OperationType = 'add' | 'sub'
-
-/**
- * 输入数字组件事件类型枚举
- * Input: 用户输入事件
- * Blur: 失焦事件
- * Watch: 监听值变化事件
- * Button: 按钮点击事件
- */
-export enum InputNumberEventType {
-  Input = 'input',
-  Blur = 'blur',
-  Watch = 'watch',
-  Button = 'button'
-}
 
 export const inputNumberProps = {
   ...baseProps,
@@ -102,5 +88,15 @@ export const inputNumberProps = {
   /**
    * 是否开启长按加减手势
    */
-  longPress: makeBooleanProp(false)
+  longPress: makeBooleanProp(false),
+  /**
+   * 是否立即响应输入变化，false 时仅在失焦和按钮点击时更新
+   */
+  immediateChange: makeBooleanProp(true),
+  /**
+   * 是否在初始化时自动修正值到有效范围
+   */
+  formatOnInit: makeBooleanProp(true)
 }
+
+export type InputNumberProps = ExtractPropTypes<typeof inputNumberProps>

--- a/src/uni_modules/wot-design-uni/components/wd-input-number/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-input-number/types.ts
@@ -1,7 +1,7 @@
 /*
  * @Author: weisheng
  * @Date: 2024-03-15 20:40:34
- * @LastEditTime: 2025-06-13 12:35:59
+ * @LastEditTime: 2025-06-21 18:23:35
  * @LastEditors: weisheng
  * @Description:
  * @FilePath: /wot-design-uni/src/uni_modules/wot-design-uni/components/wd-input-number/types.ts
@@ -96,9 +96,15 @@ export const inputNumberProps = {
   /**
    * 是否在初始化时更新 v-model 为修正后的值
    * true: 自动修正并更新 v-model
-   * false: 保持原始值不变，仅做显示格式化
+   * false: 保持原始值不修正，但仍会进行显示格式化
    */
-  updateOnInit: makeBooleanProp(true)
+  updateOnInit: makeBooleanProp(true),
+  /**
+   * 输入框类型
+   * number: 数字输入
+   * digit: 整数输入
+   */
+  inputType: makeStringProp<'number' | 'digit'>('digit')
 }
 
 export type InputNumberProps = ExtractPropTypes<typeof inputNumberProps>

--- a/src/uni_modules/wot-design-uni/components/wd-input-number/wd-input-number.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-input-number/wd-input-number.vue
@@ -14,7 +14,8 @@
       <input
         class="wd-input-number__input"
         :style="`${inputWidth ? 'width: ' + inputWidth : ''}`"
-        type="digit"
+        type="number"
+        :input-mode="precision ? 'decimal' : 'numeric'"
         :disabled="disabled || disableInput"
         :value="String(inputValue)"
         :placeholder="placeholder"
@@ -52,262 +53,364 @@ export default {
 import wdIcon from '../wd-icon/wd-icon.vue'
 import { computed, nextTick, ref, watch } from 'vue'
 import { isDef, isEqual } from '../common/util'
-import { inputNumberProps, InputNumberEventType, type OperationType } from './types'
+import { inputNumberProps, type OperationType } from './types'
 import { callInterceptor } from '../common/interceptor'
 
 const props = defineProps(inputNumberProps)
 const emit = defineEmits(['focus', 'blur', 'change', 'update:modelValue'])
-const inputValue = ref<string | number>(getInitValue()) // 输入框的值
-let longPressTimer: ReturnType<typeof setTimeout> | null = null // 长按定时器
+const inputValue = ref<string | number>(getInitValue())
+let longPressTimer: ReturnType<typeof setTimeout> | null = null
 
 /**
  * 判断数字是否达到最小值限制
  */
 const minDisabled = computed(() => {
-  const value = formatValue(inputValue.value)
-  const { disabled, min, step } = props
-  return disabled || Number(value) <= min || changeStep(value, -step) < min
+  const val = toNumber(inputValue.value)
+  return props.disabled || val <= props.min || addStep(val, -props.step) < props.min
 })
 
 /**
  * 判断数字是否达到最大值限制
  */
 const maxDisabled = computed(() => {
-  const value = formatValue(inputValue.value)
-  const { disabled, max, step } = props
-  return disabled || Number(value) >= max || changeStep(value, step) > max
+  const val = toNumber(inputValue.value)
+  return props.disabled || val >= props.max || addStep(val, props.step) > props.max
 })
 
 // 监听 modelValue 变化
 watch(
   () => props.modelValue,
-  (value) => {
-    updateValue(value, InputNumberEventType.Watch)
+  (val) => {
+    inputValue.value = formatValue(val)
   }
 )
 
-// 监听 max, min, precision 变化
+// 监听 max, min, precision 变化时重新格式化当前值
 watch([() => props.max, () => props.min, () => props.precision], () => {
-  const value = formatValue(inputValue.value)
-  updateValue(value, InputNumberEventType.Watch)
+  const val = toNumber(inputValue.value)
+  inputValue.value = formatValue(val)
 })
 
 /**
- * 对比两个值是否相等
- * @param value1 第一个值
- * @param value2 第二个值
- * @returns 是否相等
+ * 获取初始值
  */
-function isValueEqual(value1: number | string, value2: number | string) {
-  return isEqual(String(value1), String(value2))
-}
-
-// 获取初始值
 function getInitValue() {
-  const formatted = formatValue(props.modelValue)
-  if (!isValueEqual(formatted, props.modelValue)) {
-    emit('update:modelValue', formatted)
+  // 根据formatOnInit配置决定是否在初始化时修正值
+  if (props.formatOnInit) {
+    const formatted = formatValue(props.modelValue)
+    // 如果格式化后的值与原始值不同，同步到外部
+    if (!isEqual(String(formatted), String(props.modelValue))) {
+      emit('update:modelValue', formatted)
+    }
+    return formatted
   }
-  return formatted
-}
 
-// 将值转换为指定精度
-function toPrecision(value: number) {
-  const precision = Number(props.precision)
-  return Number(parseFloat(`${Math.round(value * Math.pow(10, precision)) / Math.pow(10, precision)}`).toFixed(precision))
+  // 不自动修正时，直接显示原始值的格式化版本
+  return formatValue(props.modelValue)
 }
 
 /**
  * 获取数字的小数位数
- * @param value 需要计算精度的数字
- * @returns 小数位数
  */
-function getPrecision(value?: number) {
-  if (!isDef(value)) return 0
-  const valueString = value.toString()
-  const dotPosition = valueString.indexOf('.')
-  let precision = 0
-  if (dotPosition !== -1) {
-    precision = valueString.length - dotPosition - 1
-  }
-  return precision
+function getPrecision(val?: number) {
+  if (!isDef(val)) return 0
+  const str = val.toString()
+  const dotIndex = str.indexOf('.')
+  return dotIndex === -1 ? 0 : str.length - dotIndex - 1
 }
 
 /**
- * 按步进值严格递增或递减
- * @param value 当前值
- * @returns 按步进值调整后的值
+ * 按指定精度处理数值
  */
-function toStrictlyStep(value: number | string) {
-  const stepPrecision = getPrecision(props.step)
-  const precisionFactory = Math.pow(10, stepPrecision)
-  return (Math.round(Number(value) / props.step) * precisionFactory * props.step) / precisionFactory
+function toPrecision(val: number) {
+  const precision = Number(props.precision)
+  return Math.round(val * Math.pow(10, precision)) / Math.pow(10, precision)
 }
 
-// 内部更新处理函数
-function doUpdate(value: string | number) {
-  inputValue.value = value
-  const formatted = formatValue(value)
+/**
+ * 将字符串或数字转换为标准数值
+ */
+function toNumber(val: string | number): number {
+  // 空值处理
+  if (props.allowNull && (!isDef(val) || val === '')) {
+    return NaN
+  }
+
+  if (!isDef(val) || val === '') {
+    return props.min
+  }
+
+  let str = String(val)
+
+  // 处理中间输入状态
+  if (str.endsWith('.')) str = str.slice(0, -1)
+  if (str.startsWith('.')) str = '0' + str
+  if (str.startsWith('-.')) str = '-0' + str.substring(1)
+  if (str === '-' || str === '') return props.min
+
+  let num = Number(str)
+  if (isNaN(num)) num = props.min
+
+  return normalizeValue(num)
+}
+
+/**
+ * 标准化数值（应用步进、边界、精度规则）
+ */
+function normalizeValue(val: number): number {
+  let result = val
+
+  // 严格步进
+  if (props.stepStrictly) {
+    const stepPrecision = getPrecision(props.step)
+    const factor = Math.pow(10, stepPrecision)
+    result = (Math.round(result / props.step) * factor * props.step) / factor
+  }
+
+  // 边界限制
+  if (props.stepStrictly) {
+    result = applyStrictBounds(result, props.min, props.max)
+  } else {
+    result = Math.min(Math.max(result, props.min), props.max)
+  }
+
+  // 精度处理
+  if (isDef(props.precision)) {
+    result = toPrecision(result)
+  }
+
+  return result
+}
+
+/**
+ * 严格步进模式下的边界处理
+ */
+function applyStrictBounds(val: number, min: number, max: number): number {
+  if (val >= min && val <= max) return val
+
+  const stepPrecision = getPrecision(props.step)
+  const factor = Math.pow(10, stepPrecision)
+
+  if (val < min) {
+    const minSteps = Math.ceil((min * factor) / (props.step * factor))
+    const candidate = toPrecision((minSteps * props.step * factor) / factor)
+    if (candidate > max) {
+      const maxSteps = Math.floor((max * factor) / (props.step * factor))
+      return toPrecision((maxSteps * props.step * factor) / factor)
+    }
+    return candidate
+  }
+
+  if (val > max) {
+    const maxSteps = Math.floor((max * factor) / (props.step * factor))
+    const candidate = toPrecision((maxSteps * props.step * factor) / factor)
+    if (candidate < min) {
+      const minSteps = Math.ceil((min * factor) / (props.step * factor))
+      return toPrecision((minSteps * props.step * factor) / factor)
+    }
+    return candidate
+  }
+
+  return val
+}
+
+/**
+ * 格式化值用于显示
+ */
+function formatValue(val: string | number): string | number {
+  if (props.allowNull && (!isDef(val) || val === '')) {
+    return ''
+  }
+
+  const num = toNumber(val)
+  return isDef(props.precision) ? num.toFixed(Number(props.precision)) : num
+}
+
+/**
+ * 检查是否为中间输入状态
+ */
+function isIntermediate(val: string): boolean {
+  if (!val) return false
+  const str = String(val)
+  return str.endsWith('.') || str.startsWith('.') || str.startsWith('-.') || str === '-' || (Number(props.precision) > 0 && str.indexOf('.') === -1)
+}
+
+/**
+ * 清理输入值
+ */
+function cleanInput(val: string): string {
+  if (!val) return ''
+
+  // 清理非数字、小数点、负号
+  let cleaned = val.replace(/[^\d.-]/g, '')
+
+  // 处理负号，保证负号只出现在最前面
+  const hasNegative = cleaned.startsWith('-')
+  cleaned = cleaned.replace(/-/g, '')
+  if (hasNegative) cleaned = '-' + cleaned
+
+  // 处理小数点
+  const precision = Number(props.precision)
+  if (precision > 0) {
+    const parts = cleaned.split('.')
+    if (parts.length > 2) {
+      cleaned = parts[0] + '.' + parts.slice(1).join('')
+    }
+  } else {
+    cleaned = cleaned.split('.')[0]
+  }
+
+  // 处理以点开头的情况
+  if (cleaned.startsWith('.')) return '0' + cleaned
+  if (cleaned.startsWith('-.')) return '-0' + cleaned.substring(1)
+
+  return cleaned
+}
+
+/**
+ * 更新值并触发事件
+ */
+function updateValue(val: string | number) {
+  // 空值处理
+  if (props.allowNull && (!isDef(val) || val === '')) {
+    if (isEqual('', String(props.modelValue))) {
+      inputValue.value = ''
+      return
+    }
+
+    const doUpdate = () => {
+      inputValue.value = ''
+      emit('update:modelValue', '')
+      emit('change', { value: '' })
+    }
+
+    callInterceptor(props.beforeChange, { args: [''], done: doUpdate })
+    return
+  }
+
+  const num = toNumber(val)
+  const display = formatValue(val)
+
+  if (isEqual(String(num), String(props.modelValue))) {
+    inputValue.value = display
+    return
+  }
+
+  const doUpdate = () => {
+    inputValue.value = display
+    emit('update:modelValue', num)
+    emit('change', { value: num })
+  }
+
+  callInterceptor(props.beforeChange, { args: [num], done: doUpdate })
+}
+
+/**
+ * 按步进值增减
+ */
+function addStep(val: string | number, step: number) {
+  const num = Number(val)
+  if (isNaN(num)) return normalizeValue(props.min)
+
+  const precision = Math.max(getPrecision(num), getPrecision(step))
+  const factor = Math.pow(10, precision)
+  const result = (num * factor + step * factor) / factor
+  return normalizeValue(result)
+}
+
+/**
+ * 处理按钮点击
+ */
+function handleClick(type: OperationType) {
+  const step = type === 'add' ? props.step : -props.step
+  if ((step < 0 && (minDisabled.value || props.disableMinus)) || (step > 0 && (maxDisabled.value || props.disablePlus))) return
+
+  const newVal = addStep(inputValue.value, step)
+  updateValue(newVal)
+}
+
+/**
+ * 处理输入事件
+ */
+function handleInput(event: any) {
+  const rawVal = event.detail.value || ''
+
+  // 立即更新显示
+  inputValue.value = rawVal
+
   nextTick(() => {
-    inputValue.value = formatted
-    emit('update:modelValue', inputValue.value)
-    emit('change', { value: inputValue.value })
+    // 空值处理
+    if (rawVal === '') {
+      inputValue.value = ''
+      if (props.immediateChange && props.allowNull) {
+        updateValue('')
+      }
+      return
+    }
+
+    // 清理输入
+    const cleaned = cleanInput(rawVal)
+
+    // 中间状态处理
+    if (Number(props.precision) > 0 && isIntermediate(cleaned)) {
+      inputValue.value = cleaned
+      return
+    }
+
+    // 正常输入处理
+    inputValue.value = cleaned
+    if (props.immediateChange) {
+      updateValue(cleaned)
+    }
   })
 }
 
 /**
- * 清理输入字符串中多余的小数点
- * @param value 输入的字符串
- * @returns 清理后的字符串
+ * 处理失焦事件
  */
-function cleanExtraDecimal(value: string): string {
-  const precisionAllowed = Number(props.precision) > 0
-  if (precisionAllowed) {
-    const dotIndex = value.indexOf('.')
-    if (dotIndex === -1) {
-      return value
-    } else {
-      const integerPart = value.substring(0, dotIndex + 1)
-      // 去除后续出现的'.'
-      const decimalPart = value.substring(dotIndex + 1).replace(/\./g, '')
-      return integerPart + decimalPart
-    }
-  } else {
-    // 不允许小数：保留整数部分
-    const dotIndex = value.indexOf('.')
-    return dotIndex !== -1 ? value.substring(0, dotIndex) : value
-  }
+function handleBlur(event: any) {
+  const val = event.detail.value || ''
+  updateValue(val)
+  emit('blur', { value: val })
 }
 
 /**
- * 更新输入框的值
- * @param value 新的值
- * @param eventType 触发更新的事件类型
+ * 处理聚焦事件
  */
-function updateValue(value: string | number, eventType: InputNumberEventType = InputNumberEventType.Input) {
-  const fromUser = eventType !== InputNumberEventType.Watch // watch时不认为是用户直接输入
-  const forceFormat = eventType === InputNumberEventType.Blur || eventType === InputNumberEventType.Button
-  // 对于 Input 和 Watch 类型，如果值以'.'结尾，则直接更新，不进行格式化
-  if ((eventType === InputNumberEventType.Input || eventType === InputNumberEventType.Watch) && String(value).endsWith('.') && props.precision) {
-    inputValue.value = value
-    nextTick(() => {
-      inputValue.value = cleanExtraDecimal(String(value))
-      emit('update:modelValue', inputValue.value)
-      emit('change', { value: inputValue.value })
-    })
-    return
-  }
-  if (!forceFormat && isValueEqual(value, inputValue.value)) {
-    return
-  }
-
-  const update = () => doUpdate(value)
-
-  if (fromUser) {
-    callInterceptor(props.beforeChange, {
-      args: [value],
-      done: update
-    })
-  } else {
-    update()
-  }
+function handleFocus(event: any) {
+  emit('focus', event.detail)
 }
 
-// 根据步进值改变值
-function changeStep(val: string | number, step: number) {
-  val = Number(val)
-  if (isNaN(val)) {
-    return props.min
-  }
-  const precision = Math.max(getPrecision(val), getPrecision(step))
-  const precisionFactor = Math.pow(10, precision)
-  return toPrecision((val * precisionFactor + step * precisionFactor) / precisionFactor)
-}
-
-function changeValue(step: number) {
-  if ((step < 0 && (minDisabled.value || props.disableMinus)) || (step > 0 && (maxDisabled.value || props.disablePlus))) return
-  const value = changeStep(inputValue.value, step)
-  updateValue(value, InputNumberEventType.Button)
-}
-
-// 增减值
-function handleClick(type: OperationType) {
-  const diff = type === 'add' ? props.step : -props.step
-  changeValue(diff)
-}
-
-function handleInput(event: any) {
-  const rawValue = event.detail.value || ''
-  updateValue(rawValue, InputNumberEventType.Input)
-}
-
-function handleBlur(event: any) {
-  const value = event.detail.value || ''
-  updateValue(value, InputNumberEventType.Blur)
-  emit('blur', { value })
-}
-
-// 每隔一段时间，重新调用自身，达到长按加减效果
+/**
+ * 长按逻辑
+ */
 function longPressStep(type: OperationType) {
-  clearlongPressTimer()
+  clearLongPressTimer()
   longPressTimer = setTimeout(() => {
     handleClick(type)
     longPressStep(type)
   }, 250)
 }
 
-// 按下一段时间后，达到长按状态
 function handleTouchStart(type: OperationType) {
   if (!props.longPress) return
-  clearlongPressTimer()
+  clearLongPressTimer()
   longPressTimer = setTimeout(() => {
     handleClick(type)
     longPressStep(type)
   }, 600)
 }
 
-// 触摸结束，清除定时器，停止长按加减
 function handleTouchEnd() {
   if (!props.longPress) return
-  clearlongPressTimer()
+  clearLongPressTimer()
 }
 
-// 清除定时器
-function clearlongPressTimer() {
+function clearLongPressTimer() {
   if (longPressTimer) {
     clearTimeout(longPressTimer)
     longPressTimer = null
   }
-}
-
-// 处理聚焦事件
-function handleFocus(event: any) {
-  emit('focus', event.detail)
-}
-
-// 格式化值
-function formatValue(value: string | number) {
-  if (props.allowNull && (!isDef(value) || value === '')) {
-    return ''
-  }
-
-  let formatted = Number(value)
-
-  if (isNaN(formatted)) {
-    formatted = props.min
-  }
-
-  if (props.stepStrictly) {
-    formatted = toStrictlyStep(value)
-  }
-
-  formatted = Math.min(Math.max(formatted, props.min), props.max)
-
-  if (isDef(props.precision)) {
-    formatted = toPrecision(formatted)
-  }
-
-  return formatted
 }
 </script>
 

--- a/src/uni_modules/wot-design-uni/components/wd-input-number/wd-input-number.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-input-number/wd-input-number.vue
@@ -223,7 +223,11 @@ function formatValue(val: string | number): string | number {
   }
 
   const num = toNumber(val)
-  return isDef(props.precision) ? num.toFixed(Number(props.precision)) : num
+  const precision = Number(props.precision)
+  if (!isDef(props.precision)) {
+    return num
+  }
+  return precision === 0 ? Number(num.toFixed(0)) : num.toFixed(precision)
 }
 
 /**

--- a/src/uni_modules/wot-design-uni/components/wd-input-number/wd-input-number.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-input-number/wd-input-number.vue
@@ -95,18 +95,17 @@ watch([() => props.max, () => props.min, () => props.precision], () => {
  * 获取初始值
  */
 function getInitValue() {
-  // 根据formatOnInit配置决定是否在初始化时修正值
-  if (props.formatOnInit) {
-    const formatted = formatValue(props.modelValue)
+  const formatted = formatValue(props.modelValue)
+
+  // 根据updateOnInit配置决定是否在初始化时更新v-model
+  if (props.updateOnInit) {
     // 如果格式化后的值与原始值不同，同步到外部
     if (!isEqual(String(formatted), String(props.modelValue))) {
       emit('update:modelValue', formatted)
     }
-    return formatted
   }
 
-  // 不自动修正时，直接显示原始值的格式化版本
-  return formatValue(props.modelValue)
+  return formatted
 }
 
 /**
@@ -215,7 +214,7 @@ function applyStrictBounds(val: number, min: number, max: number): number {
 }
 
 /**
- * 格式化值用于显示
+ * 格式化值用于显示（包含修正逻辑）
  */
 function formatValue(val: string | number): string | number {
   if (props.allowNull && (!isDef(val) || val === '')) {

--- a/tests/components/wd-input-number.test.ts
+++ b/tests/components/wd-input-number.test.ts
@@ -1,52 +1,137 @@
 import { mount } from '@vue/test-utils'
 import WdInputNumber from '@/uni_modules/wot-design-uni/components/wd-input-number/wd-input-number.vue'
-import { describe, test, expect } from 'vitest'
+import { describe, test, expect, vi } from 'vitest'
+import { nextTick, defineComponent, ref, toRefs } from 'vue'
+import { type InputNumberProps } from '@/uni_modules/wot-design-uni/components/wd-input-number/types'
+
+// 辅助函数：创建带v-model的包装组件
+function createWrapper(props: Partial<InputNumberProps> = {}, vModelValue: number | string = 1) {
+  const WrapperComponent = defineComponent({
+    components: { WdInputNumber },
+    props: {
+      // 定义所有可能的props，这样可以通过setProps动态修改
+      modelValue: { type: [Number, String], default: undefined },
+      min: { type: Number, default: -Infinity },
+      max: { type: Number, default: Infinity },
+      step: { type: Number, default: 1 },
+      precision: { type: [Number, String], default: undefined },
+      stepStrictly: { type: Boolean, default: false },
+      disabled: { type: Boolean, default: false },
+      disableInput: { type: Boolean, default: false },
+      disableMinus: { type: Boolean, default: false },
+      disablePlus: { type: Boolean, default: false },
+      withoutInput: { type: Boolean, default: false },
+      inputWidth: { type: [String, Number], default: undefined },
+      allowNull: { type: Boolean, default: false },
+      placeholder: { type: String, default: undefined },
+      adjustPosition: { type: Boolean, default: true },
+      immediateChange: { type: Boolean, default: true },
+      longPress: { type: Boolean, default: false },
+      beforeChange: { type: Function, default: undefined },
+      customClass: { type: String, default: '' },
+      customStyle: { type: String, default: '' },
+      formatOnInit: { type: Boolean, default: false }
+    },
+    setup(componentProps) {
+      const value = ref(vModelValue)
+
+      // 返回所有props，使其可以在模板中使用
+      return {
+        value,
+        ...toRefs(componentProps)
+      }
+    },
+    template: `<WdInputNumber 
+      v-model="value" 
+      :min="min"
+      :max="max"
+      :step="step"
+      :precision="precision"
+      :step-strictly="stepStrictly"
+      :disabled="disabled"
+      :disable-input="disableInput"
+      :disable-minus="disableMinus"
+      :disable-plus="disablePlus"
+      :without-input="withoutInput"
+      :input-width="inputWidth"
+      :allow-null="allowNull"
+      :placeholder="placeholder"
+      :adjust-position="adjustPosition"
+      :immediate-change="immediateChange"
+      :long-press="longPress"
+      :before-change="beforeChange"
+      :custom-class="customClass"
+      :custom-style="customStyle"
+      :format-on-init="formatOnInit"
+    />`
+  })
+
+  return mount(WrapperComponent, { props })
+}
+
+// 辅助函数：创建不需要v-model的组件（用于测试单向props）
+function createPropsOnlyWrapper(props: any = {}) {
+  return mount(WdInputNumber, { props })
+}
+
+// 辅助函数：模拟input事件
+function createInputEvent(value: string) {
+  return {
+    detail: { value }
+  }
+}
+
+// 辅助函数：模拟input输入
+async function simulateInput(wrapper: any, value: string) {
+  // 直接调用组件的handleInput方法
+  const component = wrapper.findComponent(WdInputNumber)
+  if (component.exists()) {
+    component.vm.handleInput(createInputEvent(value))
+  }
+  await nextTick()
+}
+
+// 辅助函数：模拟blur失焦
+async function simulateBlur(wrapper: any, value: string) {
+  // 直接调用组件的handleBlur方法
+  const component = wrapper.findComponent(WdInputNumber)
+  if (component.exists()) {
+    component.vm.handleBlur(createInputEvent(value))
+  }
+  await nextTick()
+}
 
 describe('WdInputNumber', () => {
   // 测试基本渲染
   test('基本渲染', () => {
-    const wrapper = mount(WdInputNumber, {
-      props: {
-        modelValue: 1
-      }
-    })
-    expect(wrapper.classes()).toContain('wd-input-number')
+    const wrapper = createWrapper()
+    expect(wrapper.findComponent(WdInputNumber).classes()).toContain('wd-input-number')
     expect(wrapper.find('.wd-input-number__input').exists()).toBe(true)
     expect(wrapper.findAll('.wd-input-number__action').length).toBe(2)
   })
 
   // 测试输入值
   test('显示正确的值', async () => {
-    const wrapper = mount(WdInputNumber, {
-      props: {
-        modelValue: 5
-      }
-    })
-    // 使用 attributes 代替直接访问 element.value
+    const wrapper = createWrapper({}, 5)
     expect(wrapper.find('.wd-input-number__input').attributes('value')).toBe('5')
 
-    await wrapper.setProps({ modelValue: 10 })
+    // 测试v-model更新
+    wrapper.vm.value = 10
+    await nextTick()
     expect(wrapper.find('.wd-input-number__input').attributes('value')).toBe('10')
   })
 
   // 测试最小值限制
   test('最小值限制', async () => {
-    const wrapper = mount(WdInputNumber, {
-      props: {
-        modelValue: 5,
-        min: 3
-      }
-    })
+    const wrapper = createWrapper({ min: 3 }, 5)
 
-    // 点击减号按钮两次，值应该变为3
+    // 点击减号按钮多次，值应该不能低于最小值
     await wrapper.findAll('.wd-input-number__action')[0].trigger('click')
     await wrapper.findAll('.wd-input-number__action')[0].trigger('click')
     await wrapper.findAll('.wd-input-number__action')[0].trigger('click')
 
-    // 检查是否发出了正确的事件
-    const emitted = wrapper.emitted('update:modelValue') as Array<any[]>
-    expect(emitted).toBeTruthy()
-    expect(emitted[emitted.length - 1]).toEqual([3])
+    // 值应该被限制在最小值
+    expect(wrapper.vm.value).toBe(3)
 
     // 当值等于最小值时，减号按钮应该被禁用
     expect(wrapper.findAll('.wd-input-number__action')[0].classes()).toContain('is-disabled')
@@ -54,22 +139,15 @@ describe('WdInputNumber', () => {
 
   // 测试最大值限制
   test('最大值限制', async () => {
-    const wrapper = mount(WdInputNumber, {
-      props: {
-        modelValue: 8,
-        max: 10
-      }
-    })
+    const wrapper = createWrapper({ max: 10 }, 8)
 
-    // 点击加号按钮两次，值应该变为10
+    // 点击加号按钮多次，值应该不能超过最大值
     await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
     await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
     await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
 
-    // 检查是否发出了正确的事件
-    const emitted = wrapper.emitted('update:modelValue') as Array<any[]>
-    expect(emitted).toBeTruthy()
-    expect(emitted[emitted.length - 1]).toEqual([10])
+    // 值应该被限制在最大值
+    expect(wrapper.vm.value).toBe(10)
 
     // 当值等于最大值时，加号按钮应该被禁用
     expect(wrapper.findAll('.wd-input-number__action')[1].classes()).toContain('is-disabled')
@@ -77,169 +155,975 @@ describe('WdInputNumber', () => {
 
   // 测试步进值
   test('按步进值增减', async () => {
-    const wrapper = mount(WdInputNumber, {
-      props: {
-        modelValue: 5,
-        step: 2
-      }
-    })
+    const wrapper = createWrapper({ step: 2 }, 5)
 
     // 点击加号按钮，值应该增加2
     await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
-    let emitted = wrapper.emitted('update:modelValue') as Array<any[]>
-    expect(emitted).toBeTruthy()
-    expect(emitted[emitted.length - 1]).toEqual([7])
+    expect(wrapper.vm.value).toBe(7)
 
     // 点击减号按钮，值应该减少2
     await wrapper.findAll('.wd-input-number__action')[0].trigger('click')
-    emitted = wrapper.emitted('update:modelValue') as Array<any[]>
-    expect(emitted[emitted.length - 1]).toEqual([5])
+    expect(wrapper.vm.value).toBe(5)
   })
 
   // 测试精度
   test('精度设置', async () => {
-    const wrapper = mount(WdInputNumber, {
-      props: {
-        modelValue: 1,
-        step: 0.1,
-        precision: 2
-      }
-    })
+    const wrapper = createWrapper({ step: 0.1, precision: 2 }, 1)
 
     // 点击加号按钮，值应该增加0.1并保持2位小数精度
     await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
-    const emitted = wrapper.emitted('update:modelValue') as Array<any[]>
-    expect(emitted).toBeTruthy()
-    expect(emitted[emitted.length - 1]).toEqual([1.1])
+    expect(wrapper.vm.value).toBe(1.1)
+  })
+
+  // 测试严格步进模式
+  test('严格步进模式', async () => {
+    const wrapper = createWrapper({ step: 2, stepStrictly: true }, 1)
+
+    // 模拟输入
+    await simulateInput(wrapper, '3')
+    await simulateBlur(wrapper, '3')
+    await nextTick()
+
+    // 输入3，步进2：Math.round(3/2)*2 = Math.round(1.5)*2 = 2*2 = 4
+    expect(wrapper.vm.value).toBe(4)
+  })
+
+  // 测试严格步进模式 + 边界限制
+  test('严格步进模式与边界限制', async () => {
+    const wrapper = createWrapper(
+      {
+        step: 2,
+        min: 3,
+        max: 15,
+        stepStrictly: true
+      },
+      4
+    )
+
+    // 输入1，应该调整为4（≥3的最小2的倍数）
+    await simulateInput(wrapper, '1')
+    await simulateBlur(wrapper, '1')
+    await nextTick()
+    expect(wrapper.vm.value).toBe(4)
+
+    // 输入17，应该调整为14（≤15的最大2的倍数）
+    await simulateInput(wrapper, '17')
+    await simulateBlur(wrapper, '17')
+    await nextTick()
+    expect(wrapper.vm.value).toBe(14)
   })
 
   // 测试禁用状态
   test('禁用组件', async () => {
-    const wrapper = mount(WdInputNumber, {
-      props: {
-        modelValue: 5,
-        disabled: true
-      }
-    })
+    const wrapper = createWrapper({ disabled: true }, 5)
 
-    expect(wrapper.classes()).toContain('is-disabled')
-    // 使用 attributes 代替直接访问 element.disabled
+    expect(wrapper.findComponent(WdInputNumber).classes()).toContain('is-disabled')
     expect(wrapper.find('.wd-input-number__input').attributes('disabled')).toBe('')
 
+    const initialValue = wrapper.vm.value
     // 点击按钮不应该改变值
     await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
-    expect(wrapper.emitted('update:modelValue')).toBeFalsy()
+    expect(wrapper.vm.value).toBe(initialValue)
   })
 
   // 测试禁用输入
   test('仅禁用输入', async () => {
-    const wrapper = mount(WdInputNumber, {
-      props: {
-        modelValue: 5,
-        disableInput: true
-      }
-    })
+    const wrapper = createWrapper({ disableInput: true }, 5)
 
-    // 使用 attributes 代替直接访问 element.disabled
     expect(wrapper.find('.wd-input-number__input').attributes('disabled')).toBe('')
 
     // 按钮应该仍然可用
     await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
-    expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+    expect(wrapper.vm.value).toBe(6)
   })
 
   // 测试禁用加号按钮
   test('禁用加号按钮', async () => {
-    const wrapper = mount(WdInputNumber, {
-      props: {
-        modelValue: 5,
-        disablePlus: true
-      }
-    })
+    const wrapper = createWrapper({ disablePlus: true }, 5)
 
     expect(wrapper.findAll('.wd-input-number__action')[1].classes()).toContain('is-disabled')
 
+    const initialValue = wrapper.vm.value
     // 点击加号按钮不应该改变值
     await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
-    expect(wrapper.emitted('update:modelValue')).toBeFalsy()
+    expect(wrapper.vm.value).toBe(initialValue)
 
     // 减号按钮应该仍然可用
     await wrapper.findAll('.wd-input-number__action')[0].trigger('click')
-    expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+    expect(wrapper.vm.value).toBe(4)
   })
 
   // 测试禁用减号按钮
   test('禁用减号按钮', async () => {
-    const wrapper = mount(WdInputNumber, {
-      props: {
-        modelValue: 5,
-        disableMinus: true
-      }
-    })
+    const wrapper = createWrapper({ disableMinus: true }, 5)
 
     expect(wrapper.findAll('.wd-input-number__action')[0].classes()).toContain('is-disabled')
 
+    const initialValue = wrapper.vm.value
     // 点击减号按钮不应该改变值
     await wrapper.findAll('.wd-input-number__action')[0].trigger('click')
-    expect(wrapper.emitted('update:modelValue')).toBeFalsy()
+    expect(wrapper.vm.value).toBe(initialValue)
 
     // 加号按钮应该仍然可用
     await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
-    expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+    expect(wrapper.vm.value).toBe(6)
   })
 
   // 测试不显示输入框
   test('隐藏输入框', () => {
-    const wrapper = mount(WdInputNumber, {
-      props: {
-        modelValue: 5,
-        withoutInput: true
-      }
-    })
+    const wrapper = createWrapper({ withoutInput: true }, 5)
 
-    expect(wrapper.classes()).toContain('is-without-input')
+    expect(wrapper.findComponent(WdInputNumber).classes()).toContain('is-without-input')
     expect(wrapper.find('.wd-input-number__input').exists()).toBe(false)
   })
 
-  // 测试输入框宽度
+  // 测试输入框宽度 - 只需要验证组件正常渲染
   test('设置输入框宽度', () => {
-    const wrapper = mount(WdInputNumber, {
-      props: {
-        modelValue: 5,
-        inputWidth: 100
-      }
-    })
-
-    // 只检查组件是否正确渲染，不检查具体样式
+    const wrapper = createWrapper({ inputWidth: '100px' }, 5)
     expect(wrapper.find('.wd-input-number__input').exists()).toBe(true)
+  })
+
+  // 测试允许空值
+  test('允许空值', async () => {
+    const wrapper = createWrapper({ allowNull: true }, '')
+
+    expect(wrapper.find('.wd-input-number__input').attributes('value')).toBe('')
+
+    await simulateInput(wrapper, '')
+    await simulateBlur(wrapper, '')
+    await nextTick()
+
+    expect(wrapper.vm.value).toBe('')
+  })
+
+  // 测试不允许空值的临时删除
+  test('非允许空值但可临时删除', async () => {
+    const wrapper = createWrapper({ allowNull: false, min: 1 }, 5)
+
+    await simulateInput(wrapper, '')
+    await nextTick()
+
+    // 输入过程中应该显示空值
+    expect(wrapper.find('.wd-input-number__input').attributes('value')).toBe('')
+
+    // 失焦后应该自动修正为最小值
+    await simulateBlur(wrapper, '')
+    await nextTick()
+    expect(wrapper.vm.value).toBe(1)
   })
 
   // 测试输入框占位符
   test('显示占位符', () => {
     const placeholder = '请输入'
-    const wrapper = mount(WdInputNumber, {
-      props: {
-        modelValue: '',
-        allowNull: true,
-        placeholder
-      }
-    })
+    const wrapper = createWrapper({ allowNull: true, placeholder }, '')
 
     expect(wrapper.find('.wd-input-number__input').attributes('placeholder')).toBe(placeholder)
   })
 
-  // 测试焦点事件
-  test('触发焦点和失焦事件', async () => {
-    const wrapper = mount(WdInputNumber, {
-      props: {
-        modelValue: 5
-      }
+  // 测试adjustPosition属性
+  test('adjustPosition属性', () => {
+    const wrapper = createWrapper({ adjustPosition: false }, 5)
+    expect(wrapper.find('.wd-input-number__input').attributes('adjust-position')).toBe('false')
+  })
+
+  // 测试立即更新模式
+  test('立即更新模式', async () => {
+    const wrapper = createWrapper({ immediateChange: true }, 1)
+
+    await simulateInput(wrapper, '5')
+    await nextTick()
+
+    // 立即模式下应该立即更新
+    expect(wrapper.vm.value).toBe(5)
+  })
+
+  // 测试非立即更新模式
+  test('非立即更新模式', async () => {
+    const wrapper = createWrapper({ immediateChange: false }, 1)
+
+    await simulateInput(wrapper, '5')
+    await nextTick()
+
+    // 非立即模式下输入时不应该更新
+    expect(wrapper.vm.value).toBe(1)
+
+    // 失焦时才更新
+    await simulateBlur(wrapper, '5')
+    await nextTick()
+    expect(wrapper.vm.value).toBe(5)
+  })
+
+  // 测试初始化时自动修正
+  test('初始化时自动修正', async () => {
+    const wrapper = createPropsOnlyWrapper({
+      modelValue: 1,
+      min: 3,
+      max: 15,
+      step: 2,
+      stepStrictly: true,
+      formatOnInit: true
     })
 
+    await nextTick()
+
+    // 应该触发update:modelValue事件，将值从1修正为4
+    const updateEvents = wrapper.emitted('update:modelValue')
+    expect(updateEvents).toBeTruthy()
+    expect(updateEvents![0]).toEqual([4])
+  })
+
+  // 测试不自动修正初始值
+  test('不自动修正初始值', async () => {
+    const wrapper = createPropsOnlyWrapper({
+      modelValue: 1,
+      min: 3,
+      max: 15,
+      step: 2,
+      stepStrictly: true,
+      formatOnInit: false
+    })
+
+    await nextTick()
+
+    // 不应该触发update:modelValue事件
+    const updateEvents = wrapper.emitted('update:modelValue')
+    expect(updateEvents).toBeFalsy()
+  })
+
+  // 测试拦截器功能 - 使用props形式测试更合适
+  test('beforeChange拦截器', async () => {
+    let shouldAllow = true
+    const beforeChange = vi.fn(() => shouldAllow)
+
+    const wrapper = createPropsOnlyWrapper({
+      modelValue: 5,
+      beforeChange
+    })
+
+    // 允许变更
+    shouldAllow = true
+    await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
+    expect(beforeChange).toHaveBeenCalled()
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+
+    // 阻止变更
+    shouldAllow = false
+    beforeChange.mockClear()
+    const previousEvents = wrapper.emitted('update:modelValue')?.length || 0
+    await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
+    expect(beforeChange).toHaveBeenCalled()
+    const currentEvents = wrapper.emitted('update:modelValue')?.length || 0
+    expect(currentEvents).toBe(previousEvents) // 事件数量不应该增加
+  })
+
+  // 测试异步拦截器
+  test('异步beforeChange拦截器', async () => {
+    const beforeChange = vi.fn(() => Promise.resolve(true))
+
+    const wrapper = createPropsOnlyWrapper({
+      modelValue: 5,
+      beforeChange
+    })
+
+    await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
+    expect(beforeChange).toHaveBeenCalled()
+
+    // 等待异步操作完成
+    await nextTick()
+    expect(wrapper.emitted('update:modelValue')).toBeTruthy()
+  })
+
+  // 测试长按功能
+  test('长按功能', async () => {
+    vi.useFakeTimers()
+
+    const wrapper = createWrapper({ longPress: true }, 5)
+
+    const addButton = wrapper.findAll('.wd-input-number__action')[1]
+
+    // 开始长按
+    await addButton.trigger('touchstart')
+
+    // 等待600ms后应该触发第一次增加
+    vi.advanceTimersByTime(600)
+    await nextTick()
+    expect(wrapper.vm.value).toBe(6)
+
+    // 继续长按，应该每250ms触发一次
+    vi.advanceTimersByTime(250)
+    await nextTick()
+    expect(wrapper.vm.value).toBe(7)
+
+    // 结束长按
+    await addButton.trigger('touchend')
+
+    vi.useRealTimers()
+  })
+
+  // 测试焦点事件
+  test('触发焦点和失焦事件', async () => {
+    const wrapper = createWrapper({}, 5)
+
     await wrapper.find('.wd-input-number__input').trigger('focus')
-    expect(wrapper.emitted('focus')).toBeTruthy()
+    expect(wrapper.findComponent(WdInputNumber).emitted('focus')).toBeTruthy()
 
     await wrapper.find('.wd-input-number__input').trigger('blur')
-    expect(wrapper.emitted('blur')).toBeTruthy()
+    expect(wrapper.findComponent(WdInputNumber).emitted('blur')).toBeTruthy()
+  })
+
+  // 测试输入处理：中间状态
+  test('中间状态输入处理', async () => {
+    const wrapper = createWrapper({ precision: 2, immediateChange: false }, 1)
+
+    // 输入以小数点结尾的值
+    await simulateInput(wrapper, '1.')
+    await nextTick()
+
+    // 中间状态应该只更新显示值，不提交
+    expect(wrapper.find('.wd-input-number__input').attributes('value')).toBe('1.')
+    expect(wrapper.vm.value).toBe(1) // v-model值不应该变化
+
+    // 失焦时应该格式化并提交
+    await simulateBlur(wrapper, '1.')
+    await nextTick()
+    expect(wrapper.vm.value).toBe(1)
+  })
+
+  // 测试以小数点开头的输入
+  test('以小数点开头的输入', async () => {
+    const wrapper = createWrapper({ precision: 2 }, 1)
+
+    await simulateInput(wrapper, '.5')
+    await simulateBlur(wrapper, '.5')
+    await nextTick()
+
+    expect(wrapper.vm.value).toBe(0.5)
+  })
+
+  // 测试负数输入
+  test('负数输入处理', async () => {
+    const wrapper = createWrapper({ min: -10 }, 1)
+
+    // 只输入负号
+    await simulateInput(wrapper, '-')
+    await nextTick()
+
+    // 中间状态应该显示负号，但实际组件可能直接处理为最小值
+    const currentValue = wrapper.find('.wd-input-number__input').attributes('value')
+    expect(['-', '-10']).toContain(currentValue)
+
+    // 失焦时应该转为最小值
+    await simulateBlur(wrapper, '-')
+    await nextTick()
+    expect(wrapper.vm.value).toBe(-10)
+  })
+
+  // 测试负小数输入
+  test('负小数输入处理', async () => {
+    const wrapper = createWrapper({ min: -10, precision: 2 }, 1)
+
+    await simulateInput(wrapper, '-.5')
+    await simulateBlur(wrapper, '-.5')
+    await nextTick()
+
+    expect(wrapper.vm.value).toBe(-0.5)
+  })
+
+  // 测试非法字符输入过滤
+  test('非法字符输入过滤', async () => {
+    const wrapper = createWrapper({}, 1)
+
+    await simulateInput(wrapper, 'abc123def')
+    await nextTick()
+
+    // 应该只保留数字
+    expect(wrapper.find('.wd-input-number__input').attributes('value')).toBe('123')
+  })
+
+  // 测试多个小数点处理
+  test('多个小数点处理', async () => {
+    const wrapper = createWrapper({ precision: 2 }, 1)
+
+    await simulateInput(wrapper, '1.2.3')
+    await nextTick()
+
+    // 应该只保留第一个小数点
+    expect(wrapper.find('.wd-input-number__input').attributes('value')).toBe('1.23')
+  })
+
+  // 测试精度为0时的小数点过滤
+  test('精度为0时过滤小数点', async () => {
+    const wrapper = createWrapper({ precision: 0 }, 1)
+
+    await simulateInput(wrapper, '1.5')
+    await nextTick()
+
+    // 精度为0时应该移除小数点
+    expect(wrapper.find('.wd-input-number__input').attributes('value')).toBe('1')
+  })
+
+  // 测试超出边界的输入
+  test('超出边界的输入处理', async () => {
+    const wrapper = createWrapper({ min: 1, max: 10 }, 5)
+
+    // 输入小于最小值的数
+    await simulateInput(wrapper, '0')
+    await simulateBlur(wrapper, '0')
+    await nextTick()
+    expect(wrapper.vm.value).toBe(1)
+
+    // 输入大于最大值的数
+    await simulateInput(wrapper, '15')
+    await simulateBlur(wrapper, '15')
+    await nextTick()
+    expect(wrapper.vm.value).toBe(10)
+  })
+
+  // 测试NaN输入处理
+  test('NaN输入处理', async () => {
+    const wrapper = createWrapper({ min: 1 }, 5)
+    await simulateInput(wrapper, '')
+    await simulateBlur(wrapper, '')
+    await nextTick()
+
+    // 空值应该转为最小值
+    expect(wrapper.vm.value).toBe(1)
+  })
+
+  // 测试change事件触发
+  test('change事件触发', async () => {
+    const wrapper = createWrapper({}, 5)
+
+    await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
+
+    const changeEvents = wrapper.findComponent(WdInputNumber).emitted('change') as Array<any[]>
+    expect(changeEvents).toBeTruthy()
+    expect(changeEvents[changeEvents.length - 1]).toEqual([{ value: 6 }])
+  })
+
+  // 测试props变化时的同步
+  test('props变化监听', async () => {
+    const wrapper = createWrapper({ min: 1, max: 10 }, 5)
+
+    // 测试精度变化是否会触发重新格式化
+    await wrapper.setProps({ precision: 1 })
+    await nextTick()
+
+    // 验证组件正常运行，值被格式化为1位小数（应该显示为5.0而不是5）
+    expect(wrapper.find('.wd-input-number__input').attributes('value')).toBe('5.0')
+
+    // 测试精度为2的情况
+    await wrapper.setProps({ precision: 2 })
+    await nextTick()
+
+    // 值应该被格式化为2位小数（应该显示为5.00）
+    expect(wrapper.find('.wd-input-number__input').attributes('value')).toBe('5.00')
+
+    // 测试取消精度设置
+    await wrapper.setProps({ precision: undefined })
+    await nextTick()
+
+    // 没有精度时应该显示为数值
+    expect(wrapper.find('.wd-input-number__input').attributes('value')).toBe('5')
+  })
+
+  // 测试边界值按钮禁用逻辑
+  test('边界值按钮禁用逻辑', async () => {
+    const wrapper = createWrapper({ min: 3, max: 7, step: 2 }, 3)
+
+    // 当前值3，步进2，减少后为1，小于最小值3，所以减号应该禁用
+    expect(wrapper.findAll('.wd-input-number__action')[0].classes()).toContain('is-disabled')
+  })
+
+  // 测试数值标准化函数覆盖
+  test('数值标准化边界情况', async () => {
+    const wrapper = createWrapper(
+      {
+        min: 1,
+        max: 10,
+        step: 0.1,
+        precision: 1,
+        stepStrictly: true
+      },
+      0
+    )
+
+    // 初始化时不会自动标准化
+    expect(wrapper.vm.value).toBe(0)
+
+    // 用户交互时才会标准化 - 模拟失焦事件
+    await simulateBlur(wrapper, '0')
+    await nextTick()
+
+    // 失焦后值应该被标准化为符合最小值要求
+    expect(wrapper.vm.value).toBeGreaterThanOrEqual(1)
+  })
+
+  // 测试精度计算功能
+  test('精度计算功能', async () => {
+    const wrapper = createWrapper({ precision: 2 }, 1.123456)
+
+    // 初始化时不会自动处理精度
+    expect(wrapper.vm.value).toBe(1.123456)
+
+    // 用户交互时才会应用精度处理 - 模拟失焦事件
+    await simulateBlur(wrapper, '1.123456')
+    await nextTick()
+
+    // 失焦后值应该被格式化为2位小数
+    expect(wrapper.vm.value).toBe(1.12)
+  })
+
+  // 测试工具函数覆盖
+  test('工具函数覆盖测试', () => {
+    const wrapper = createWrapper({ step: 0.001, precision: 3 }, 1)
+
+    // 测试组件正常运行
+    expect(wrapper.vm).toBeDefined()
+  })
+
+  // 测试边界情况：无效初始值处理
+  test('无效初始值处理', async () => {
+    // 使用特殊的wrapper来处理无效值
+    const WrapperComponent = defineComponent({
+      components: { WdInputNumber },
+      setup() {
+        const value = ref('invalid' as any)
+        return {
+          value,
+          min: 1,
+          stepStrictly: true
+        }
+      },
+      template: '<WdInputNumber v-model="value" :min="min" :step-strictly="stepStrictly" />'
+    })
+
+    const wrapper = mount(WrapperComponent)
+    await nextTick()
+
+    // 初始化时保持无效值
+    expect(wrapper.vm.value).toBe('invalid')
+
+    // 用户交互时才会修正 - 模拟点击按钮
+    await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
+    await nextTick()
+
+    // 按钮操作后应该被修正为最小值
+    expect(wrapper.vm.value).toBe(2)
+  })
+
+  // 专门测试props响应式变化
+  test('props响应式变化测试', async () => {
+    const wrapper = createWrapper({ step: 1, min: 0, max: 100 }, 5)
+
+    // 验证初始props
+    const inputNumber = wrapper.findComponent(WdInputNumber)
+    expect(inputNumber.props('step')).toBe(1)
+    expect(inputNumber.props('min')).toBe(0)
+    expect(inputNumber.props('max')).toBe(100)
+
+    // 修改props
+    await wrapper.setProps({ step: 2, min: 2, max: 50 })
+    await nextTick()
+
+    // 验证props已经响应式更新
+    expect(inputNumber.props('step')).toBe(2)
+    expect(inputNumber.props('min')).toBe(2)
+    expect(inputNumber.props('max')).toBe(50)
+
+    // 验证组件行为也随之改变（点击按钮应该按新的step值增减）
+    await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
+    expect(wrapper.vm.value).toBe(7) // 5 + 2(新的step值) = 7
+  })
+
+  // 专门测试精度格式化保持
+  test('精度格式化保持测试', async () => {
+    // 测试精度为1的情况
+    const wrapper1 = createWrapper({ precision: 1 }, 1)
+    await nextTick()
+    expect(wrapper1.find('.wd-input-number__input').attributes('value')).toBe('1.0')
+
+    // 测试精度为2的情况
+    const wrapper2 = createWrapper({ precision: 2 }, 1)
+    await nextTick()
+    expect(wrapper2.find('.wd-input-number__input').attributes('value')).toBe('1.00')
+
+    // 测试精度为3的情况
+    const wrapper3 = createWrapper({ precision: 3 }, 1.5)
+    await nextTick()
+    expect(wrapper3.find('.wd-input-number__input').attributes('value')).toBe('1.500')
+
+    // 测试没有精度设置的情况（应该显示为数值）
+    const wrapper4 = createWrapper({}, 1)
+    await nextTick()
+    expect(wrapper4.find('.wd-input-number__input').attributes('value')).toBe('1')
+  })
+
+  // 测试自定义样式和类名
+  test('自定义样式和类名', () => {
+    const customClass = 'my-custom-class'
+    const customStyle = 'background: red;'
+    const wrapper = createWrapper({ customClass, customStyle }, 1)
+
+    const component = wrapper.findComponent(WdInputNumber)
+    expect(component.classes()).toContain(customClass)
+    expect(component.attributes('style')).toContain('background: red;')
+  })
+
+  // 测试input-mode属性
+  test('input-mode属性设置', () => {
+    // 有精度时应该是decimal
+    const wrapper1 = createWrapper({ precision: 2 }, 1)
+    expect(wrapper1.find('.wd-input-number__input').attributes('input-mode')).toBe('decimal')
+
+    // 无精度时应该是numeric
+    const wrapper2 = createWrapper({}, 1)
+    expect(wrapper2.find('.wd-input-number__input').attributes('input-mode')).toBe('numeric')
+  })
+
+  // 测试长按功能禁用时的行为
+  test('长按功能禁用时的行为', async () => {
+    const wrapper = createWrapper({ longPress: false }, 5)
+    const addButton = wrapper.findAll('.wd-input-number__action')[1]
+
+    const initialValue = wrapper.vm.value
+
+    // 触发touchstart，但长按功能禁用，不应该有任何效果
+    await addButton.trigger('touchstart')
+    await addButton.trigger('touchend')
+
+    expect(wrapper.vm.value).toBe(initialValue)
+  })
+
+  // 测试异步拦截器拒绝变更
+  test('异步拦截器拒绝变更', async () => {
+    const beforeChange = vi.fn(() => Promise.resolve(false))
+    const wrapper = createPropsOnlyWrapper({
+      modelValue: 5,
+      beforeChange
+    })
+
+    const initialEvents = wrapper.emitted('update:modelValue')?.length || 0
+    await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
+
+    // 等待异步操作完成
+    await nextTick()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    const finalEvents = wrapper.emitted('update:modelValue')?.length || 0
+    expect(finalEvents).toBe(initialEvents) // 事件数量不应该增加
+  })
+
+  // 测试更复杂的严格步进场景
+  test('复杂严格步进场景', async () => {
+    const wrapper = createWrapper(
+      {
+        step: 0.3,
+        min: 0.1,
+        max: 2.9,
+        stepStrictly: true,
+        precision: 1
+      },
+      0.1
+    )
+
+    // 输入0.25，应该调整为最接近的0.3的倍数
+    await simulateInput(wrapper, '0.25')
+    await simulateBlur(wrapper, '0.25')
+    await nextTick()
+
+    // 0.25 / 0.3 = 0.833..., Math.round(0.833) = 1, 1 * 0.3 = 0.3
+    expect(wrapper.vm.value).toBe(0.3)
+  })
+
+  // 测试空值在不同模式下的行为
+  test('空值在不同模式下的行为', async () => {
+    // 允许空值 + 立即模式
+    const wrapper1 = createWrapper({ allowNull: true, immediateChange: true }, '')
+    await simulateInput(wrapper1, '')
+    await nextTick()
+    expect(wrapper1.vm.value).toBe('')
+
+    // 允许空值 + 非立即模式
+    const wrapper2 = createWrapper({ allowNull: true, immediateChange: false }, '')
+    await simulateInput(wrapper2, '')
+    await nextTick()
+    expect(wrapper2.vm.value).toBe('') // 非立即模式也应该保持空值
+
+    // 不允许空值 + 立即模式
+    const wrapper3 = createWrapper({ allowNull: false, immediateChange: true, min: 1 }, 5)
+    await simulateInput(wrapper3, '')
+    await nextTick()
+    expect(wrapper3.vm.value).toBe(5) // 立即模式下应该保持原值不变
+  })
+
+  // 测试数值精度边界情况
+  test('数值精度边界情况', async () => {
+    // 测试极小步进值
+    const wrapper1 = createWrapper({ step: 0.001, precision: 3 }, 1.001)
+    await wrapper1.findAll('.wd-input-number__action')[1].trigger('click')
+    expect(wrapper1.vm.value).toBe(1.002)
+
+    // 测试精度为0但有小数步进
+    const wrapper2 = createWrapper({ step: 0.5, precision: 0 }, 1)
+    await wrapper2.findAll('.wd-input-number__action')[1].trigger('click')
+    expect(wrapper2.vm.value).toBe(2) // 应该被精度0处理为整数
+  })
+
+  // 测试边界值的精确计算
+  test('边界值精确计算', async () => {
+    const wrapper = createWrapper(
+      {
+        min: 0.1,
+        max: 0.9,
+        step: 0.1,
+        precision: 1
+      },
+      0.1
+    )
+
+    // 连续点击加号直到接近最大值
+    for (let i = 0; i < 10; i++) {
+      await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
+      await nextTick()
+    }
+
+    // 应该被限制在最大值
+    expect(wrapper.vm.value).toBe(0.9)
+
+    // 加号按钮应该被禁用
+    expect(wrapper.findAll('.wd-input-number__action')[1].classes()).toContain('is-disabled')
+  })
+
+  // 测试连续快速操作
+  test('连续快速操作', async () => {
+    const wrapper = createWrapper({ step: 1 }, 5)
+
+    // 快速连续点击
+    const addButton = wrapper.findAll('.wd-input-number__action')[1]
+    await addButton.trigger('click')
+    await addButton.trigger('click')
+    await addButton.trigger('click')
+    await nextTick()
+
+    expect(wrapper.vm.value).toBe(8)
+  })
+
+  // 测试输入框类型属性
+  test('输入框类型属性', () => {
+    const wrapper = createWrapper({}, 1)
+    expect(wrapper.find('.wd-input-number__input').attributes('type')).toBe('number')
+  })
+
+  // 测试组件在极端值下的稳定性
+  test('极端值下的稳定性', async () => {
+    // 测试接近JavaScript数值极限的情况
+    const wrapper = createWrapper(
+      {
+        min: -Number.MAX_SAFE_INTEGER,
+        max: Number.MAX_SAFE_INTEGER
+      },
+      0
+    )
+
+    // 设置一个非常大的值
+    wrapper.vm.value = Number.MAX_SAFE_INTEGER - 1
+    await nextTick()
+
+    // 点击加号，应该被限制在最大值
+    await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
+    expect(wrapper.vm.value).toBeLessThanOrEqual(Number.MAX_SAFE_INTEGER)
+  })
+
+  // 测试组件清理逻辑
+  test('组件清理逻辑', async () => {
+    vi.useFakeTimers()
+
+    const wrapper = createWrapper({ longPress: true }, 5)
+    const addButton = wrapper.findAll('.wd-input-number__action')[1]
+
+    // 开始长按
+    await addButton.trigger('touchstart')
+
+    // 在长按过程中卸载组件
+    wrapper.unmount()
+
+    // 推进时间，确保没有内存泄漏
+    vi.advanceTimersByTime(1000)
+
+    // 如果没有正确清理，这里可能会有错误
+    expect(true).toBe(true) // 能执行到这里说明清理正常
+
+    vi.useRealTimers()
+  })
+
+  // 测试负数步进的边界情况
+  test('负数步进边界情况', async () => {
+    const wrapper = createWrapper(
+      {
+        min: -10,
+        max: -1,
+        step: 2
+      },
+      -5
+    )
+
+    // 点击减号，应该变为-7
+    await wrapper.findAll('.wd-input-number__action')[0].trigger('click')
+    expect(wrapper.vm.value).toBe(-7)
+
+    // 再次点击减号，应该变为-9
+    await wrapper.findAll('.wd-input-number__action')[0].trigger('click')
+    expect(wrapper.vm.value).toBe(-9)
+
+    // 再次点击减号，应该被限制在-10（不是-11）
+    await wrapper.findAll('.wd-input-number__action')[0].trigger('click')
+    expect(wrapper.vm.value).toBe(-10)
+  })
+
+  // 测试小数精度的累积误差
+  test('小数精度累积误差处理', async () => {
+    const wrapper = createWrapper(
+      {
+        step: 0.1,
+        precision: 1
+      },
+      0
+    )
+
+    // 连续增加0.1，测试精度处理
+    for (let i = 0; i < 10; i++) {
+      await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
+    }
+
+    // 应该是1.0而不是0.9999999999999999
+    expect(wrapper.vm.value).toBe(1.0)
+    expect(wrapper.find('.wd-input-number__input').attributes('value')).toBe('1.0')
+  })
+
+  // 测试输入框聚焦时的值保持
+  test('输入框聚焦时值保持', async () => {
+    const wrapper = createWrapper({ precision: 2 }, 1.5)
+    const input = wrapper.find('.wd-input-number__input')
+
+    // 聚焦时应该保持当前显示的格式化值
+    await input.trigger('focus')
+    expect(input.attributes('value')).toBe('1.50')
+  })
+
+  // 测试多种无效输入的组合
+  test('多种无效输入组合', async () => {
+    const wrapper = createWrapper({ precision: 2, min: 0 }, 1)
+
+    // 测试包含多种无效字符的输入
+    await simulateInput(wrapper, 'abc1.2.3def4..5ghi')
+    await nextTick()
+
+    // 应该清理为有效的数字格式，并按precision格式化
+    expect(wrapper.find('.wd-input-number__input').attributes('value')).toBe('1.23')
+  })
+
+  // 测试步进值为负数的情况
+  test('负步进值处理', async () => {
+    // 虽然一般不会设置负步进值，但测试组件的健壮性
+    const wrapper = createWrapper({ step: -1 }, 5)
+
+    // 点击"加号"按钮，实际上会减少值
+    await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
+    expect(wrapper.vm.value).toBe(4)
+
+    // 点击"减号"按钮，实际上会增加值
+    await wrapper.findAll('.wd-input-number__action')[0].trigger('click')
+    expect(wrapper.vm.value).toBe(5)
+  })
+
+  // 测试beforeChange拦截器的边界情况
+  test('beforeChange拦截器边界情况', async () => {
+    // 测试拦截器返回异常Promise的情况
+    const beforeChange = vi.fn(() => Promise.reject(new Error('拦截器错误')))
+
+    const wrapper = createPropsOnlyWrapper({
+      modelValue: 5,
+      beforeChange
+    })
+
+    // 即使拦截器Promise被拒绝，组件也应该稳定运行
+    const initialEvents = wrapper.emitted('update:modelValue')?.length || 0
+    await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
+
+    // 等待异步操作完成
+    await nextTick()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    const finalEvents = wrapper.emitted('update:modelValue')?.length || 0
+    // 异常情况下不应该触发更新
+    expect(finalEvents).toBe(initialEvents)
+    expect(beforeChange).toHaveBeenCalled()
+  })
+
+  // 测试组件的响应式性能
+  test('响应式性能测试', async () => {
+    const wrapper = createWrapper({}, 1)
+
+    // 快速连续修改props，测试组件是否能正确响应
+    await wrapper.setProps({ step: 2 })
+    await wrapper.setProps({ step: 3 })
+    await wrapper.setProps({ step: 1 })
+    await nextTick()
+
+    // 最终应该使用最后设置的step值
+    await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
+    expect(wrapper.vm.value).toBe(2) // 1 + 1 = 2
+  })
+
+  // 测试输入框的禁用属性传递
+  test('输入框禁用属性传递', () => {
+    // 测试全局禁用
+    const wrapper1 = createWrapper({ disabled: true }, 1)
+    expect(wrapper1.find('.wd-input-number__input').attributes()).toHaveProperty('disabled')
+
+    // 测试仅输入框禁用
+    const wrapper2 = createWrapper({ disableInput: true }, 1)
+    expect(wrapper2.find('.wd-input-number__input').attributes()).toHaveProperty('disabled')
+
+    // 测试都不禁用
+    const wrapper3 = createWrapper({}, 1)
+    expect(wrapper3.find('.wd-input-number__input').attributes()).not.toHaveProperty('disabled')
+  })
+
+  // 测试allowNull与其他属性的组合
+  test('allowNull与其他属性组合', async () => {
+    // allowNull + stepStrictly
+    const wrapper1 = createWrapper(
+      {
+        allowNull: true,
+        stepStrictly: true,
+        step: 2
+      },
+      ''
+    )
+
+    await simulateInput(wrapper1, '3')
+    await simulateBlur(wrapper1, '3')
+    await nextTick()
+
+    // 即使允许空值，严格步进也应该生效
+    expect(wrapper1.vm.value).toBe(4) // 3调整为最接近的2的倍数4
+
+    // allowNull + precision
+    const wrapper2 = createWrapper(
+      {
+        allowNull: true,
+        precision: 2
+      },
+      ''
+    )
+
+    await simulateInput(wrapper2, '1.1')
+    await simulateBlur(wrapper2, '1.1')
+    await nextTick()
+
+    expect(wrapper2.vm.value).toBe(1.1)
+    expect(wrapper2.find('.wd-input-number__input').attributes('value')).toBe('1.10')
   })
 })

--- a/tests/components/wd-input-number.test.ts
+++ b/tests/components/wd-input-number.test.ts
@@ -903,7 +903,7 @@ describe('WdInputNumber', () => {
   // 测试输入框类型属性
   test('输入框类型属性', () => {
     const wrapper = createWrapper({}, 1)
-    expect(wrapper.find('.wd-input-number__input').attributes('type')).toBe('number')
+    expect(wrapper.find('.wd-input-number__input').attributes('type')).toBe('digit')
   })
 
   // 测试组件在极端值下的稳定性

--- a/tests/components/wd-input-number.test.ts
+++ b/tests/components/wd-input-number.test.ts
@@ -30,7 +30,7 @@ function createWrapper(props: Partial<InputNumberProps> = {}, vModelValue: numbe
       beforeChange: { type: Function, default: undefined },
       customClass: { type: String, default: '' },
       customStyle: { type: String, default: '' },
-      formatOnInit: { type: Boolean, default: false }
+      updateOnInit: { type: Boolean, default: false }
     },
     setup(componentProps) {
       const value = ref(vModelValue)
@@ -62,7 +62,7 @@ function createWrapper(props: Partial<InputNumberProps> = {}, vModelValue: numbe
       :before-change="beforeChange"
       :custom-class="customClass"
       :custom-style="customStyle"
-      :format-on-init="formatOnInit"
+      :update-on-init="updateOnInit"
     />`
   })
 
@@ -361,7 +361,7 @@ describe('WdInputNumber', () => {
       max: 15,
       step: 2,
       stepStrictly: true,
-      formatOnInit: true
+      updateOnInit: true
     })
 
     await nextTick()
@@ -380,7 +380,7 @@ describe('WdInputNumber', () => {
       max: 15,
       step: 2,
       stepStrictly: true,
-      formatOnInit: false
+      updateOnInit: false
     })
 
     await nextTick()

--- a/tests/components/wd-input-number.test.ts
+++ b/tests/components/wd-input-number.test.ts
@@ -700,16 +700,7 @@ describe('WdInputNumber', () => {
 
     const wrapper = mount(WrapperComponent)
     await nextTick()
-
-    // 初始化时保持无效值
-    expect(wrapper.vm.value).toBe('invalid')
-
-    // 用户交互时才会修正 - 模拟点击按钮
-    await wrapper.findAll('.wd-input-number__action')[1].trigger('click')
-    await nextTick()
-
-    // 按钮操作后应该被修正为最小值
-    expect(wrapper.vm.value).toBe(2)
+    expect(wrapper.vm.value).toBe(1)
   })
 
   // 专门测试props响应式变化


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [x] 站点、文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

相关功能需求和用户反馈，主要解决InputNumber组件在使用过程中缺少的细粒度控制功能。

### 💡 需求背景和解决方案

#### 需求背景
InputNumber组件在实际使用中存在以下需求：
1. **输入更新策略控制** - 某些场景下需要减少频繁的change事件触发，只在用户完成输入后才更新
2. **初始值处理策略** - 在使用严格步进模式时，需要控制是否自动修正初始值到有效范围

#### 解决方案
**1. 新增更新模式控制**
```typescript
// 非立即更新模式，仅在失焦和按钮点击时触发change事件
<wd-input-number v-model="value" :immediate-change="false" />
```

**2. 新增初始化行为控制**
```typescript
// 不在初始化时自动修正值
<wd-input-number v-model="value" :format-on-init="false" :min="3" :step="2" step-strictly />
```

#### API 实现

**新增属性：** 
- `immediate-change: boolean` - 是否立即响应输入变化，默认true
- `format-on-init: boolean` - 是否在初始化时自动修正值到有效范围，默认true

**TypeScript类型定义：**
```typescript
export const inputNumberProps = {
  // ... 其他属性
  immediateChange: makeBooleanProp(true),
  formatOnInit: makeBooleanProp(true)
}
```

#### 功能演示

新增了以下演示用例：
- 禁用减号/加号按钮的独立控制
- 严格步进模式下的边界限制处理
- 非立即更新模式的对比演示
- 初始化自动修正的开关控制
- 临时空值处理的边界情况

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 输入框组件支持分别禁用加号和减号按钮。
  - 新增“非即时更新模式”，可控制变更事件是在输入时立即触发还是仅在失焦/按钮点击时触发。
  - 增加初始化时自动校正初始值的功能，确保初始值符合范围和步长约束。
  - 新增支持输入框类型切换（数字或数字键盘模式）。
  - 优化输入解析、格式化和事件处理，提升输入体验和边界情况支持。
  - 新增多个示例展示上述功能及其他高级用法。

- **文档**
  - 输入框组件文档新增上述功能的详细说明和使用示例，完善属性表说明。

- **测试**
  - 大幅扩展和优化了输入框组件的测试用例，覆盖更多场景和边界情况，提升组件稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->