### PR TITLE
fix: 🐛 修复 DatetimePicker 超出隐藏 ellipsis 无效的问题

### DIFF
--- a/src/subPages/datetimePicker/Index.vue
+++ b/src/subPages/datetimePicker/Index.vue
@@ -69,6 +69,12 @@
         :display-format-tab-label="displayFormatTabLabel"
       />
     </demo-block>
+    <demo-block title="超出隐藏" transparent>
+      <wd-cell-group border>
+        <wd-datetime-picker label="日期选择器超出隐藏" v-model="valueEllipsis" ellipsis @confirm="handleConfirmEllipsis" />
+        <wd-datetime-picker label="日期区间超出隐藏" v-model="valueRangeEllipsis" ellipsis @confirm="handleConfirmRangeEllipsis" />
+      </wd-cell-group>
+    </demo-block>
     <wd-toast />
   </page-wraper>
 </template>
@@ -106,6 +112,8 @@ const value18 = ref(Date.now())
 const value19 = ref('09:20:26')
 const valueClear1 = ref<number>(Date.now())
 const valueClear2 = ref<any[]>([Date.now(), Date.now()])
+const valueEllipsis = ref<number>(Date.now())
+const valueRangeEllipsis = ref<any[]>([Date.now(), Date.now() + 7 * 24 * 60 * 60 * 1000])
 const minDate = ref<number>(Date.now())
 const maxDate = ref<number>(new Date(new Date().getFullYear() + 1, new Date().getMonth(), new Date().getDate()).getTime())
 
@@ -235,6 +243,15 @@ function handleClear2() {
 function handleConfirmClear2({ value }: any) {
   console.log('datetime picker 2 confirmed:', value)
 }
+
+function handleConfirmEllipsis({ value }: any) {
+  console.log('ellipsis datetime picker confirmed:', value)
+}
+
+function handleConfirmRangeEllipsis({ value }: any) {
+  console.log('range ellipsis datetime picker confirmed:', value)
+}
+
 /** picker触发cancel事件，同步触发cancel事件 */
 function onCancel() {}
 </script>

--- a/src/uni_modules/wot-design-uni/components/wd-datetime-picker/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-datetime-picker/index.scss
@@ -52,6 +52,18 @@
         font-size: $-cell-icon-size-large;
       }
     }
+    
+    .wd-cell__value--ellipsis {
+      view {
+        @include lineEllipsis;
+        width: 100%;
+      }
+      
+      text {
+        @include lineEllipsis;
+        max-width: 100%;
+      }
+    }
   }
 
   @include e(placeholder) {

--- a/src/uni_modules/wot-design-uni/components/wd-datetime-picker/wd-datetime-picker.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-datetime-picker/wd-datetime-picker.vue
@@ -3,6 +3,7 @@
     <wd-cell
       v-if="!$slots.default"
       :title="label"
+      :required="required"
       :size="size"
       :title-width="labelWidth"
       :prop="prop"


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

 

### 💡 需求背景和解决方案
修复 DatetimePicker 超出隐藏 ellipsis 无效的问题
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增“超出隐藏”演示块，支持日期选择和日期范围选择时内容超出显示省略号。
* **样式**
  * 优化日期选择器内容超出时的省略号显示效果。
* **优化**
  * 日期选择器的“必填”属性现在会正确传递到内部显示单元，提升必填项的标识一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->