### PR TITLE
fix: 🐛 修复 grid-item 组件 custom-text 失效的问题

### DIFF
--- a/docs/.vitepress/config/version-data.ts
+++ b/docs/.vitepress/config/version-data.ts
@@ -5,6 +5,6 @@
 export const versionData = {
   "/component/count-to": "1.3.8",
   "/component/keyboard": "1.3.10",
-  "/component/root-portal": "$LOWEST_VERSION$",
+  "/component/root-portal": "1.11.0",
   "/component/signature": "1.6.0"
 }

--- a/docs/component/grid.md
+++ b/docs/component/grid.md
@@ -243,9 +243,9 @@
 | max           | 图标右上角 `badge` 最大值，超过最大值会显示 '{max}+'，要求 value 是 Number 类型                                           | number         | -                                           | -      | -        |
 | url           | 点击后跳转的链接地址                                                                                                      | string         | -                                           | -      | -        |
 | link-type     | 页面跳转方式, 参考[微信小程序路由文档](https://developers.weixin.qq.com/miniprogram/dev/framework/app-service/route.html) | string         | navigateTo / switchTab / reLaunch           | -      | -        |
-| use-slot      | 是否开启 `GridItem` 内容插槽                                                                                              | boolean        | -                                           | false  | -        |
-| use-icon-slot | 是否开启 `GridItem` icon 插槽                                                                                             | boolean        | -                                           | false  | -        |
-| use-text-slot | 是否开启 `GridItem` text 内容插槽                                                                                         | boolean        | -                                           | false  | -        |
+| <s>use-slot</s> | 是否开启 `GridItem` 内容插槽 **（$LOWEST_VERSION$已废弃，直接使用默认插槽即可）**                                                          | boolean        | -                                           | false  | -        |
+| <s>use-icon-slot</s> | 是否开启 `GridItem` icon 插槽 **（$LOWEST_VERSION$已废弃，组件会自动检测icon插槽的存在）**                                                | boolean        | -                                           | false  | -        |
+| <s>use-text-slot</s> | 是否开启 `GridItem` text 内容插槽 **（$LOWEST_VERSION$已废弃，组件会自动检测text插槽的存在）**                                            | boolean        | -                                           | false  | -        |
 | icon-size     | 图标大小                                                                                                                  | string         | -                                           | 26px   | -        |
 | badge-props   | 自定义徽标的属性，传入的对象会被透传给 [Badge 组件的 props](/component/badge#attributes)                                  | BadgeProps     | -                                           | -      | 0.1.50   |
 

--- a/docs/en-US/component/grid.md
+++ b/docs/en-US/component/grid.md
@@ -230,9 +230,9 @@ Set jump link through `url` property.
 | icon-size | Icon size | string | '26px' | - |
 | url | Page jump link | string | - | - |
 | link-type | Page jump type | string | 'navigateTo' | - |
-| use-slot | Whether to use slot | boolean | false | - |
-| use-icon-slot | Whether to use icon slot | boolean | false | - |
-| use-text-slot | Whether to use text slot | boolean | false | - |
+| <s>use-slot</s> | Whether to use slot **($LOWEST_VERSION$Deprecated, use default slot directly)** | boolean | false | - |
+| <s>use-icon-slot</s> | Whether to use icon slot **($LOWEST_VERSION$Deprecated, component auto-detects icon slot existence)** | boolean | false | - |
+| <s>use-text-slot</s> | Whether to use text slot **($LOWEST_VERSION$Deprecated, component auto-detects text slot existence)** | boolean | false | - |
 | clickable | Whether clickable | boolean | false | - |
 
 ## GridItem Events

--- a/src/uni_modules/wot-design-uni/components/wd-grid-item/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-grid-item/types.ts
@@ -36,14 +36,17 @@ export const gridItemProps = {
   linkType: makeStringProp<LinkType>('navigateTo'),
   /**
    * 是否开启 GridItem 内容插槽
+   * @deprecated 已废弃，直接使用默认插槽即可
    */
   useSlot: makeBooleanProp(false),
   /**
    * 是否开启 GridItem icon 插槽
+   * @deprecated 已废弃，组件会自动根据 icon 插槽是否存在来显示
    */
   useIconSlot: makeBooleanProp(false),
   /**
    * 是否开启 GridItem text 内容插槽
+   * @deprecated 已废弃，组件会自动根据 text 插槽是否存在来显示
    */
   useTextSlot: makeBooleanProp(false),
   /**

--- a/src/uni_modules/wot-design-uni/components/wd-grid-item/wd-grid-item.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-grid-item/wd-grid-item.vue
@@ -5,19 +5,18 @@
       :style="gutterContentStyle"
       :hover-class="hoverClass"
     >
-      <slot v-if="useSlot" />
-      <block v-else>
-        <view :style="'width:' + iconSize + '; height: ' + iconSize" class="wd-grid-item__wrapper">
-          <wd-badge custom-class="badge" v-bind="customBadgeProps">
-            <template v-if="useIconSlot">
-              <slot name="icon" />
-            </template>
-            <wd-icon v-else :name="icon" :size="iconSize" :custom-class="customIcon" />
+      <slot>
+        <view class="wd-grid-item__wrapper">
+          <wd-badge v-bind="customBadgeProps">
+            <slot name="icon">
+              <wd-icon :name="icon" :size="iconSize" :custom-class="customIcon" />
+            </slot>
           </wd-badge>
         </view>
-        <slot name="text" v-if="useTextSlot" />
-        <view v-else class="wd-grid-item__text custom-text">{{ text }}</view>
-      </block>
+        <slot name="text">
+          <view :class="`wd-grid-item__text ${customText}`">{{ text }}</view>
+        </slot>
+      </slot>
     </view>
   </view>
 </template>

--- a/src/uni_modules/wot-design-uni/components/wd-icon/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-icon/index.scss
@@ -28,9 +28,14 @@
   font-weight: normal;
   font-variant: normal;
   text-transform: none;
+  line-height: 1;
   /* Better Font Rendering =========== */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  &::before {
+    display: inline-block;
+  }
 
   @include m(image) {
     width: 1em;


### PR DESCRIPTION
✅ Closes: #995

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
修复 grid-item 组件 custom-text 失效的问题
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充