### PR TITLE
feat: 新增wd-cell-group圆角支持及样式调整

### DIFF
--- a/src/subPages/cell/Index.vue
+++ b/src/subPages/cell/Index.vue
@@ -1,6 +1,7 @@
 <template>
   <page-wraper>
     <wd-toast />
+
     <demo-block :title="$t('jiBenYongFa')" transparent>
       <wd-cell-group>
         <wd-cell :title="$t('biao-ti-wen-zi')" :value="$t('nei-rong')" />
@@ -132,6 +133,13 @@
             </view>
           </template>
         </wd-cell>
+      </wd-cell-group>
+    </demo-block>
+
+    <demo-block :title="$t('yuan-jiao')" transparent>
+      <wd-cell-group round>
+        <wd-cell :title="$t('biao-ti-wen-zi')" :value="$t('nei-rong')" />
+        <wd-cell :title="$t('biao-ti-wen-zi-0')" :label="$t('miaoShuXinXi-0')" :value="$t('nei-rong')" />
       </wd-cell-group>
     </demo-block>
   </page-wraper>

--- a/src/uni_modules/wot-design-uni/components/common/abstracts/variable.scss
+++ b/src/uni_modules/wot-design-uni/components/common/abstracts/variable.scss
@@ -179,6 +179,7 @@ $-cell-group-padding: var(--wot-cell-group-padding, 13px $-cell-padding) !defaul
 $-cell-group-title-color: var(--wot-cell-group-title-color, rgba(0, 0, 0, 0.85)) !default; // 组标题文字颜色
 $-cell-group-value-fs: var(--wot-cell-group-value-fs, $-fs-content) !default; // 组值字号
 $-cell-group-value-color: var(--wot-cell-group-value-color, $-color-content) !default; // 组值文字颜色
+$-cell-group-value-round: var(--wot-cell-group-value-round, 12px) !default; // 组值圆角
 
 $-cell-wrapper-padding: var(--wot-cell-wrapper-padding, 10px) !default; // cell 容器padding
 $-cell-wrapper-padding-large: var(--wot-cell-wrapper-padding-large, 12px) !default; // large类型cell容器padding
@@ -227,7 +228,6 @@ $-calendar-range-color: var(--wot-calendar-range-color, rgba(#4d80f0, 0.09)) !de
 $-calendar-active-border: var(--wot-calendar-active-border, 8px) !default;
 $-calendar-info-fs: var(--wot-calendar-info-fs, 10px) !default;
 $-calendar-item-margin-bottom: var(--wot-calendar-item-margin-bottom, 4px) !default;
- 
 
 /* checkbox */
 $-checkbox-margin: var(--wot-checkbox-margin, 10px) !default; // 多个复选框距离
@@ -286,9 +286,6 @@ $-divider-content-right-width: var(--wot-divider-content-right-width, 10%) !defa
 $-divider-vertical-height: var(--wot-divider-vertical-height, 16px) !default; // 垂直分割线高度
 $-divider-vertical-content-margin: var(--wot-divider-vertical-content-margin, 0 8px) !default; // 垂直分割线内容间距
 $-divider-vertical-line-width: var(--wot-divider-vertical-line-width, 1px) !default; // 线条高度
-
-
-
 
 /* drop-menu */
 $-drop-menu-height: var(--wot-drop-menu-height, 48px) !default; // 展示选中项的高度
@@ -772,7 +769,6 @@ $-swiper-item-padding: var(--wot-swiper-item-padding, 0);
 $-swiper-item-text-color: var(--wot-swiper-item-text-color, #ffffff);
 $-swiper-item-text-fs: var(--wot-swiper-item-text-fs, $-fs-title);
 
-
 /* swiper-nav */
 // dot & dots-bar
 $-swiper-nav-dot-color: var(--wot-swiper-nav-dot-color, $-font-white-2) !default;
@@ -969,6 +965,3 @@ $-signature-radius: var(--wot-signature-radius, 4px) !default; // 圆角
 $-signature-border: var(--wot-signature-border, 1px solid $-color-gray-5) !default; // 边框圆角
 $-signature-footer-margin-top: var(--wot-signature-footer-margin-top, 8px) !default; // 底部按钮上边距
 $-signature-button-margin-left: var(--wot-signature-button-margin-left, 8px) !default; // 底部按钮左边距
-
-
-

--- a/src/uni_modules/wot-design-uni/components/wd-cell-group/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-cell-group/index.scss
@@ -11,6 +11,11 @@
       }
     }
 
+    @include when(round) {
+      border-radius: $-cell-group-value-round;
+      overflow: hidden;
+    }
+
     @include e(title) {
       background: $-dark-background2;
       color: $-dark-color;
@@ -23,7 +28,6 @@
     @include e(body) {
       background: $-dark-background2;
     }
-
   }
 }
 
@@ -34,6 +38,10 @@
     .wd-cell-group__title {
       @include halfPixelBorder;
     }
+  }
+  @include when(round) {
+    border-radius: $-cell-group-value-round;
+    overflow: hidden;
   }
   @include e(title) {
     position: relative;

--- a/src/uni_modules/wot-design-uni/components/wd-cell-group/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-cell-group/types.ts
@@ -35,7 +35,11 @@ export const cellGroupProps = {
   /**
    * 是否展示边框线
    */
-  border: makeBooleanProp(false)
+  border: makeBooleanProp(false),
+  /**
+   * 是否展示圆角
+   */
+  round: makeBooleanProp(false)
 }
 
 export type CellGroupProps = ExtractPropTypes<typeof cellGroupProps>

--- a/src/uni_modules/wot-design-uni/components/wd-cell-group/wd-cell-group.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-cell-group/wd-cell-group.vue
@@ -1,5 +1,5 @@
 <template>
-  <view :class="['wd-cell-group', border ? 'is-border' : '', customClass]" :style="customStyle">
+  <view :class="['wd-cell-group', border ? 'is-border' : '', round ? 'is-round' : '', customClass]" :style="customStyle">
     <view v-if="title || value || useSlot" class="wd-cell-group__title">
       <!--左侧标题-->
       <view class="wd-cell-group__left">


### PR DESCRIPTION
# 添加 CellGroup 圆角功能

## 📝 修改概述
为 `wd-cell-group` 组件添加圆角显示功能，支持通过 `round` 属性设置组件圆角样式。

## 🔄 修改内容

### 1. 组件功能增强
- **新增 `round` 属性**：支持设置 cell-group 为圆角样式
- **样式优化**：添加圆角样式和溢出隐藏处理

### 2. 文件修改详情

#### `wd-cell-group.vue`
- 在组件根元素的 class 绑定中添加 `round ? 'is-round' : ''` 条件类名

#### `types.ts`
- 新增 `round` 属性定义
  - 类型：`Boolean`
  - 默认值：`false`
  - 描述：是否展示圆角

#### `index.scss`
- 新增 `.is-round` 样式类
  - 设置 `border-radius: $-cell-group-value-round`
  - 添加 `overflow: hidden` 防止子元素溢出
- 同时适配暗色模式下的圆角样式

#### `variable.scss`
- 新增 `$-cell-group-value-round` CSS 变量
  - 默认值：`12px`
  - 用于控制圆角大小
- 清理多余的空行，优化代码格式

#### 示例页面更新
- 在 `Index.vue` 中新增圆角功能演示
- 添加 `yuan-jiao`（圆角）示例块，展示 `round` 属性的使用效果

## 🎯 功能特性
- ✅ 支持圆角样式切换
- ✅ 兼容现有边框功能
- ✅ 支持暗色主题
- ✅ CSS 变量可自定义圆角大小
- ✅ 向后兼容，不影响现有代码

## 📱 使用方式

```vue
<!-- 基础用法 -->
<wd-cell-group round>
  <wd-cell title="标题" value="内容" />
</wd-cell-group>

<!-- 结合边框使用 -->
<wd-cell-group round border>
  <wd-cell title="标题" value="内容" />
</wd-cell-group>
```

## 🎨 样式定制

可通过 CSS 变量自定义圆角大小：

```css
:root {
  --wot-cell-group-value-round: 16px; /* 自定义圆角大小 */
}
```

## 🧪 测试验证
- ✅ 基础圆角功能正常
- ✅ 与边框属性兼容性良好
- ✅ 暗色模式下显示正确
- ✅ 不影响现有组件功能
- ✅ 示例页面展示完整

## 📋 变更类型
- [x] 新功能 (feature)
- [ ] 修复缺陷 (bugfix)  
- [ ] 性能优化 (performance)
- [ ] 文档更新 (docs)
- [ ] 样式调整 (style)
- [ ] 重构代码 (refactor)
- [ ] 测试相关 (test)
- [ ] 构建相关 (build)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - Cell 组合新增“圆角”可选项，支持明暗主题，启用后分组呈现圆角样式并自动裁剪溢出内容。
- 样式
  - 引入可配置的圆角尺寸变量，整体圆角显示更一致。
- 文档
  - 示例页新增“圆角”演示块，展示两个 Cell 的圆角分组效果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->