### PR TITLE
feat: ✨ swiper新增default slot 用户可自定义swiper-item中的内容展示

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-swiper/wd-swiper.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-swiper/wd-swiper.vue
@@ -23,32 +23,35 @@
         @animationfinish="handleAnimationfinish"
       >
         <swiper-item v-for="(item, index) in list" :key="index" class="wd-swiper__item">
-          <video
-            v-if="isVideo(item)"
-            :id="`video-${index}-${uid}`"
-            :style="{ height: addUnit(height) }"
-            :src="isObj(item) ? item[valueKey] : item"
-            :poster="isObj(item) ? item.poster : ''"
-            :class="`wd-swiper__video ${customItemClass} ${getCustomItemClass(currentValue, index, list)}`"
-            @play="handleVideoPaly"
-            @pause="handleVideoPause"
-            :enable-progress-gesture="false"
-            :loop="videoLoop"
-            :muted="muted"
-            :autoplay="autoplayVideo"
-            objectFit="cover"
-            @click="handleClick(index, item)"
-          />
-          <image
-            v-else
-            :src="isObj(item) ? item[valueKey] : item"
-            :class="`wd-swiper__image ${customImageClass} ${customItemClass} ${getCustomItemClass(currentValue, index, list)}`"
-            :style="{ height: addUnit(height) }"
-            :mode="imageMode"
-            @click="handleClick(index, item)"
-          />
-
-          <text v-if="isObj(item) && item[textKey]" :class="`wd-swiper__text ${customTextClass}`" :style="customTextStyle">{{ item[textKey] }}</text>
+          <slot :item="item" :index="index">
+            <video
+              v-if="isVideo(item)"
+              :id="`video-${index}-${uid}`"
+              :style="{ height: addUnit(height) }"
+              :src="isObj(item) ? item[valueKey] : item"
+              :poster="isObj(item) ? item.poster : ''"
+              :class="`wd-swiper__video ${customItemClass} ${getCustomItemClass(currentValue, index, list)}`"
+              @play="handleVideoPaly"
+              @pause="handleVideoPause"
+              :enable-progress-gesture="false"
+              :loop="videoLoop"
+              :muted="muted"
+              :autoplay="autoplayVideo"
+              objectFit="cover"
+              @click="handleClick(index, item)"
+            />
+            <image
+              v-else
+              :src="isObj(item) ? item[valueKey] : item"
+              :class="`wd-swiper__image ${customImageClass} ${customItemClass} ${getCustomItemClass(currentValue, index, list)}`"
+              :style="{ height: addUnit(height) }"
+              :mode="imageMode"
+              @click="handleClick(index, item)"
+            />
+            <text v-if="isObj(item) && item[textKey]" :class="`wd-swiper__text ${customTextClass}`" :style="customTextStyle">
+              {{ item[textKey] }}
+            </text>
+          </slot>
         </swiper-item>
       </swiper>
       <!-- #ifdef MP-WEIXIN -->


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue



### 💡 需求背景和解决方案

<!--
1. swiper组件无法定制item的样式及展示效果
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

需求背景： swiper组件定制item的样式及展示效果，但是现有的swiper并没有对应的slot

实现方法： 在目前的swiper-item的基础上新增slot插槽，并提供item,index作用域变量

用法：
``` vue
      <wd-swiper
        :list="swiperList"
        autoplay
        v-model:current="current"
        :indicator="{ type: 'dots' }"
        @click="handleClick"
        @change="onChange"
      >
        <template v-slot="{ item, index }">
          <view class="custom-indicator" style="position: absolute; bottom: 24rpx; right: 24rpx">{{ index + 1 }}/{{ item }}</view>
        </template>
      </wd-swiper>
```


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充