### PR TITLE
fix: 🐛 修复 DatetimePicker 区间选择时无法选择绑定值范围以外的时间的问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-datetime-picker-view/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-datetime-picker-view/types.ts
@@ -84,8 +84,7 @@ export const datetimePickerViewProps = {
   /**
    * 是否在手指松开时立即触发picker-view的 change 事件。若不开启则会在滚动动画结束后触发 change 事件，1.2.25版本起提供，仅微信小程序和支付宝小程序支持。
    */
-  immediateChange: makeBooleanProp(false),
-  startSymbol: makeBooleanProp(false)
+  immediateChange: makeBooleanProp(false)
 }
 
 export type DatetimePickerViewColumnType = 'year' | 'month' | 'date' | 'hour' | 'minute' | 'second'
@@ -99,7 +98,7 @@ export type DatetimePickerViewFilter = (type: DatetimePickerViewColumnType, valu
 
 export type DatetimePickerViewFormatter = (type: string, value: string) => string
 
-export type DatetimePickerViewColumnFormatter = (picker: DatetimePickerViewInstance) => DatetimePickerViewOption[][]
+export type DatetimePickerViewColumnFormatter = (picker: DatetimePickerViewExpose) => DatetimePickerViewOption[][]
 
 export type DatetimePickerViewProps = ExtractPropTypes<typeof datetimePickerViewProps>
 

--- a/src/uni_modules/wot-design-uni/components/wd-datetime-picker-view/util.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-datetime-picker-view/util.ts
@@ -4,14 +4,15 @@ import { type DateTimeType } from './types'
  * @description 根据传入的值和类型，获取当前的选项数组，便于传入 pickerView
  * @param value
  * @param type picker类型
+ * @param useSecond 是否使用秒，仅在 time 和 datetime 类型下生效
  */
-export function getPickerValue(value: string | number, type: DateTimeType) {
+export function getPickerValue(value: string | number, type: DateTimeType, useSecond: boolean = false) {
   const values: number[] = []
   const date = new Date(value)
   if (type === 'time') {
     const pair = String(value).split(':')
     values.push(parseInt(pair[0]), parseInt(pair[1]))
-    if (pair[2]) {
+    if (useSecond && pair[2]) {
       values.push(parseInt(pair[2]))
     }
   } else {
@@ -19,7 +20,10 @@ export function getPickerValue(value: string | number, type: DateTimeType) {
     if (type === 'date') {
       values.push(date.getDate())
     } else if (type === 'datetime') {
-      values.push(date.getDate(), date.getHours(), date.getMinutes(), date.getSeconds())
+      values.push(date.getDate(), date.getHours(), date.getMinutes())
+      if (useSecond) {
+        values.push(date.getSeconds())
+      }
     }
   }
   return values

--- a/src/uni_modules/wot-design-uni/components/wd-datetime-picker-view/wd-datetime-picker-view.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-datetime-picker-view/wd-datetime-picker-view.vue
@@ -27,7 +27,7 @@ export default {
 <script lang="ts" setup>
 import wdPickerView from '../wd-picker-view/wd-picker-view.vue'
 import { getCurrentInstance, onBeforeMount, ref, watch } from 'vue'
-import { debounce, isFunction, isDef, padZero, range, isArray, isString } from '../common/util'
+import { debounce, isDef, padZero, range, isArray, isString } from '../common/util'
 import { datetimePickerViewProps, type DatetimePickerViewColumnType, type DatetimePickerViewOption, type DatetimePickerViewExpose } from './types'
 import type { PickerViewInstance } from '../wd-picker-view/types'
 import { getPickerValue } from './util'
@@ -80,7 +80,6 @@ const { proxy } = getCurrentInstance() as any
  * @description updateValue 防抖函数的占位符
  */
 const updateValue = debounce(() => {
-  // 只有等created hook初始化数据之后，observer才能执行此操作
   if (!created.value) return
   const val = correctValue(props.modelValue)
   const isEqual = val === innerValue.value
@@ -109,47 +108,16 @@ watch(
     if (type.indexOf(target) === -1) {
       console.error(`type must be one of ${type}`)
     }
-    // 每次type更新时都需要刷新整个列表
-    updateValue()
-  },
-  { deep: true, immediate: true }
-)
-
-watch(
-  () => props.filter,
-  (fn) => {
-    if (fn && !isFunction(fn)) {
-      console.error('The type of filter must be Function')
-    }
-    updateValue()
-  },
-  { deep: true, immediate: true }
-)
-
-watch(
-  () => props.formatter,
-  (fn) => {
-    if (fn && !isFunction(fn)) {
-      console.error('The type of formatter must be Function')
-    }
-    updateValue()
-  },
-  { deep: true, immediate: true }
-)
-
-watch(
-  () => props.columnFormatter,
-  (fn) => {
-    if (fn && !isFunction(fn)) {
-      console.error('The type of columnFormatter must be Function')
-    }
-    updateValue()
   },
   { deep: true, immediate: true }
 )
 
 watch(
   [
+    () => props.type,
+    () => props.filter,
+    () => props.formatter,
+    () => props.columnFormatter,
     () => props.minDate,
     () => props.maxDate,
     () => props.minHour,
@@ -392,7 +360,7 @@ function getBoundary(type: 'min' | 'max', innerValue: number) {
  * @return {Array}
  */
 function updateColumnValue(value: string | number) {
-  const values = getPickerValue(value, props.type)
+  const values = getPickerValue(value, props.type, props.useSecond)
   // 更新pickerView的value,columns
   if (props.modelValue !== value) {
     emit('update:modelValue', value)
@@ -486,8 +454,8 @@ function columnChange(picker: PickerViewInstance) {
   /** 根据计算选中项的时间戳，重新计算所有的选项列表 */
   // 更新选中时间戳
   innerValue.value = correctValue(value)
-  // 根据innerValue获取最新的时间表，重新生成对应的数据源
 
+  // 根据innerValue获取最新的时间表，重新生成对应的数据源
   const newColumns = updateColumns()
   // 深拷贝联动之前的选中项
   const selectedIndex = picker.getSelectedIndex().slice(0)


### PR DESCRIPTION
✅ Closes: #1170

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
#1170 
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
修复 DatetimePicker 区间选择时无法选择绑定值范围以外的时间的问题
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 日期时间选择器现在支持根据需要选择是否包含秒数。

* **优化**
  * 起止时间选择器分别采用独立的列格式化函数，提升了区分性和灵活性。

* **移除**
  * 移除了表单校验相关功能，包括必填项和错误提示。
  * 移除了起始符号（start-symbol）属性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->