### PR TITLE
docs: ✏️ 修复文档中 calendar 类型名 `monthrang` → `monthrange` 的拼写错误。

### DIFF
--- a/docs/component/calendar.md
+++ b/docs/component/calendar.md
@@ -119,7 +119,7 @@ function handleConfirm({ value }) {
 
 ## 日周月切换
 
-设置 `show-type-switch` 属性，展示 日周月 切换功能，支持在日周月类型 `date、week、month` 之间进行来回切换，可以通过 `type` 属性设置初始类型。如果 `type` 为 range 类型如 `daterange`，则日历可以在 `daterange、weekrange、monthrang` 之间进行来回切换。
+设置 `show-type-switch` 属性，展示 日周月 切换功能，支持在日周月类型 `date、week、month` 之间进行来回切换，可以通过 `type` 属性设置初始类型。如果 `type` 为 range 类型如 `daterange`，则日历可以在 `daterange、weekrange、monthrange` 之间进行来回切换。
 
 ```html
 <wd-calendar label="日周月切换" :first-day-of-week="1" show-type-switch v-model="value" @confirm="handleConfirm" />


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 修正了日历组件中“日周月切换”功能描述的拼写错误，将“monthrang”更正为“monthrange”。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->