### PR TITLE
fix: 修复children为函数时，wd-tabs渲染错误

### DIFF
--- a/tests/components/wd-tabs.test.ts
+++ b/tests/components/wd-tabs.test.ts
@@ -427,4 +427,42 @@ describe('WdTabs 和 WdTab 组件', () => {
     // 检查组件是否正确渲染
     expect(wrapper.find('.wd-tabs').exists()).toBe(true)
   })
+
+  // 测试tab变化时，tabs-nav是否顺序是否正确
+  test('tab变化时，tabs-nav是否顺序是否正确', async () => {
+    const wrapper = mount(
+      {
+        template: `
+        <wd-tabs v-model="activeTab">
+          <wd-tab v-for="item in tabData" :key="item" :title="item">{{ item }}</wd-tab>
+        </wd-tabs>
+      `,
+        data() {
+          return {
+            tabData: ['Wot Design Uni'],
+            activeTab: 'Wot Design Uni'
+          }
+        }
+      },
+      {
+        global: { components: globalComponents }
+      }
+    )
+    await nextTick()
+    // 检查组件是否正确渲染
+    expect(wrapper.find('.wd-tabs').exists()).toBe(true)
+
+    // 调整数据
+    await wrapper.setData({ tabData: ['Wot', 'Design', 'Uni'], activeTab: 'Wot' })
+    await nextTick()
+
+    const items = wrapper.findAll('.wd-tabs__nav-item-text')
+    expect(items.length).toBe(3)
+    // 按顺序断言每个元素的文本内容
+    expect(items[0].text()).toBe('Wot')
+    expect(items[1].text()).toBe('Design')
+    expect(items[2].text()).toBe('Uni')
+
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

#1191

### 💡 需求背景和解决方案

1、修复children为函数时，wd-tabs渲染错误
2、publicChildren.sort排序由 **引用** 改为 **uid** 



### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充