### PR TITLE
fix: 🐛 修复因commit 06106a76b疏忽了startSymbol导致的日期范围选择器异常

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-datetime-picker-view/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-datetime-picker-view/types.ts
@@ -104,6 +104,7 @@ export type DatetimePickerViewColumnFormatter = (picker: DatetimePickerViewInsta
 export type DatetimePickerViewProps = ExtractPropTypes<typeof datetimePickerViewProps>
 
 export type DatetimePickerViewExpose = {
+  startSymbol: boolean | undefined
   updateColumns: () => DatetimePickerViewOption[][]
   setColumns: (columnList: DatetimePickerViewOption[][]) => void
   getSelects: () => Record<string, any> | Record<string, any>[] | undefined

--- a/src/uni_modules/wot-design-uni/components/wd-datetime-picker-view/wd-datetime-picker-view.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-datetime-picker-view/wd-datetime-picker-view.vue
@@ -521,6 +521,7 @@ function getSelects() {
 }
 
 defineExpose<DatetimePickerViewExpose>({
+  startSymbol: props.startSymbol,
   updateColumns,
   setColumns,
   getSelects,


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [x] TypeScript 定义更新

### 🔗 相关 Issue

还没开issue，感觉就加两行代码给主仓库查漏补缺不需要开issue，直接合并上就行

### 💡 需求背景和解决方案

#### bug复现
1. 打开 [https://wot-design-uni.cn/component/datetime-picker.html](https://wot-design-uni.cn/component/datetime-picker.html)
2. 在电脑屏幕右侧的组件预览窗口点击倒数第一个组件(范围tab展示格式)或者倒数第二个组件(区域选择)
3. 拨动开始日期的年份滚筒
4. 此时被拨动到上方的年份莫名其妙被禁用

#### 找到原因
1. debug发现 src/uni_modules/wot-design-uni/components/wd-datetime-picker/wd-datetime-picker.vue 接收到的startSymbol总是undefined，和类型约束中的boolean不符，组件无法得知是在处理起始时间的边界值还是结束时间的边界值
2. 翻阅历史提交，发现在作者的一次提交 “typescript类型支持增强” 中无意疏漏，没有把startSymbol属性从组件导出

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 日期时间选择器组件的外部接口现支持访问 `startSymbol` 属性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->