### PR TITLE
Tabs组件标题支持Slot定制

### DIFF
--- a/docs/component/tabs.md
+++ b/docs/component/tabs.md
@@ -251,6 +251,30 @@ function handlePopupShow() {
 }
 ```
 
+## 自定义标题插槽 <el-tag text style="vertical-align: middle;margin-left:8px;" effect="plain">1.12.0</el-tag>
+
+使用插槽 `title` 可以自定义渲染标签页标题。
+
+```html
+<wd-tabs v-model="tab">
+  <template #title="{ item, title, index }">
+    <!-- item:标签对象; title: 标题文本; index: 标签索引; -->
+    <view style="display: flex; align-items: center; gap: 8rpx">
+      {{ title }}
+      <wd-icon name="caret-down" />
+      ({{ index }})
+    </view>
+  </template>
+  <template #default>
+    <block v-for="item in tabs" :key="item">
+      <wd-tab :title="item" :name="item">
+        <view class="content">内容{{ tab }}</view>
+      </wd-tab>
+    </block>
+  </template>
+</wd-tabs>
+```
+
 ## Tabs Attributes
 
 | 参数          | 说明                                                                                     | 类型            | 可选值   | 默认值 | 最低版本 |
@@ -288,6 +312,13 @@ function handlePopupShow() {
 | change   | 绑定值变化时触发     | event = { index, name },index 为 tab 下标，name 为 tab 绑定的值 | -        |
 | click    | 点击标题时触发       | event = { index, name },index 为 tab 下标，name 为 tab 绑定的值 | -        |
 | disabled | 点击禁用的标题时触发 | event = { index, name },index 为 tab 下标，name 为 tab 绑定的值 | -        |
+
+## Tabs Slot
+
+| name  | 说明                | 最低版本   |
+| ----- |-------------------|--------|
+| title | 标题，便于开发者自定义标题 | 1.12.0 |
+| default  | 内容                | -      |
 
 ## Methods
 

--- a/docs/component/tabs.md
+++ b/docs/component/tabs.md
@@ -255,6 +255,17 @@ function handlePopupShow() {
 
 使用插槽 `title` 可以自定义渲染标签页标题。
 
+使用插槽 `map-nav-item` 可以自定义渲染导航地图中的标签项。
+
+插槽参数：
+
+| 参数         | 说明       | 最低版本 |
+| ------------ | ---------- | -------- |
+| item | 标签对象 | -        |
+| title | 标题文本 | -        |
+| index | 标签索引 | -        |
+| active | 是否选中 | -        |
+
 ```html
 <wd-tabs v-model="tab">
   <template #title="{ item, title, index }">
@@ -263,6 +274,18 @@ function handlePopupShow() {
       {{ title }}
       <wd-icon name="caret-down" />
       ({{ index }})
+    </view>
+  </template>
+  <template #map-nav-item="{ item, title, index, active }">
+    <view
+      style="display: flex; align-items: center; gap: 8rpx; width: 200rpx; height: 64rpx; position: relative"
+      :style="{ color: active ? '#0083ff' : index === 2 ? 'red' : '' }"
+    >
+      <wd-icon name="caret-right" color="#0083ff" v-if="active" style="position: absolute; left: 0" />
+      <view style="text-align: center; flex: 1">
+        {{ title }}
+      </view>
+      <wd-icon name="caret-left" color="#0083ff" v-if="active" style="position: absolute; right: 0" />
     </view>
   </template>
   <template #default>

--- a/src/subPages/tabs/Index.vue
+++ b/src/subPages/tabs/Index.vue
@@ -137,6 +137,25 @@
         </wd-tab>
       </wd-tabs>
     </wd-popup>
+
+    <demo-block :title="$t('tong-guo-slot-zi-ding-yi-biao-ti')" transparent>
+      <wd-tabs v-model="tab11">
+        <template #title="{ item, title, index }">
+          <view style="display: flex; align-items: center; gap: 8rpx" :style="{ color: index === 2 ? 'red' : '' }">
+            {{ title }}
+            ({{ index === 2 ? 10 : 0 }})
+            <wd-icon name="caret-down" color="#0083ff" v-if="item.name === tab11" />
+          </view>
+        </template>
+        <template #default>
+          <block v-for="item in tabs" :key="item">
+            <wd-tab :title="item" :name="item">
+              <view class="content">{{ $t('nei-rong') }}{{ tab }}</view>
+            </wd-tab>
+          </block>
+        </template>
+      </wd-tabs>
+    </demo-block>
   </page-wraper>
 </template>
 <script lang="ts" setup>
@@ -192,6 +211,7 @@ const tab7 = ref<number>(0)
 const tab8 = ref<number>(0)
 const tab9 = ref<number>(0)
 const tab10 = ref<number>(3)
+const tab11 = ref<number>(0)
 
 const toast = useToast()
 function handleClick({ index, name }: any) {

--- a/src/subPages/tabs/Index.vue
+++ b/src/subPages/tabs/Index.vue
@@ -140,16 +140,34 @@
 
     <demo-block :title="$t('tong-guo-slot-zi-ding-yi-biao-ti')" transparent>
       <wd-tabs v-model="tab11">
-        <template #title="{ item, title, index }">
-          <view style="display: flex; align-items: center; gap: 8rpx" :style="{ color: index === 2 ? 'red' : '' }">
-            {{ title }}
-            ({{ index === 2 ? 10 : 0 }})
-            <wd-icon name="caret-down" color="#0083ff" v-if="item.name === tab11" />
+        <template #map-nav-item="{ item, title, index, active }">
+          <view
+            style="display: flex; align-items: center; gap: 8rpx; width: 200rpx; height: 64rpx; position: relative"
+            :style="{ color: active ? '#0083ff' : index === 2 ? 'red' : '' }"
+          >
+            <wd-icon name="caret-right" color="#0083ff" v-if="active" style="position: absolute; left: 0" />
+            <view style="text-align: center; flex: 1">
+              {{ item.disabled ? '(x)' : '' }}
+              {{ title }}
+              ({{ index === 2 ? 10 : 0 }})
+            </view>
+            <wd-icon name="caret-left" color="#0083ff" v-if="active" style="position: absolute; right: 0" />
+          </view>
+        </template>
+        <template #title="{ item, title, index, active }">
+          <view style="display: flex; align-items: center; gap: 8rpx; width: 100%" :style="{ color: index === 2 ? 'red' : '' }">
+            <wd-icon name="caret-right" color="#0083ff" v-if="active" style="position: absolute; left: 0" />
+            <view style="text-align: center; flex: 1">
+              {{ item.disabled ? '(x)' : '' }}
+              {{ title }}
+              ({{ index === 2 ? 10 : 0 }})
+            </view>
+            <wd-icon name="caret-left" color="#0083ff" v-if="active" style="position: absolute; right: 0" />
           </view>
         </template>
         <template #default>
-          <block v-for="item in tabs" :key="item">
-            <wd-tab :title="item" :name="item">
+          <block v-for="item in 11" :key="item">
+            <wd-tab :title="$t('biao-qian-item') + item">
               <view class="content">{{ $t('nei-rong') }}{{ tab11 }}</view>
             </wd-tab>
           </block>
@@ -211,7 +229,7 @@ const tab7 = ref<number>(0)
 const tab8 = ref<number>(0)
 const tab9 = ref<number>(0)
 const tab10 = ref<number>(3)
-const tab11 = ref<string>(tabs.value[0])
+const tab11 = ref<number>(0)
 
 const toast = useToast()
 function handleClick({ index, name }: any) {

--- a/src/subPages/tabs/Index.vue
+++ b/src/subPages/tabs/Index.vue
@@ -150,7 +150,7 @@
         <template #default>
           <block v-for="item in tabs" :key="item">
             <wd-tab :title="item" :name="item">
-              <view class="content">{{ $t('nei-rong') }}{{ tab }}</view>
+              <view class="content">{{ $t('nei-rong') }}{{ tab11 }}</view>
             </wd-tab>
           </block>
         </template>
@@ -211,7 +211,7 @@ const tab7 = ref<number>(0)
 const tab8 = ref<number>(0)
 const tab9 = ref<number>(0)
 const tab10 = ref<number>(3)
-const tab11 = ref<number>(0)
+const tab11 = ref<string>(tabs.value[0])
 
 const toast = useToast()
 function handleClick({ index, name }: any) {

--- a/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
@@ -17,10 +17,12 @@
                     :class="`wd-tabs__nav-item  ${state.activeIndex === index ? 'is-active' : ''} ${item.disabled ? 'is-disabled' : ''}`"
                     :style="state.activeIndex === index ? (color ? 'color:' + color : '') : inactiveColor ? 'color:' + inactiveColor : ''"
                   >
-                    <wd-badge v-if="item.badgeProps" v-bind="item.badgeProps">
-                      <text class="wd-tabs__nav-item-text">{{ item.title }}</text>
-                    </wd-badge>
-                    <text v-else class="wd-tabs__nav-item-text">{{ item.title }}</text>
+                    <slot name="title" :item="item">
+                      <wd-badge v-if="item.badgeProps" v-bind="item.badgeProps">
+                        <text class="wd-tabs__nav-item-text">{{ item.title }}</text>
+                      </wd-badge>
+                      <text v-else class="wd-tabs__nav-item-text">{{ item.title }}</text>
+                    </slot>
 
                     <view class="wd-tabs__line wd-tabs__line--inner" v-if="state.activeIndex === index && state.useInnerLine"></view>
                   </view>
@@ -87,10 +89,12 @@
                 :class="`wd-tabs__nav-item ${state.activeIndex === index ? 'is-active' : ''} ${item.disabled ? 'is-disabled' : ''}`"
                 :style="state.activeIndex === index ? (color ? 'color:' + color : '') : inactiveColor ? 'color:' + inactiveColor : ''"
               >
-                <wd-badge custom-class="wd-tabs__nav-item-badge" v-if="item.badgeProps" v-bind="item.badgeProps">
-                  <text class="wd-tabs__nav-item-text">{{ item.title }}</text>
-                </wd-badge>
-                <text v-else class="wd-tabs__nav-item-text">{{ item.title }}</text>
+                <slot name="title" :item="item" :title="item.title" :index="index">
+                  <wd-badge custom-class="wd-tabs__nav-item-badge" v-if="item.badgeProps" v-bind="item.badgeProps">
+                    <text class="wd-tabs__nav-item-text">{{ item.title }}</text>
+                  </wd-badge>
+                  <text v-else class="wd-tabs__nav-item-text">{{ item.title }}</text>
+                </slot>
                 <view class="wd-tabs__line wd-tabs__line--inner" v-if="state.activeIndex === index && state.useInnerLine"></view>
               </view>
               <view class="wd-tabs__line" :style="state.lineStyle"></view>

--- a/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
@@ -17,7 +17,7 @@
                     :class="`wd-tabs__nav-item  ${state.activeIndex === index ? 'is-active' : ''} ${item.disabled ? 'is-disabled' : ''}`"
                     :style="state.activeIndex === index ? (color ? 'color:' + color : '') : inactiveColor ? 'color:' + inactiveColor : ''"
                   >
-                    <slot name="title" :item="item" :title="item.title" :index="index">
+                    <slot name="title" :item="item" :title="item.title" :index="index" :active="state.activeIndex === index">
                       <wd-badge v-if="item.badgeProps" v-bind="item.badgeProps">
                         <text class="wd-tabs__nav-item-text">{{ item.title }}</text>
                       </wd-badge>
@@ -41,20 +41,22 @@
               </view>
               <view :class="`wd-tabs__map-body  ${state.animating ? 'is-open' : ''}`" :style="state.mapShow ? '' : 'display:none'">
                 <view class="wd-tabs__map-nav-item" v-for="(item, index) in children" :key="index" @click="handleSelect(index)">
-                  <view
-                    :class="`wd-tabs__map-nav-btn ${state.activeIndex === index ? 'is-active' : ''}  ${item.disabled ? 'is-disabled' : ''}`"
-                    :style="
-                      state.activeIndex === index
-                        ? color
-                          ? 'color:' + color + ';border-color:' + color
+                  <slot name="map-nav-item" :item="item" :title="item.title" :index="index" :active="state.activeIndex === index">
+                    <view
+                      :class="`wd-tabs__map-nav-btn ${state.activeIndex === index ? 'is-active' : ''}  ${item.disabled ? 'is-disabled' : ''}`"
+                      :style="
+                        state.activeIndex === index
+                          ? color
+                            ? 'color:' + color + ';border-color:' + color
+                            : ''
+                          : inactiveColor
+                          ? 'color:' + inactiveColor
                           : ''
-                        : inactiveColor
-                        ? 'color:' + inactiveColor
-                        : ''
-                    "
-                  >
-                    {{ item.title }}
-                  </view>
+                      "
+                    >
+                      {{ item.title }}
+                    </view>
+                  </slot>
                 </view>
               </view>
             </view>
@@ -89,7 +91,7 @@
                 :class="`wd-tabs__nav-item ${state.activeIndex === index ? 'is-active' : ''} ${item.disabled ? 'is-disabled' : ''}`"
                 :style="state.activeIndex === index ? (color ? 'color:' + color : '') : inactiveColor ? 'color:' + inactiveColor : ''"
               >
-                <slot name="title" :item="item" :title="item.title" :index="index">
+                <slot name="title" :item="item" :title="item.title" :index="index" :active="state.activeIndex === index">
                   <wd-badge custom-class="wd-tabs__nav-item-badge" v-if="item.badgeProps" v-bind="item.badgeProps">
                     <text class="wd-tabs__nav-item-text">{{ item.title }}</text>
                   </wd-badge>
@@ -112,9 +114,22 @@
           </view>
           <view :class="`wd-tabs__map-body ${state.animating ? 'is-open' : ''}`" :style="state.mapShow ? '' : 'display:none'">
             <view class="wd-tabs__map-nav-item" v-for="(item, index) in children" :key="index" @click="handleSelect(index)">
-              <view :class="`wd-tabs__map-nav-btn ${state.activeIndex === index ? 'is-active' : ''}  ${item.disabled ? 'is-disabled' : ''}`">
-                {{ item.title }}
-              </view>
+              <slot name="map-nav-item" :item="item" :title="item.title" :index="index" :active="state.activeIndex === index">
+                <view
+                  :class="`wd-tabs__map-nav-btn ${state.activeIndex === index ? 'is-active' : ''}  ${item.disabled ? 'is-disabled' : ''}`"
+                  :style="
+                    state.activeIndex === index
+                      ? color
+                        ? 'color:' + color + ';border-color:' + color
+                        : ''
+                      : inactiveColor
+                      ? 'color:' + inactiveColor
+                      : ''
+                  "
+                >
+                  {{ item.title }}
+                </view>
+              </slot>
             </view>
           </view>
         </view>

--- a/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
@@ -17,7 +17,7 @@
                     :class="`wd-tabs__nav-item  ${state.activeIndex === index ? 'is-active' : ''} ${item.disabled ? 'is-disabled' : ''}`"
                     :style="state.activeIndex === index ? (color ? 'color:' + color : '') : inactiveColor ? 'color:' + inactiveColor : ''"
                   >
-                    <slot name="title" :item="item">
+                    <slot name="title" :item="item" :title="item.title" :index="index">
                       <wd-badge v-if="item.badgeProps" v-bind="item.badgeProps">
                         <text class="wd-tabs__nav-item-text">{{ item.title }}</text>
                       </wd-badge>


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [x] 站点、文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

#739 
#1216 

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
wd-tabs允许以插槽形式自定义标题。
通过在组件中标题部分最外层添加slot实现，并传递了渲染所需的相关参数： item, title, index
改动效果演示已实现在Demo中。

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - Tabs 组件新增 title 与 map-nav-item 插槽，支持为每个标签自定义标题渲染并提供 item、title、index、active 等插槽属性；默认外观保持不变。
- 文档
  - 添加自定义标题插槽用例与 Slots 参考说明；示例页新增基于插槽的标题演示，展示高亮、计数和选中指示等自定义效果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->