### PR TITLE
feat: ✨ PickerView Option 支持 Icon + Name 组合

### DIFF
--- a/docs/component/picker-view.md
+++ b/docs/component/picker-view.md
@@ -27,6 +27,7 @@ function onChange({picker, value, index}) {
 | value | string / number / boolean | 选项值，如果 value 属性不存在，则使用 label 作为选项的值 | - |
 | label | string | 选项文本内容 | - |
 | disabled | boolean | 选项是否禁用 | - |
+| icon | string | 选项图标 | $LOWEST_VERSION$ |
 
 ## 禁用选项
 

--- a/docs/en-US/component/picker-view.md
+++ b/docs/en-US/component/picker-view.md
@@ -26,6 +26,7 @@ When `columns` options are objects, their data structure is:
 | value | string / number / boolean | Option value, if value property doesn't exist, label is used as the option's value | - |
 | label | string | Option text content | - |
 | disabled | boolean | Whether the option is disabled | - |
+| icon | string | Option icon | $LOWEST_VERSION$ |
 
 ## Disabled Options
 

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -1178,6 +1178,7 @@
   "tu-biao": "icon",
   "tu-biao-an-niu": "Icon Button",
   "tu-biao-cha-cao": "Icon slot",
+  "tu-biao-yong-fa-shu-zhi-value7": "Icon usage, numerical value: ",
   "tu-pian-gu-jia-ping": "Picture Skeleton Screen",
   "tu-pian-shui-yin": "Image watermark",
   "tu-pian-zu-he-gu-jia-ping": "Image combination skeleton screen",

--- a/src/locale/zh-CN.json
+++ b/src/locale/zh-CN.json
@@ -1178,6 +1178,7 @@
   "tu-biao": "图标",
   "tu-biao-an-niu": "图标按钮",
   "tu-biao-cha-cao": "图标插槽",
+  "tu-biao-yong-fa-shu-zhi-value7": "图标用法，数值: ",
   "tu-pian-gu-jia-ping": "图片骨架屏",
   "tu-pian-shui-yin": "图片水印",
   "tu-pian-zu-he-gu-jia-ping": "图片组合骨架屏",

--- a/src/subPages/pickerView/Index.vue
+++ b/src/subPages/pickerView/Index.vue
@@ -16,6 +16,10 @@
       <wd-picker-view v-model="value3" :columns="columns3" loading />
     </demo-block>
 
+    <demo-block :title="$t('tu-biao-yong-fa-shu-zhi-value7') + value7">
+      <wd-picker-view v-model="value7" :columns="columns7" />
+    </demo-block>
+
     <demo-block :title="$t('duo-lie-shu-zhi-value4') + `[${value4}]`">
       <wd-picker-view v-model="value4" :columns="columns4" />
     </demo-block>
@@ -117,6 +121,16 @@ const columns4 = ref([
 
 const value5 = ref(['110000', '110100', '110102'])
 const columns5 = ref([district[0], district[district[0][0].value], district[district[district[0][0].value][0].value]])
+
+const value7 = ref<string>(t('xuanXiang_1-0'))
+const columns7 = ref([
+  { label: t('xuanXiang_1-0'), icon: 'apple' },
+  { label: t('xuanXiang_2-0'), icon: 'windows' },
+  {
+    label: t('xuanXiang_3-0'),
+    icon: 'android'
+  }
+])
 
 const onChangeDistrict: PickerViewColumnChange = (picker, value, columnIndex, resolve) => {
   const item = (value as Record<string, any>[])[columnIndex]

--- a/src/uni_modules/wot-design-uni/components/wd-picker-view/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-picker-view/types.ts
@@ -1,4 +1,4 @@
-import type { ComponentPublicInstance, ExtractPropTypes, PropType, Ref } from 'vue'
+import type { ComponentPublicInstance, ExtractPropTypes, PropType } from 'vue'
 import { baseProps, makeArrayProp, makeBooleanProp, makeNumberProp, makeStringProp } from '../common/props'
 import { getType, isArray, isObj } from '../common/util'
 
@@ -7,6 +7,7 @@ export type ColumnItem = {
   value?: string | number | boolean
   label?: string
   disabled?: boolean
+  icon?: string
 }
 
 export type PickerViewColumnChange = (
@@ -129,8 +130,8 @@ export function formatArray(
        */
       // eslint-disable-next-line no-prototype-builtins
       if (!row.hasOwnProperty(valueKey) && !row.hasOwnProperty(labelKey)) {
-        // eslint-disable-next-line prettier/prettier
-      throw Error('Can\'t find valueKey and labelKey in columns')
+        // eslint-disable-next-line prettier/prettier, quotes
+        throw Error("Can't find valueKey and labelKey in columns")
       }
       // eslint-disable-next-line no-prototype-builtins
       if (!row.hasOwnProperty(labelKey)) {

--- a/src/uni_modules/wot-design-uni/components/wd-picker-view/wd-picker-view.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-picker-view/wd-picker-view.vue
@@ -24,6 +24,7 @@
             }`"
             :style="`line-height: ${itemHeight}px;`"
           >
+            <wd-icon v-if="row.icon" :name="row.icon" />
             {{ row[labelKey] }}
           </view>
         </picker-view-column>

--- a/tests/components/wd-picker-view.test.ts
+++ b/tests/components/wd-picker-view.test.ts
@@ -1,12 +1,14 @@
 import { mount } from '@vue/test-utils'
 import WdPickerView from '@/uni_modules/wot-design-uni/components/wd-picker-view/wd-picker-view.vue'
 import WdLoading from '@/uni_modules/wot-design-uni/components/wd-loading/wd-loading.vue'
+import WdIcon from '@/uni_modules/wot-design-uni/components/wd-icon/wd-icon.vue'
 import { describe, expect, test } from 'vitest'
 
 describe('WdPickerView', () => {
   // 在每个测试前设置全局组件
   const globalComponents = {
-    'wd-loading': WdLoading
+    'wd-loading': WdLoading,
+    'wd-icon': WdIcon
   }
 
   test('基本渲染', () => {
@@ -149,6 +151,36 @@ describe('WdPickerView', () => {
 
     // 检查内部的 formatColumns 是否正确设置了 disabled 属性
     expect((wrapper.vm as any).formatColumns[0][1].disabled).toBe(true)
+  })
+
+  test('带图标的选项', () => {
+    const columns = [
+      { value: '1', label: '选项1', icon: 'home' },
+      { value: '2', label: '选项2', icon: 'settings' }
+    ]
+    const wrapper = mount(WdPickerView, {
+      props: {
+        columns,
+        modelValue: '1'
+      },
+      global: {
+        components: globalComponents
+      }
+    })
+
+    // 检查是否正确设置了 columns
+    expect(wrapper.props('columns')).toEqual(columns)
+
+    // 检查是否渲染了图标组件
+    const iconComponents = wrapper.findAllComponents(WdIcon)
+    expect(iconComponents.length).toBe(2)
+
+    // 检查第一个图标的属性
+    expect(iconComponents[0].props('name')).toBe('home')
+
+    // 检查图标和标签是否都被渲染
+    const items = wrapper.findAll('.wd-picker-view-column__item')
+    expect(items.length).toBe(2)
   })
 
   test('自定义样式', () => {


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

业务场景需要icon + name的组合


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 选择器组件的选项现支持显示图标，可为每个选项设置 icon 属性。
  * 示例页面新增带图标的选择器演示。

* **文档**
  * 更新了 picker-view 组件文档，新增 icon 属性说明及相关版本提示。

* **本地化**
  * 新增中英文关于图标用法的本地化字符串。

* **测试**
  * 增加了带图标选项的选择器组件测试用例，确保图标正确渲染。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->