### PR TITLE
fix: 签字版组件设置exportScale < 1时在支付宝小程序上导出图片不完整

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-signature/wd-signature.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-signature/wd-signature.vue
@@ -532,8 +532,8 @@ function canvasToImage() {
   const { canvasWidth, canvasHeight } = canvasState
   uni.canvasToTempFilePath(
     {
-      width: canvasWidth * exportScale,
-      height: canvasHeight * exportScale,
+      width: canvasWidth,
+      height: canvasHeight,
       destWidth: canvasWidth * exportScale,
       destHeight: canvasHeight * exportScale,
       fileType,


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [x ] 新特性提交
- [ x] 站点、文档改进
- [ x] 演示代码改进
- [ x] 组件样式/交互改进
- [ x] TypeScript 定义更新
- [ x] CI/CD 改进
- [ x] 包体积优化
- [ x] 性能优化
- [ x] 功能增强
- [ x] 国际化改进
- [ x] 代码重构
- [ x] 代码风格优化
- [ x] 测试用例
- [ x] 分支合并
- [ x] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

自己使用发现

### 💡 需求背景和解决方案

问题：wd-signature组件在支付宝小程序上使用时，如果设置 exportScale属性值小于1，返回的签字图片始终会按这个比例截取原图。
解决方案：经过查看源码发现通过 canvas 导出图片时，width/height 均乘了 exportScale 值，也就是说实际导出的画布会被截取，去掉这个就可以了。


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修复签名图片导出时的尺寸处理问题，提升图片生成的清晰度与准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->