### PR TITLE
fix: 🐛 修复 signature 组件设置background-color为透明色导致撤销无效

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-signature/wd-signature.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-signature/wd-signature.vue
@@ -91,6 +91,45 @@ const canvasState = reactive({
   ctx: null as UniApp.CanvasContext | null // canvas上下文
 })
 
+/**
+ * 判断颜色是否为透明色
+ * @param color 颜色值（支持 rgba/hsla/hex/transparent）
+ */
+function isTransparentColor(color: string | undefined): boolean {
+  if (!color) return true
+  const transparentKeywords = ['transparent', '#0000', '#00000000']
+
+  // 标准透明关键字
+  if (transparentKeywords.includes(color.toLowerCase())) {
+    return true
+  }
+
+  // 匹配 rgba(r, g, b, a)
+  const rgbaMatch = color.match(/^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)(?:\s*,\s*(\d*\.?\d+))?\)$/i)
+  if (rgbaMatch) {
+    const alpha = rgbaMatch[4] ? parseFloat(rgbaMatch[4]) : 1
+    return alpha === 0
+  }
+
+  // 匹配 hsla(h, s, l, a)
+  const hslaMatch = color.match(/^hsla?\(\s*(\d+)(?:deg)?\s*,\s*(\d+)%\s*,\s*(\d+)%(?:\s*,\s*(\d*\.?\d+))?\)$/i)
+  if (hslaMatch) {
+    const alpha = hslaMatch[4] ? parseFloat(hslaMatch[4]) : 1
+    return alpha === 0
+  }
+
+  // 匹配 #RRGGBBAA 或 #RGBA
+  const hexMatch = color.match(/^#([0-9a-f]{8}|[0-9a-f]{4})$/i)
+  if (hexMatch) {
+    const hex = hexMatch[1]
+    const alphaHex = hex.length === 8 ? hex.slice(6, 8) : hex.slice(3, 4).repeat(2)
+    const alpha = parseInt(alphaHex, 16)
+    return alpha === 0
+  }
+
+  return false
+}
+
 watch(
   () => props.penColor,
   () => {
@@ -302,8 +341,8 @@ const redrawCanvas = () => {
   if (!ctx) return
 
   // 清除画布并设置背景
-  if (isDef(props.backgroundColor)) {
-    ctx.setFillStyle(props.backgroundColor)
+  if (!isTransparentColor(props.backgroundColor)) {
+    ctx.setFillStyle(props.backgroundColor as string)
     ctx.fillRect(0, 0, canvasState.canvasWidth, canvasState.canvasHeight)
   } else {
     ctx.clearRect(0, 0, canvasState.canvasWidth, canvasState.canvasHeight)
@@ -570,8 +609,8 @@ function clearCanvas() {
   const { canvasWidth, canvasHeight, ctx } = canvasState
   if (ctx) {
     ctx.clearRect(0, 0, canvasWidth, canvasHeight)
-    if (isDef(props.backgroundColor)) {
-      ctx.setFillStyle(props.backgroundColor)
+    if (!isTransparentColor(props.backgroundColor)) {
+      ctx.setFillStyle(props.backgroundColor as string)
       ctx.fillRect(0, 0, canvasWidth, canvasHeight)
     }
     ctx.draw()


### PR DESCRIPTION
BREAKING CHANGE: 🧨 signature

✅ Closes: #1223

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
[签名组件当背景颜色设为透明时点击撤销无效](https://github.com/Moonofweisheng/wot-design-uni/issues/1223)

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1. 新增函数判断是否为透明色，不是透明色且有值则设置背景色。
微信小程序测试：
![weixin](https://github.com/user-attachments/assets/9e9fc308-5854-4a37-9daf-7585e828e1b1)
浏览器测试：
![浏览器](https://github.com/user-attachments/assets/7fbb0efa-afcc-4cb1-9a7a-e0c5bbd25862)
支付宝小程序测试：
![支付宝小程序](https://github.com/user-attachments/assets/8ffddb52-be25-4b18-b3ef-bdb403f1044c)



### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新增功能
  * 透明背景的签名画布在清空与重绘时将保持透明显示，不再被意外填充底色；当设置不透明背景色时将按设定正确填充，提升显示一致性与可预期性。
* 杂务
  * 无对外接口或配置变更，现有用法无需调整。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->