### PR TITLE
feat: 1、wd-picker支持自定义placeholder为空值。2、columns为空时，不再自动将picker绑定的值清空。

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-picker/wd-picker.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-picker/wd-picker.vue
@@ -22,6 +22,7 @@
       :custom-value-class="customValueClass"
       :ellipsis="ellipsis"
       :use-title-slot="!!$slots.label"
+      :marker-side="markerSide"
       @click="showPopup"
     >
       <template v-if="$slots.label" #title>
@@ -142,26 +143,6 @@ watch(
 )
 
 watch(
-  () => props.columns,
-  (newValue) => {
-    displayColumns.value = deepClone(newValue)
-    resetColumns.value = deepClone(newValue)
-    if (newValue.length === 0) {
-      // 当 columns 变为空时，清空 pickerValue 和 showValue
-      pickerValue.value = isArray(props.modelValue) ? [] : ''
-      // showValue.value = ''
-    } else {
-      // 非空时正常更新显示值
-      handleShowValueUpdate(props.modelValue)
-    }
-  },
-  {
-    deep: true,
-    immediate: true
-  }
-)
-
-watch(
   () => props.modelValue,
   (newValue) => {
     pickerValue.value = newValue
@@ -174,7 +155,25 @@ watch(
   }
 )
 
-
+watch(
+  () => props.columns,
+  (newValue) => {
+    displayColumns.value = deepClone(newValue)
+    resetColumns.value = deepClone(newValue)
+    if (newValue.length === 0) {
+      // 当 columns 变为空时，清空 pickerValue 和 showValue
+      pickerValue.value = isArray(props.modelValue) ? [] : ''
+      showValue.value = ''
+    } else {
+      // 非空时正常更新显示值
+      handleShowValueUpdate(props.modelValue)
+    }
+  },
+  {
+    deep: true,
+    immediate: true
+  }
+)
 
 watch(
   () => props.columnChange,
@@ -197,6 +196,11 @@ const showClear = computed(() => {
 // 是否展示箭头
 const showArrow = computed(() => {
   return !props.disabled && !props.readonly && !showClear.value
+})
+
+//自定义placeholder
+const placeholderValue = computed(() => {
+  return isDef(props.placeholder) ? props.placeholder : translate('placeholder')
 })
 
 const cellClass = computed(() => {
@@ -404,10 +408,6 @@ function handleClear() {
   emit('update:modelValue', clearValue)
   emit('clear')
 }
-
-const placeholderValue = computed(() => {
-  return isDef(props.placeholder) ? props.placeholder : translate('placeholder')
-})
 
 defineExpose<PickerExpose>({
   close,


### PR DESCRIPTION


- [ x ] 日常 bug 修复
- [ x ] 新特性提交


### 🔗 相关 Issue

<!--
[1. 描述相关需求的来源，如相关的 issue 讨论链接。](https://github.com/Moonofweisheng/wot-design-uni/issues/1202)
-->

### 💡 需求背景和解决方案

<!--
1、当在查看页面，没有选值的wd-picker会默认显示“请选择”，不太友好，可以根据页面情况传入placeholder=""覆盖默认placeholder的值。
2、当columns数据为空时，建议不要自动清空wd-picker绑定的值，显示代码也行呢，这种操作容易让用户误导，建议将清空绑定值的业务逻辑交给用户，初始渲染的时候也是这种场景。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ x ] 文档已补充或无须补充
- [ x ] 代码演示已提供或无须提供
- [ x ] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **优化**
  * 优化选择器组件的占位符显示逻辑，提升占位符的准确性和一致性。
  * 当未选择任何选项时，显示值可回退为原始输入值，提升显示效果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->