### PR TITLE
feat: ✨ 为Calendar和CalendarView增加季度选择

### DIFF
--- a/docs/component/calendar-view.md
+++ b/docs/component/calendar-view.md
@@ -67,10 +67,24 @@ function handleChange({ value }) {
   console.log(value)
 }
 ```
+## 季度选择
 
+设置 `type` 为 `quarter` 类型，此时 `value` 有值时其值为季度的第一天。
+
+```html
+<wd-calendar-view type="quarter" v-model="value" @change="handleChange" />
+```
+
+```typescript
+const value = ref(Date.now())
+
+function handleChange({ value }) {
+  console.log(value)
+}
+```
 ## 范围选择
 
-`type` 支持 `daterange`（日期范围选择）、`weekrange`（周范围选择）、`monthrange`（月范围选择） 类型，此时 `value` 为数组格式。
+`type` 支持 `daterange`（日期范围选择）、`weekrange`（周范围选择）、`monthrange`（月范围选择）、`quarterrange`（季度范围选择） 类型，此时 `value` 为数组格式。
 
 ```html
 <wd-calendar-view type="daterange" v-model="value" @change="handleChange" />

--- a/docs/component/calendar.md
+++ b/docs/component/calendar.md
@@ -64,9 +64,24 @@ function handleConfirm({ value }) {
 }
 ```
 
+## 季度选择
+
+设置 `type` 为 `quarter` 类型，此时 `value` 有值时其值为季度的第一天。
+
+```html
+<wd-calendar type="quarter" v-model="value" @confirm="handleConfirm" />
+```
+
+```typescript
+const value = ref<number>(Date.now())
+function handleConfirm({ value }) {
+  console.log(value)
+}
+```
+
 ## 范围选择
 
-`type` 支持 `daterange`（日期范围选择）、`weekrange`（周范围选择）、`monthrange`（月范围选择） 类型，此时 `value` 为数组格式。
+`type` 支持 `daterange`（日期范围选择）、`weekrange`（周范围选择）、`monthrange`（月范围选择）、`quarterrange`（季度范围选择） 类型，此时 `value` 为数组格式。
 
 ```html
 <wd-calendar type="daterange" v-model="value" @confirm="handleConfirm" />
@@ -397,50 +412,50 @@ function handleConfirm({ value }) {
 
 ## Attributes
 
-| 参数 | 说明 | 类型 | 可选值 | 默认值 | 最低版本 |
-|------|------|------|--------|--------|----------|
-| v-model | 选中值，为 13 位时间戳或时间戳数组 | null / number / array | - | - | - |
-| type | 日期类型 | string | date / dates / datetime / week / month / daterange / datetimerange / weekrange / monthrange | date | - |
-| min-date | 最小日期，为 13 位时间戳 | number | - | 当前日期往前推 6 个月 | - |
-| max-date | 最大日期，为 13 位时间戳 | number | - | 当前日期往后推 6 个月 | - |
-| first-day-of-week | 周起始天 | number | - | 0 | - |
-| formatter | 日期格式化函数 | function | - | - | - |
-| max-range | type 为范围选择时有效，最大日期范围 | number | - | - | - |
-| range-prompt | type 为范围选择时有效，选择超出最大日期范围时的错误提示文案 | string | - | 选择天数不能超过 x 天 | - |
-| allow-same-day | type 为范围选择时有效，是否允许选择同一天 | boolean | - | false | - |
-| default-time | 选中日期所使用的当日内具体时刻 | string / array | - | 00:00:00 | - |
-| time-filter | type 为 'datetime' 或 'datetimerange' 时有效，用于过滤时间选择器的数据 | function | - | - | - |
-| hide-second | type 为 'datetime' 或 'datetimerange' 时有效，是否不展示秒修改 | boolean | - | false | - |
-| show-confirm | 是否显示确定按钮 | boolean | - | true | - |
-| show-type-switch | 是否显示类型切换功能 | boolean | - | false | - |
-| shortcuts | 快捷选项，为对象数组，其中对象的 `text` 必传 | array | - | - | - |
-| title | 弹出层标题 | string | - | 选择日期 | - |
-| label | 选择器左侧文案 | string | - | - | - |
-| placeholder | 选择器占位符 | string | - | 请选择 | - |
-| disabled | 禁用 | boolean | - | false | - |
-| readonly | 只读 | boolean | - | false | - |
-| display-format | 自定义展示文案的格式化函数，返回一个字符串 | function | - | - | - |
-| inner-display-format | 自定义范围选择类型的面板内部回显，返回一个字符串 | function | - | - | - |
-| size | 设置选择器大小 | string | large | - | - |
-| label-width | 设置左侧标题宽度 | string | - | 33% | - |
-| error | 是否为错误状态，错误状态时右侧内容为红色 | boolean | - | false | - |
-| required | 必填样式 | boolean | - | false | - |
-| marker-side | 必填标记位置 | string | before / after | before | 1.12.0 |
-| center | 是否垂直居中 | boolean | - | false | - |
-| ellipsis | 是否超出隐藏 | boolean | - | false | - |
-| align-right | 选择器的值靠右展示 | boolean | - | false | - |
-| before-confirm | 确定前校验函数，接收 { value, resolve } 参数，通过 resolve 继续执行，resolve 接收 1 个 boolean 参数 | function | - | - | - |
-| <s>use-default-slot</s> | <s>使用默认插槽时设置该选项</s>，已废弃直接使用默认插槽即可。 | boolean | - | false | - |
-| <s>use-label-slot</s> | <s>使用 label 插槽时设置该选项</s>，已废弃直接使用 label 插槽即可。 | boolean | - | false | - |
-| close-on-click-modal | 点击遮罩是否关闭 | boolean | - | true | - |
-| z-index | 弹窗层级 | number | - | 15 | - |
-| safe-area-inset-bottom | 弹出面板是否设置底部安全距离（iphone X 类型的机型） | boolean | - | true | - |
-| prop | 表单域 `model` 字段名，在使用表单校验功能的情况下，该属性是必填的 | string | - | - | - |
-| rules | 表单验证规则，结合`wd-form`组件使用 | `FormItemRule []` | - | `[]` | - |
-| immediate-change | type 为 'datetime' 或 'datetimerange' 时有，是否在手指松开时立即触发 picker-view 的 change 事件。若不开启则会在滚动动画结束后触发 change 事件，1.2.25 版本起提供，仅微信小程序和支付宝小程序支持。 | boolean | - | false | 1.2.25 |
-| with-cell | 是否使用内置 cell 选择器 | boolean | - | true | 1.5.0 |
-| clearable | 显示清空按钮 | boolean | - | false | 1.11.0 |
-| root-portal | 是否从页面中脱离出来，用于解决各种 fixed 失效问题 | boolean | - | false | 1.11.0 |
+| 参数 | 说明 | 类型 | 可选值                                                                                                                  | 默认值 | 最低版本 |
+|------|------|------|----------------------------------------------------------------------------------------------------------------------|--------|----------|
+| v-model | 选中值，为 13 位时间戳或时间戳数组 | null / number / array | -                                                                                                                    | - | - |
+| type | 日期类型 | string | date / dates / datetime / week / month / daterange / datetimerange / weekrange / monthrange / quarter / quarterrange | date | - |
+| min-date | 最小日期，为 13 位时间戳 | number | -                                                                                                                    | 当前日期往前推 6 个月 | - |
+| max-date | 最大日期，为 13 位时间戳 | number | -                                                                                                                    | 当前日期往后推 6 个月 | - |
+| first-day-of-week | 周起始天 | number | -                                                                                                                    | 0 | - |
+| formatter | 日期格式化函数 | function | -                                                                                                                    | - | - |
+| max-range | type 为范围选择时有效，最大日期范围 | number | -                                                                                                                    | - | - |
+| range-prompt | type 为范围选择时有效，选择超出最大日期范围时的错误提示文案 | string | -                                                                                                                    | 选择天数不能超过 x 天 | - |
+| allow-same-day | type 为范围选择时有效，是否允许选择同一天 | boolean | -                                                                                                                    | false | - |
+| default-time | 选中日期所使用的当日内具体时刻 | string / array | -                                                                                                                    | 00:00:00 | - |
+| time-filter | type 为 'datetime' 或 'datetimerange' 时有效，用于过滤时间选择器的数据 | function | -                                                                                                                    | - | - |
+| hide-second | type 为 'datetime' 或 'datetimerange' 时有效，是否不展示秒修改 | boolean | -                                                                                                                    | false | - |
+| show-confirm | 是否显示确定按钮 | boolean | -                                                                                                                    | true | - |
+| show-type-switch | 是否显示类型切换功能 | boolean | -                                                                                                                    | false | - |
+| shortcuts | 快捷选项，为对象数组，其中对象的 `text` 必传 | array | -                                                                                                                    | - | - |
+| title | 弹出层标题 | string | -                                                                                                                    | 选择日期 | - |
+| label | 选择器左侧文案 | string | -                                                                                                                    | - | - |
+| placeholder | 选择器占位符 | string | -                                                                                                                    | 请选择 | - |
+| disabled | 禁用 | boolean | -                                                                                                                    | false | - |
+| readonly | 只读 | boolean | -                                                                                                                    | false | - |
+| display-format | 自定义展示文案的格式化函数，返回一个字符串 | function | -                                                                                                                    | - | - |
+| inner-display-format | 自定义范围选择类型的面板内部回显，返回一个字符串 | function | -                                                                                                                    | - | - |
+| size | 设置选择器大小 | string | large                                                                                                                | - | - |
+| label-width | 设置左侧标题宽度 | string | -                                                                                                                    | 33% | - |
+| error | 是否为错误状态，错误状态时右侧内容为红色 | boolean | -                                                                                                                    | false | - |
+| required | 必填样式 | boolean | -                                                                                                                    | false | - |
+| marker-side | 必填标记位置 | string | before / after                                                                                                       | before | 1.12.0 |
+| center | 是否垂直居中 | boolean | -                                                                                                                    | false | - |
+| ellipsis | 是否超出隐藏 | boolean | -                                                                                                                    | false | - |
+| align-right | 选择器的值靠右展示 | boolean | -                                                                                                                    | false | - |
+| before-confirm | 确定前校验函数，接收 { value, resolve } 参数，通过 resolve 继续执行，resolve 接收 1 个 boolean 参数 | function | -                                                                                                                    | - | - |
+| <s>use-default-slot</s> | <s>使用默认插槽时设置该选项</s>，已废弃直接使用默认插槽即可。 | boolean | -                                                                                                                    | false | - |
+| <s>use-label-slot</s> | <s>使用 label 插槽时设置该选项</s>，已废弃直接使用 label 插槽即可。 | boolean | -                                                                                                                    | false | - |
+| close-on-click-modal | 点击遮罩是否关闭 | boolean | -                                                                                                                    | true | - |
+| z-index | 弹窗层级 | number | -                                                                                                                    | 15 | - |
+| safe-area-inset-bottom | 弹出面板是否设置底部安全距离（iphone X 类型的机型） | boolean | -                                                                                                                    | true | - |
+| prop | 表单域 `model` 字段名，在使用表单校验功能的情况下，该属性是必填的 | string | -                                                                                                                    | - | - |
+| rules | 表单验证规则，结合`wd-form`组件使用 | `FormItemRule []` | -                                                                                                                    | `[]` | - |
+| immediate-change | type 为 'datetime' 或 'datetimerange' 时有，是否在手指松开时立即触发 picker-view 的 change 事件。若不开启则会在滚动动画结束后触发 change 事件，1.2.25 版本起提供，仅微信小程序和支付宝小程序支持。 | boolean | -                                                                                                                    | false | 1.2.25 |
+| with-cell | 是否使用内置 cell 选择器 | boolean | -                                                                                                                    | true | 1.5.0 |
+| clearable | 显示清空按钮 | boolean | -                                                                                                                    | false | 1.11.0 |
+| root-portal | 是否从页面中脱离出来，用于解决各种 fixed 失效问题 | boolean | -                                                                                                                    | false | 1.11.0 |
 
 ### FormItemRule 数据结构
 

--- a/docs/en-US/component/calendar-view.md
+++ b/docs/en-US/component/calendar-view.md
@@ -67,10 +67,24 @@ function handleChange({ value }) {
   console.log(value)
 }
 ```
+## Month Type Selection
 
+Set `type` to `quarter` type. When `value` has a value, its value is the first day of the quarter.
+
+```html
+<wd-calendar-view type="quarter" v-model="value" @change="handleChange" />
+```
+
+```typescript
+const value = ref(Date.now())
+
+function handleChange({ value }) {
+  console.log(value)
+}
+```
 ## Range Selection
 
-`type` supports `daterange` (date range selection), `weekrange` (week range selection), `monthrange` (month range selection) types. At this time, `value` is in array format.
+`type` supports `daterange` (date range selection), `weekrange` (week range selection), `monthrange` (month range selection), `quarterrange` (quarter range selection) types. At this time, `value` is in array format.
 
 ```html
 <wd-calendar-view type="daterange" v-model="value" @change="handleChange" />

--- a/docs/en-US/component/calendar.md
+++ b/docs/en-US/component/calendar.md
@@ -63,10 +63,23 @@ function handleConfirm({ value }) {
   console.log(value)
 }
 ```
+## Quarter Selection
 
+Set `type` to `quarter` type. When `value` has a value, its value is the first day of the quarter.
+
+```html
+<wd-calendar type="quarter" v-model="value" @confirm="handleConfirm" />
+```
+
+```typescript
+const value = ref<number>(Date.now())
+function handleConfirm({ value }) {
+  console.log(value)
+}
+```
 ## Range Selection
 
-`type` supports `daterange` (date range selection), `weekrange` (week range selection), `monthrange` (month range selection) types. At this time, `value` is in array format.
+`type` supports `daterange` (date range selection), `weekrange` (week range selection), `monthrange` (month range selection), `quarterrange` (quarter range selection) types. At this time, `value` is in array format.
 
 ```html
 <wd-calendar type="daterange" v-model="value" @confirm="handleConfirm" />
@@ -169,48 +182,48 @@ Set the `formatter` parameter, which is a function type that receives an `object
 
 ## Attributes
 
-| Attribute | Description | Type | Options | Default | Version |
-|-----------|-------------|------|----------|---------|----------|
-| v-model | Selected value, 13-digit timestamp or timestamp array | null / number / array | - | - | - |
-| type | Date type | string | date / dates / datetime / week / month / daterange / datetimerange / weekrange / monthrange | date | - |
-| min-date | Minimum date, 13-digit timestamp | number | - | 6 months before current date | - |
-| max-date | Maximum date, 13-digit timestamp | number | - | 6 months after current date | - |
-| first-day-of-week | Week start day | number | - | 0 | - |
-| formatter | Date formatting function | function | - | - | - |
-| max-range | Maximum date range for range selection types | number | - | - | - |
-| range-prompt | Error message when selection exceeds maximum date range | string | - | Selection cannot exceed x days | - |
-| allow-same-day | Whether to allow selecting the same day in range selection | boolean | - | false | - |
-| default-time | Specific time of day for selected date | string / array | - | 00:00:00 | - |
-| time-filter | Filter function for time picker data, effective for 'datetime' or 'datetimerange' types | function | - | - | - |
-| hide-second | Whether to hide second modification for 'datetime' or 'datetimerange' types | boolean | - | false | - |
-| show-confirm | Whether to show confirm button | boolean | - | true | - |
-| show-type-switch | Whether to show type switch function | boolean | - | false | - |
-| shortcuts | Quick options, array of objects with required 'text' property | array | - | - | - |
-| title | Popup title | string | - | Select Date | - |
-| label | Picker left text | string | - | - | - |
-| placeholder | Picker placeholder | string | - | Please select | - |
-| disabled | Disabled state | boolean | - | false | - |
-| readonly | Read-only state | boolean | - | false | - |
-| display-format | Custom display text formatting function, returns a string | function | - | - | - |
-| inner-display-format | Custom panel internal display for range selection types, returns a string | function | - | - | - |
-| size | Set picker size | string | large | - | - |
-| label-width | Set left title width | string | - | 33% | - |
-| error | Whether in error state, right content is red in error state | boolean | - | false | - |
-| required | Required style | boolean | - | false | - |
-| marker-side | Position of the required marker | 'before' \| 'after' | - | 'before' | 1.12.0 |
-| center | Whether to vertically center | boolean | - | false | - |
-| ellipsis | Whether to hide overflow | boolean | - | false | - |
-| align-right | Display picker value aligned to the right | boolean | - | false | - |
-| before-confirm | Validation function before confirmation, receives { value, resolve } parameters, continue through resolve, resolve accepts a boolean parameter | function | - | - | - |
-| close-on-click-modal | Whether to close when clicking mask | boolean | - | true | - |
-| z-index | Popup layer z-index | number | - | 15 | - |
-| safe-area-inset-bottom | Whether to set bottom safe area for popup panel (iPhone X type devices) | boolean | - | true | - |
-| prop | Form field `model` field name, required when using form validation | string | - | - | - |
-| rules | Form validation rules, used with `wd-form` component | `FormItemRule []` | - | `[]` | - |
-| immediate-change | Whether to trigger the picker-view's change event immediately when the finger is released. If not enabled, the change event will be triggered after the scrolling animation ends. Available from version 1.2.25, only supported on WeChat Mini Program and Alipay Mini Program. | boolean | - | false | 1.2.25 |
-| with-cell | Whether to use built-in cell picker | boolean | - | true | 1.5.0 |
-| clearable | Show clear button | boolean | - | false | 1.11.0 |
-| root-portal | Whether to detach from the page, used to solve various fixed positioning issues | boolean | - | false | 1.11.0 |
+| Attribute | Description | Type | Options                                                                                                              | Default | Version |
+|-----------|-------------|------|----------------------------------------------------------------------------------------------------------------------|---------|----------|
+| v-model | Selected value, 13-digit timestamp or timestamp array | null / number / array | -                                                                                                                    | - | - |
+| type | Date type | string | date / dates / datetime / week / month / daterange / datetimerange / weekrange / monthrange / quarter / quarterrange | date | - |
+| min-date | Minimum date, 13-digit timestamp | number | -                                                                                                                    | 6 months before current date | - |
+| max-date | Maximum date, 13-digit timestamp | number | -                                                                                                                    | 6 months after current date | - |
+| first-day-of-week | Week start day | number | -                                                                                                                    | 0 | - |
+| formatter | Date formatting function | function | -                                                                                                                    | - | - |
+| max-range | Maximum date range for range selection types | number | -                                                                                                                    | - | - |
+| range-prompt | Error message when selection exceeds maximum date range | string | -                                                                                                                    | Selection cannot exceed x days | - |
+| allow-same-day | Whether to allow selecting the same day in range selection | boolean | -                                                                                                                    | false | - |
+| default-time | Specific time of day for selected date | string / array | -                                                                                                                    | 00:00:00 | - |
+| time-filter | Filter function for time picker data, effective for 'datetime' or 'datetimerange' types | function | -                                                                                                                    | - | - |
+| hide-second | Whether to hide second modification for 'datetime' or 'datetimerange' types | boolean | -                                                                                                                    | false | - |
+| show-confirm | Whether to show confirm button | boolean | -                                                                                                                    | true | - |
+| show-type-switch | Whether to show type switch function | boolean | -                                                                                                                    | false | - |
+| shortcuts | Quick options, array of objects with required 'text' property | array | -                                                                                                                    | - | - |
+| title | Popup title | string | -                                                                                                                    | Select Date | - |
+| label | Picker left text | string | -                                                                                                                    | - | - |
+| placeholder | Picker placeholder | string | -                                                                                                                    | Please select | - |
+| disabled | Disabled state | boolean | -                                                                                                                    | false | - |
+| readonly | Read-only state | boolean | -                                                                                                                    | false | - |
+| display-format | Custom display text formatting function, returns a string | function | -                                                                                                                    | - | - |
+| inner-display-format | Custom panel internal display for range selection types, returns a string | function | -                                                                                                                    | - | - |
+| size | Set picker size | string | large                                                                                                                | - | - |
+| label-width | Set left title width | string | -                                                                                                                    | 33% | - |
+| error | Whether in error state, right content is red in error state | boolean | -                                                                                                                    | false | - |
+| required | Required style | boolean | -                                                                                                                    | false | - |
+| marker-side | Position of the required marker | 'before' \| 'after' | -                                                                                                                    | 'before' | 1.12.0 |
+| center | Whether to vertically center | boolean | -                                                                                                                    | false | - |
+| ellipsis | Whether to hide overflow | boolean | -                                                                                                                    | false | - |
+| align-right | Display picker value aligned to the right | boolean | -                                                                                                                    | false | - |
+| before-confirm | Validation function before confirmation, receives { value, resolve } parameters, continue through resolve, resolve accepts a boolean parameter | function | -                                                                                                                    | - | - |
+| close-on-click-modal | Whether to close when clicking mask | boolean | -                                                                                                                    | true | - |
+| z-index | Popup layer z-index | number | -                                                                                                                    | 15 | - |
+| safe-area-inset-bottom | Whether to set bottom safe area for popup panel (iPhone X type devices) | boolean | -                                                                                                                    | true | - |
+| prop | Form field `model` field name, required when using form validation | string | -                                                                                                                    | - | - |
+| rules | Form validation rules, used with `wd-form` component | `FormItemRule []` | -                                                                                                                    | `[]` | - |
+| immediate-change | Whether to trigger the picker-view's change event immediately when the finger is released. If not enabled, the change event will be triggered after the scrolling animation ends. Available from version 1.2.25, only supported on WeChat Mini Program and Alipay Mini Program. | boolean | -                                                                                                                    | false | 1.2.25 |
+| with-cell | Whether to use built-in cell picker | boolean | -                                                                                                                    | true | 1.5.0 |
+| clearable | Show clear button | boolean | -                                                                                                                    | false | 1.11.0 |
+| root-portal | Whether to detach from the page, used to solve various fixed positioning issues | boolean | -                                                                                                                    | false | 1.11.0 |
 
 ### FormItemRule Data Structure
 

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -1452,6 +1452,8 @@
   "yue-xuan-ze": "Monthly selection",
   "yun-xu-ban-xuan": "Allow half selection",
   "yun-xu-kong-zhi-bing-she-zhi-placeholder": "Allow null values and set placeholder",
+  "ji-du-xuan-ze": "Quarterly selection",
+  "ji-du-fan-wei-xuan-ze": "Quarterly Range Selection",
   "yy-nian-mm-yue-dd-ri": "YY year MM month DD day",
   "yy-nian-mm-yue-dd-ri-0": "YY year MM month DD day",
   "yy-nian-mm-yue-dd-ri-1": "YY year MM month DD day",

--- a/src/locale/zh-CN.json
+++ b/src/locale/zh-CN.json
@@ -1452,6 +1452,8 @@
   "yue-xuan-ze": "月选择",
   "yun-xu-ban-xuan": "允许半选",
   "yun-xu-kong-zhi-bing-she-zhi-placeholder": "允许空值，并设置 placeholder",
+  "ji-du-xuan-ze": "季度选择",
+  "ji-du-fan-wei-xuan-ze" : "季度范围选择",
   "yy-nian-mm-yue-dd-ri": "YY年MM月DD日",
   "yy-nian-mm-yue-dd-ri-0": "YY年MM月DD日",
   "yy-nian-mm-yue-dd-ri-1": "YY年MM月DD日",

--- a/src/subPages/calendar/Index.vue
+++ b/src/subPages/calendar/Index.vue
@@ -9,8 +9,10 @@
         <wd-calendar :label="$t('ri-qi-shi-jian-fan-wei-xuan-ze')" type="datetimerange" v-model="value5" />
         <wd-calendar :label="$t('zhou-xuan-ze')" type="week" v-model="value6" />
         <wd-calendar :label="$t('yue-xuan-ze')" type="month" :min-date="minDate" v-model="value7" />
+        <wd-calendar :label="$t('ji-du-xuan-ze')" type="quarter" :min-date="minDate" v-model="value19" />
         <wd-calendar :label="$t('zhou-fan-wei-xuan-ze')" :first-day-of-week="1" type="weekrange" v-model="value8" />
         <wd-calendar :label="$t('yue-fan-wei-xuan-ze')" type="monthrange" v-model="value9" />
+        <wd-calendar :label="$t('ji-du-fan-wei-xuan-ze')" type="quarterrange" :min-date="minDate" v-model="value20" />
         <wd-calendar :label="$t('ri-zhou-yue-qie-huan')" :first-day-of-week="1" show-type-switch v-model="value10" />
         <wd-calendar :label="$t('kuai-jie-cao-zuo')" v-model="value16" :show-confirm="false" />
         <wd-calendar :label="$t('ri-qi-ge-shi-hua')" type="daterange" v-model="value11" :formatter="formatter" />
@@ -69,12 +71,12 @@
   <wd-message-box />
 </template>
 <script lang="ts" setup>
-import { useToast } from '@/uni_modules/wot-design-uni'
-import { dayjs } from '@/uni_modules/wot-design-uni'
+import { dayjs, useToast } from '@/uni_modules/wot-design-uni'
 import type { CalendarDayItem, CalendarFormatter } from '@/uni_modules/wot-design-uni/components/wd-calendar-view/types'
 import type { CalendarInstance, CalendarOnShortcutsClickOption } from '@/uni_modules/wot-design-uni/components/wd-calendar/types'
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+
 const { t } = useI18n()
 
 const minDate = ref<number>(new Date(new Date().getFullYear() - 20, new Date().getMonth() - 6, new Date().getDate()).getTime())
@@ -97,6 +99,9 @@ const value15 = ref<number | null>(null)
 const value16 = ref<number>(Date.now())
 const value17 = ref<number>(Date.now())
 const value18 = ref<number>(Date.now())
+const value19 = ref<number>(Date.now())
+const value20 = ref<number>([Date.now() - 24 * 60 * 60 * 1000 * 33 * 4, Date.now()])
+
 const valueClear1 = ref<number | null>(Date.now())
 const valueClear2 = ref<number[]>([Date.now() - 24 * 60 * 60 * 1000 * 3, Date.now()])
 

--- a/src/subPages/calendarView/Index.vue
+++ b/src/subPages/calendarView/Index.vue
@@ -7,6 +7,7 @@
           <wd-radio value="date">date</wd-radio>
           <wd-radio value="week">week</wd-radio>
           <wd-radio value="month">month</wd-radio>
+          <wd-radio value="quarter">quarter</wd-radio>
         </wd-radio-group>
       </view>
       <wd-calendar-view :type="type1" v-model="value1" @change="handleChange1"></wd-calendar-view>
@@ -21,6 +22,7 @@
           <wd-radio value="daterange">daterange</wd-radio>
           <wd-radio value="weekrange">weekrange</wd-radio>
           <wd-radio value="monthrange">monthrange</wd-radio>
+          <wd-radio value="quarterrange">quarterrange</wd-radio>
         </wd-radio-group>
       </view>
       <wd-calendar-view :type="type2" allow-same-day v-model="value3" @change="handleChange3"></wd-calendar-view>

--- a/src/uni_modules/wot-design-uni/components/common/abstracts/variable.scss
+++ b/src/uni_modules/wot-design-uni/components/common/abstracts/variable.scss
@@ -220,6 +220,7 @@ $-calendar-day-color: var(--wot-calendar-day-color, rgba(0, 0, 0, 0.85)) !defaul
 $-calendar-day-fw: var(--wot-calendar-day-fw, 500) !default;
 $-calendar-day-height: var(--wot-calendar-day-height, 64px) !default;
 $-calendar-month-width: var(--wot-calendar-month-width, 50px) !default;
+$-calendar-quarter-width: var(--wot-calendar-quarter-width, 50px) !default;
 $-calendar-active-color: var(--wot-calendar-active-color, $-color-theme) !default;
 $-calendar-selected-color: var(--wot-calendar-selected-color, $-color-white) !default;
 $-calendar-disabled-color: var(--wot-calendar-disabled-color, rgba(0, 0, 0, 0.25)) !default;

--- a/src/uni_modules/wot-design-uni/components/wd-calendar-view/quarter/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-calendar-view/quarter/index.scss
@@ -1,0 +1,153 @@
+@import '../../common/abstracts/variable';
+@import '../../common/abstracts/mixin';
+
+.wot-theme-dark {
+  @include b(year) {
+    @include e(title) {
+      color: $-dark-color;
+    }
+
+    @include e(quarters) {
+      color: $-dark-color;
+    }
+
+    @include e(quarter) {
+
+      @include when(disabled) {
+        .wd-year__quarter-text {
+          color: $-dark-color-gray;
+        }
+      }
+    }
+  }
+}
+
+@include b(year) {
+  @include e(title) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 45px;
+    font-size: $-calendar-panel-title-fs;
+    color: $-calendar-panel-title-color;
+  }
+
+  @include e(quarters) {
+    display: flex;
+    flex-wrap: wrap;
+    font-size: $-calendar-day-fs;
+    color: $-calendar-day-color;
+  }
+
+  @include e(quarter) {
+    position: relative;
+    width: 50%;
+    height: $-calendar-day-height;
+    line-height: $-calendar-day-height;
+    text-align: center;
+    margin-bottom: $-calendar-item-margin-bottom;
+
+    @include when(disabled) {
+      .wd-year__quarter-text {
+        color: $-calendar-disabled-color;
+      }
+    }
+
+    @include when(current) {
+      color: $-calendar-active-color;
+    }
+
+    @include when(selected) {
+      color: #fff;
+
+      .wd-year__quarter-text {
+        border-radius: $-calendar-active-border;
+        background: $-calendar-active-color;
+      }
+    }
+
+    @include when(middle) {
+      background: $-calendar-range-color;
+    }
+
+    @include when(start) {
+      color: $-calendar-selected-color;
+
+      &::after {
+        position: absolute;
+        top: 0;
+        right: 0;
+        left: 50%;
+        bottom: 0;
+        content: '';
+        background: $-calendar-range-color;
+      }
+
+      .wd-year__quarter-text {
+        background: $-calendar-active-color;
+        border-radius: $-calendar-active-border 0 0 $-calendar-active-border;
+      }
+
+      &.is-without-end::after {
+        display: none;
+      }
+    }
+
+    @include when(end) {
+      color: $-calendar-selected-color;
+
+      &::after {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 50%;
+        bottom: 0;
+        content: '';
+        background: $-calendar-range-color;
+      }
+
+      .wd-year__quarter-text {
+        background: $-calendar-active-color;
+        border-radius: 0 $-calendar-active-border $-calendar-active-border 0;
+      }
+    }
+
+    @include when(same) {
+      color: $-calendar-selected-color;
+
+      .wd-year__quarter-text {
+        background: $-calendar-active-color;
+        border-radius: $-calendar-active-border;
+      }
+    }
+    @include when(last-row){
+      margin-bottom: 0;
+    }
+  }
+
+  @include e(quarter-text) {
+    width: $-calendar-quarter-width;
+    margin: 0 auto;
+    text-align: center;
+  }
+
+  @include e(quarter-top) {
+    position: absolute;
+    top: 10px;
+    left: 0;
+    right: 0;
+    line-height: 1.1;
+    font-size: $-calendar-info-fs;
+    text-align: center;
+  }
+
+  @include e(quarter-bottom) {
+    position: absolute;
+    bottom: 10px;
+    left: 0;
+    right: 0;
+    line-height: 1.1;
+    font-size: $-calendar-info-fs;
+    text-align: center;
+  }
+}

--- a/src/uni_modules/wot-design-uni/components/wd-calendar-view/quarter/quarter.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-calendar-view/quarter/quarter.vue
@@ -1,0 +1,219 @@
+<template>
+  <wd-toast selector="wd-year" />
+
+  <view class="wd-year year">
+    <view class="wd-year__title" v-if="showTitle">{{ yearTitle(date) }}</view>
+
+    <view class="wd-year__quarters">
+      <view
+        v-for="(item, index) in quarters"
+        :key="index"
+        :class="`wd-year__quarter ${item.disabled ? 'is-disabled' : ''} ${item.isLastRow ? 'is-last-row' : ''} ${
+          item.type ? quarterTypeClass(item.type) : ''
+        }`"
+        @click="handleDateClick(index)"
+      >
+        <view class="wd-year__quarter-top">{{ item.topInfo }}</view>
+        <view class="wd-year__quarter-text">{{ getQuarterLabel(item.date) }}</view>
+        <view class="wd-year__quarter-bottom">{{ item.bottomInfo }}</view>
+      </view>
+    </view>
+  </view>
+</template>
+<script lang="ts">
+export default {
+  options: {
+    addGlobalClass: true,
+    virtualHost: true,
+    styleIsolation: 'shared'
+  }
+}
+</script>
+
+<script lang="ts" setup>
+import wdToast from '../../wd-toast/wd-toast.vue'
+import { computed, ref, watch } from 'vue'
+import { deepClone, isArray, isFunction } from '../../common/util'
+import { compareQuarter, formatYearTitle, getDateByDefaultTime, getItemClass, getQuarterByOffset, getQuarterOffset } from '../utils'
+import { useToast } from '../../wd-toast'
+import { useTranslate } from '../../composables/useTranslate'
+import dayjs from '../../../dayjs'
+
+import { quarterProps } from './types'
+import type { CalendarDayItem, CalendarDayType } from '../types'
+
+const props = defineProps(quarterProps)
+const emit = defineEmits(['change'])
+
+const toast = useToast('wd-year')
+const { translate } = useTranslate('calendar-view')
+
+const quarters = ref<CalendarDayItem[]>([])
+const quarterTypeClass = computed(() => {
+  return (quarterType: CalendarDayType) => {
+    return getItemClass(quarterType, props.value, props.type)
+  }
+})
+
+const yearTitle = computed(() => {
+  return (date: number) => {
+    return formatYearTitle(date)
+  }
+})
+
+watch(
+  [() => props.type, () => props.date, () => props.value, () => props.minDate, () => props.maxDate, () => props.formatter],
+  () => {
+    setQuarters()
+  },
+  {
+    deep: true,
+    immediate: true
+  }
+)
+
+/**
+ * 获取季度的格式化标签
+ * @param {number} date - 时间戳
+ * @returns {string} 格式化后的季度字符串，例如 "2023-Q2"
+ */
+function getQuarterLabel(date: number): string {
+  // 使用 Day.js 处理传入的时间戳
+  const dateObj = dayjs(date)
+
+  // 获取季度数字 (1-4)
+  const quarterNum = dateObj.quarter()
+
+  return `Q${quarterNum}`
+}
+
+function setQuarters() {
+  const quarterList: CalendarDayItem[] = []
+  const date = new Date(props.date)
+  const year = date.getFullYear()
+  const value = props.value
+
+  if (props.type.indexOf('range') > -1 && value && !isArray(value)) {
+    console.error('[wot-design] value should be array when type is range')
+    return
+  }
+
+  for (let quarter = 0; quarter < 4; quarter++) {
+    // 计算季度的起始月份：Q1=0(1月), Q2=3(4月), Q3=6(7月), Q4=9(10月)
+    const quarterStartMonth = quarter * 3
+    const quarterStartDate = new Date(year, quarterStartMonth, 1).getTime()
+
+    let type: CalendarDayType = getQuarterType(quarterStartDate)
+
+    if (!type && compareQuarter(quarterStartDate, Date.now()) === 0) {
+      type = 'current'
+    }
+
+    const quarterObj = getFormatterDate(quarterStartDate, quarter, type)
+    quarterList.push(quarterObj)
+  }
+
+  quarters.value = deepClone(quarterList)
+}
+function getQuarterType(date: number) {
+  if (props.type === 'quarterrange' && isArray(props.value)) {
+    const [startDate, endDate] = props.value || []
+
+    if (startDate && compareQuarter(date, startDate) === 0) {
+      if (endDate && compareQuarter(startDate, endDate) === 0) {
+        return 'same'
+      }
+      return 'start'
+    } else if (endDate && compareQuarter(date, endDate) === 0) {
+      return 'end'
+    } else if (startDate && endDate && compareQuarter(date, startDate) === 1 && compareQuarter(date, endDate) === -1) {
+      return 'middle'
+    } else {
+      return ''
+    }
+  } else {
+    if (props.value && compareQuarter(date, props.value as number) === 0) {
+      return 'selected'
+    } else {
+      return ''
+    }
+  }
+}
+function handleDateClick(index: number) {
+  const date = quarters.value[index]
+
+  if (date.disabled) return
+
+  switch (props.type) {
+    case 'quarter':
+      handleQuarterChange(date)
+      break
+    case 'quarterrange':
+      handleQuarterRangeChange(date)
+      break
+    default:
+      handleQuarterChange(date)
+  }
+}
+function getDate(date: number) {
+  return props.defaultTime && props.defaultTime.length > 0 ? getDateByDefaultTime(date, props.defaultTime[0]) : date
+}
+function handleQuarterChange(date: CalendarDayItem) {
+  if (date.type !== 'selected') {
+    emit('change', {
+      value: getDate(date.date)
+    })
+  }
+}
+function handleQuarterRangeChange(date: CalendarDayItem) {
+  let value: (number | null)[] = []
+  const [startDate, endDate] = isArray(props.value) ? props.value || [] : []
+  const compare = compareQuarter(date.date, startDate!)
+
+  // 禁止选择同个季度
+  if (!props.allowSameDay && !endDate && compare === 0) return
+
+  if (startDate && !endDate && compare > -1) {
+    if (props.maxRange && getQuarterOffset(date.date, startDate) > props.maxRange) {
+      const maxEndDate = getQuarterByOffset(startDate, props.maxRange - 1)
+      value = [startDate, getDate(maxEndDate)]
+      toast.show({
+        msg: props.rangePrompt || translate('rangePromptQuarter', props.maxRange)
+      })
+    } else {
+      value = [startDate, getDate(date.date)]
+    }
+  } else {
+    value = [getDate(date.date), null]
+  }
+  emit('change', {
+    value
+  })
+}
+
+function getFormatterDate(date: number, quarter: number, type?: CalendarDayType) {
+  let quarterObj: CalendarDayItem = {
+    date: date,
+    text: `Q${quarter + 1}`, // 改为显示季度文本，如 Q1, Q2, Q3, Q4
+    topInfo: '',
+    bottomInfo: '',
+    type,
+    disabled: compareQuarter(date, props.minDate) === -1 || compareQuarter(date, props.maxDate) === 1,
+    isLastRow: quarter >= 2 // 季度索引 0-3，每行2个，所以最后一行是索引2和3
+  }
+
+  if (props.formatter) {
+    if (isFunction(props.formatter)) {
+      quarterObj = props.formatter(quarterObj)
+    } else {
+      console.error('[wot-design] error(wd-calendar-view): the formatter prop of wd-calendar-view should be a function')
+    }
+  }
+
+  return quarterObj
+}
+</script>
+
+<style lang="scss" scoped>
+@import './index.scss';
+</style>

--- a/src/uni_modules/wot-design-uni/components/wd-calendar-view/quarter/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-calendar-view/quarter/types.ts
@@ -1,0 +1,20 @@
+import { makeBooleanProp, makeRequiredProp } from '@/uni_modules/wot-design-uni/components/common/props'
+import type { PropType } from 'vue'
+import type { CalendarFormatter, CalendarType } from '@/uni_modules/wot-design-uni/components/wd-calendar-view/types'
+
+export const quarterProps = {
+  type: makeRequiredProp(String as PropType<CalendarType>),
+  date: makeRequiredProp(Number),
+  value: makeRequiredProp([Number, Array] as PropType<number | (number | null)[] | null>),
+  minDate: makeRequiredProp(Number),
+  maxDate: makeRequiredProp(Number),
+  // 日期格式化函数
+  formatter: Function as PropType<CalendarFormatter>,
+  maxRange: Number,
+  rangePrompt: String,
+  allowSameDay: makeBooleanProp(false),
+  defaultTime: {
+    type: [Array] as PropType<Array<number[]>>
+  },
+  showTitle: makeBooleanProp(true)
+}

--- a/src/uni_modules/wot-design-uni/components/wd-calendar-view/quarterPanel/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-calendar-view/quarterPanel/index.scss
@@ -1,0 +1,24 @@
+@import '../../common/abstracts/variable';
+@import '../../common/abstracts/mixin';
+
+.wot-theme-dark {
+  @include b(quarter-panel) {
+    @include e(title) {
+      color: $-dark-color;
+      box-shadow: 0px 4px 8px 0 rgba(255, 255,255, 0.02);
+    }
+  }
+}
+
+@include b(quarter-panel) {
+  font-size: $-calendar-fs;
+  padding: $-calendar-panel-padding;
+
+  @include e(title) {
+    padding: 5px 0;
+    text-align: center;
+    font-size: $-calendar-panel-title-fs;
+    color: $-calendar-panel-title-color;
+    box-shadow: 0px 4px 8px 0 rgba(0, 0, 0, 0.02);
+  }
+}

--- a/src/uni_modules/wot-design-uni/components/wd-calendar-view/quarterPanel/quarter-panel.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-calendar-view/quarterPanel/quarter-panel.vue
@@ -1,0 +1,95 @@
+<template>
+  <view class="wd-quarter-panel">
+    <view v-if="showPanelTitle" class="wd-quarter-panel__title">{{ title }}</view>
+    <scroll-view class="wd-quarter-panel__container" :style="`height: ${scrollHeight}px`" scroll-y @scroll="yearScroll" :scroll-top="scrollTop">
+      <view v-for="(item, index) in years" :key="index" :id="`year${index}`">
+        <quarter
+          :type="type"
+          :date="item.date"
+          :value="value"
+          :min-date="minDate"
+          :max-date="maxDate"
+          :max-range="maxRange"
+          :formatter="formatter"
+          :range-prompt="rangePrompt"
+          :allow-same-day="allowSameDay"
+          :default-time="defaultTime"
+          :showTitle="index !== 0"
+          @change="handleDateChange"
+        />
+      </view>
+    </scroll-view>
+  </view>
+</template>
+<script lang="ts">
+export default {
+  options: {
+    addGlobalClass: true,
+    virtualHost: true,
+    styleIsolation: 'shared'
+  }
+}
+</script>
+<script lang="ts" setup>
+import { ref, computed } from 'vue'
+
+import { quarterPanelProps } from './types'
+import { formatYearTitle, getYears } from '../utils'
+import { type YearInfo } from '../yearPanel/types'
+import Quarter from '../quarter/quarter.vue'
+const props = defineProps(quarterPanelProps)
+
+const emit = defineEmits(['change'])
+const scrollTop = ref<number>(0) // 滚动位置
+const scrollIndex = ref<number>(0) // 当前显示的年份索引
+
+// 标题
+const title = computed(() => {
+  return formatYearTitle(years.value[scrollIndex.value].date)
+})
+// 年份信息
+const years = computed<YearInfo[]>(() => {
+  return getYears(props.minDate, props.maxDate).map((year, index) => {
+    return {
+      date: year,
+      height: index === 0 ? 200 : 245
+    }
+  })
+})
+const yearScroll = (event: { detail: { scrollTop: number } }) => {
+  if (years.value.length <= 1) {
+    return
+  }
+  const scrollTop = Math.max(0, event.detail.scrollTop)
+  doSetSubtitle(scrollTop)
+}
+/**
+ * 设置小标题
+ * scrollTop 滚动条位置
+ */
+function doSetSubtitle(scrollTop: number) {
+  let height: number = 0 // 月份高度和
+  for (let index = 0; index < years.value.length; index++) {
+    height = height + years.value[index].height
+    if (scrollTop < height) {
+      scrollIndex.value = index
+      return
+    }
+  }
+}
+function handleDateChange({ value }: { value: number[] }) {
+  emit('change', {
+    value
+  })
+}
+
+// 滚动区域的高度
+const scrollHeight = computed(() => {
+  const scrollHeight: number = props.panelHeight + (props.showPanelTitle ? 26 : 16)
+  return scrollHeight
+})
+</script>
+
+<style lang="scss" scoped>
+@import './index.scss';
+</style>

--- a/src/uni_modules/wot-design-uni/components/wd-calendar-view/quarterPanel/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-calendar-view/quarterPanel/types.ts
@@ -1,0 +1,20 @@
+import { monthPanelProps } from '@/uni_modules/wot-design-uni/components/wd-calendar-view/monthPanel/types'
+import { makeBooleanProp, makeRequiredProp } from '@/uni_modules/wot-design-uni/components/common/props'
+import type { PropType } from 'vue'
+import type { CalendarFormatter, CalendarType } from '@/uni_modules/wot-design-uni/components/wd-calendar-view/types'
+
+export const quarterPanelProps = {
+  type: makeRequiredProp(String as PropType<CalendarType>),
+  value: makeRequiredProp([Number, Array] as PropType<number | (number | null)[] | null>),
+  minDate: makeRequiredProp(Number),
+  maxDate: makeRequiredProp(Number),
+  formatter: Function as PropType<CalendarFormatter>,
+  maxRange: Number,
+  rangePrompt: String,
+  allowSameDay: makeBooleanProp(false),
+  showPanelTitle: makeBooleanProp(false),
+  defaultTime: {
+    type: [Array] as PropType<Array<number[]>>
+  },
+  panelHeight: makeRequiredProp(Number)
+}

--- a/src/uni_modules/wot-design-uni/components/wd-calendar-view/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-calendar-view/types.ts
@@ -1,7 +1,18 @@
 import type { ComponentPublicInstance, ExtractPropTypes, PropType } from 'vue'
 import { baseProps, makeBooleanProp, makeNumberProp, makeRequiredProp, makeStringProp } from '../common/props'
 
-export type CalendarType = 'date' | 'dates' | 'datetime' | 'week' | 'month' | 'daterange' | 'datetimerange' | 'weekrange' | 'monthrange'
+export type CalendarType =
+  | 'date'
+  | 'dates'
+  | 'datetime'
+  | 'week'
+  | 'month'
+  | 'daterange'
+  | 'datetimerange'
+  | 'weekrange'
+  | 'monthrange'
+  | 'quarter'
+  | 'quarterrange'
 
 export const calendarViewProps = {
   ...baseProps,

--- a/src/uni_modules/wot-design-uni/components/wd-calendar-view/utils.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-calendar-view/utils.ts
@@ -3,6 +3,7 @@ import dayjs from '../../dayjs'
 import { isArray, isFunction, padZero } from '../common/util'
 import { useTranslate } from '../composables/useTranslate'
 import type { CalendarDayType, CalendarItem, CalendarTimeFilter, CalendarType } from './types'
+
 const { translate } = useTranslate('calendar-view')
 
 const weeks = computed(() => {
@@ -70,6 +71,28 @@ export function compareMonth(date1: number, date2: number) {
   }
 
   return year1 > year2 ? 1 : -1
+}
+/**
+ * 比较两个日期的季度
+ * @param {timestamp} date1 - 第一个时间戳
+ * @param {timestamp} date2 - 第二个时间戳
+ * @returns {number} 0:同一季度，1:date1季度较晚，-1:date2季度较晚
+ */
+export function compareQuarter(date1: number, date2: number): number {
+  const getQuarter = (date: Date): number => Math.floor(date.getMonth() / 3) + 1
+
+  const d1 = new Date(date1)
+  const d2 = new Date(date2)
+
+  const year1 = d1.getFullYear()
+  const year2 = d2.getFullYear()
+  const quarter1 = getQuarter(d1)
+  const quarter2 = getQuarter(d2)
+
+  if (year1 === year2 && quarter1 === quarter2) return 0
+
+  // 先比较年份，再比较季度
+  return year1 > year2 || (year1 === year2 && quarter1 > quarter2) ? 1 : -1
 }
 
 /**
@@ -225,7 +248,49 @@ export function getMonthOffset(date1: number, date2: number) {
 
   return month1 - month2 + 1
 }
+/**
+ * 获取偏移指定季度数后的日期
+ * @param {timestamp} date - 基准日期的时间戳
+ * @param {number} offset - 要偏移的季度数（正数为未来，负数为过去）
+ * @returns {number} 偏移后的日期时间戳
+ */
+export function getQuarterByOffset(date: number, offset: number): number {
+  const dateValue = new Date(date)
 
+  // 计算要增加的月份数（每个季度3个月）
+  const monthsToAdd = offset * 3
+
+  // 设置新的月份
+  dateValue.setMonth(dateValue.getMonth() + monthsToAdd)
+
+  return dateValue.getTime()
+}
+/**
+ * 获取两个日期之间的季度偏移量
+ * @param {timestamp} date1 - 第一个时间戳
+ * @param {timestamp} date2 - 第二个时间戳
+ * @returns {number} 两个日期之间的季度差值
+ */
+export function getQuarterOffset(date1: number, date2: number): number {
+  // 获取日期所在季度（1-4）
+  const getQuarter = (date: Date): number => {
+    const month = date.getMonth() // 0-11 (0代表一月)
+    return Math.floor(month / 3) + 1
+  }
+
+  const dateValue1 = new Date(date1)
+  const dateValue2 = new Date(date2)
+
+  const year1 = dateValue1.getFullYear()
+  const year2 = dateValue2.getFullYear()
+  const quarter1 = getQuarter(dateValue1)
+  const quarter2 = getQuarter(dateValue2)
+
+  // 计算总季度差
+  const totalQuarterOffset = (year1 - year2) * 4 + (quarter1 - quarter2)
+
+  return totalQuarterOffset
+}
 /**
  * 获取偏移月份
  * @param {timestamp} date

--- a/src/uni_modules/wot-design-uni/components/wd-calendar-view/wd-calendar-view.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-calendar-view/wd-calendar-view.vue
@@ -1,7 +1,24 @@
 <template>
   <view :class="`wd-calendar-view ${customClass}`">
+    <!-- 季度选择面板 -->
+    <quarter-panel
+      v-if="type === 'quarter' || type === 'quarterrange'"
+      ref="quarterPanelRef"
+      :type="type"
+      :value="modelValue"
+      :min-date="minDate"
+      :max-date="maxDate"
+      :formatter="formatter"
+      :max-range="maxRange"
+      :range-prompt="rangePrompt"
+      :allow-same-day="allowSameDay"
+      :show-panel-title="showPanelTitle"
+      :default-time="formatDefauleTime"
+      :panel-height="panelHeight"
+      @change="handleChange"
+    />
     <year-panel
-      v-if="type === 'month' || type === 'monthrange'"
+      v-else-if="type === 'month' || type === 'monthrange'"
       ref="yearPanelRef"
       :type="type"
       :value="modelValue"
@@ -56,6 +73,7 @@ import { ref, watch } from 'vue'
 import { getDefaultTime } from './utils'
 import yearPanel from './yearPanel/year-panel.vue'
 import MonthPanel from './monthPanel/month-panel.vue'
+import QuarterPanel from './quarterPanel/quarter-panel.vue'
 import { calendarViewProps, type CalendarViewExpose } from './types'
 
 const props = defineProps(calendarViewProps)
@@ -64,6 +82,7 @@ const formatDefauleTime = ref<number[][]>([])
 
 const yearPanelRef = ref()
 const monthPanelRef = ref()
+const quarterPanelRef = ref()
 
 watch(
   () => props.defaultTime,
@@ -85,7 +104,13 @@ function scrollIntoView() {
 }
 
 function getPanel() {
-  return props.type.indexOf('month') > -1 ? yearPanelRef.value : monthPanelRef.value
+  if (props.type.indexOf('quarter') > -1) {
+    return quarterPanelRef.value
+  } else if (props.type.indexOf('month') > -1) {
+    return yearPanelRef.value
+  } else {
+    return monthPanelRef.value
+  }
 }
 
 function handleChange({ value }: { value: number | number[] | null }) {

--- a/src/uni_modules/wot-design-uni/components/wd-calendar/wd-calendar.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-calendar/wd-calendar.vue
@@ -199,6 +199,22 @@ const defaultDisplayFormat = (value: number | number[], type: CalendarType): str
       return `${(value as number[])[0] ? dayjs((value as number[])[0]).format('YYYY / MM') : translate('startMonth')} ${translate('to')} ${
         (value as number[])[1] ? dayjs((value as number[])[1]).format('YYYY / MM') : translate('endMonth')
       }`
+    case 'quarter': {
+      const date = new Date(value as number)
+      const year = date.getFullYear()
+      const month = date.getMonth()
+      const quarter = Math.floor(month / 3) + 1
+      return translate('quarterFormat', year, quarter)
+    }
+    case 'quarterrange': {
+      if (!value || !isArray(value)) return ''
+      const [start, end] = value as number[]
+      if (!start && !end) return ''
+
+      return `${
+        start ? translate('quarterFormat', new Date(start).getFullYear(), Math.floor(new Date(start).getMonth() / 3) + 1) : translate('startQuarter')
+      } - ${end ? translate('quarterFormat', new Date(end).getFullYear(), Math.floor(new Date(end).getMonth() / 3) + 1) : translate('endQuarter')}`
+    }
   }
 }
 

--- a/src/uni_modules/wot-design-uni/dayjs/index.d.ts
+++ b/src/uni_modules/wot-design-uni/dayjs/index.d.ts
@@ -414,6 +414,8 @@ declare namespace dayjs {
     locale(): string
 
     locale(preset: string | ILocale, object?: Partial<ILocale>): Dayjs
+
+    quarter():string
   }
 
   export type PluginFunc<T = unknown> = (option: T, c: typeof Dayjs, d: typeof dayjs) => void

--- a/src/uni_modules/wot-design-uni/dayjs/index.js
+++ b/src/uni_modules/wot-design-uni/dayjs/index.js
@@ -1,61 +1,61 @@
 /* eslint-disable */
-import * as C from './constant';
-import en from './locale/en';
-import U from './utils';
-var L = 'en'; // global locale
+import * as C from './constant'
+import en from './locale/en'
+import U from './utils'
 
-var Ls = {}; // global loaded locale
+var L = 'en' // global locale
 
-Ls[L] = en;
-var IS_DAYJS = '$isDayjsObject'; // eslint-disable-next-line no-use-before-define
+var Ls = {} // global loaded locale
+
+Ls[L] = en
+var IS_DAYJS = '$isDayjsObject' // eslint-disable-next-line no-use-before-define
 
 var isDayjs = function isDayjs(d) {
-  return d instanceof Dayjs || !!(d && d[IS_DAYJS]);
-};
+  return d instanceof Dayjs || !!(d && d[IS_DAYJS])
+}
 
 var parseLocale = function parseLocale(preset, object, isLocal) {
-  var l;
-  if (!preset) return L;
+  var l
+  if (!preset) return L
 
   if (typeof preset === 'string') {
-    var presetLower = preset.toLowerCase();
+    var presetLower = preset.toLowerCase()
 
     if (Ls[presetLower]) {
-      l = presetLower;
+      l = presetLower
     }
 
     if (object) {
-      Ls[presetLower] = object;
-      l = presetLower;
+      Ls[presetLower] = object
+      l = presetLower
     }
 
-    var presetSplit = preset.split('-');
+    var presetSplit = preset.split('-')
 
     if (!l && presetSplit.length > 1) {
-      return parseLocale(presetSplit[0]);
+      return parseLocale(presetSplit[0])
     }
   } else {
-    var name = preset.name;
-    Ls[name] = preset;
-    l = name;
+    var name = preset.name
+    Ls[name] = preset
+    l = name
   }
 
-  if (!isLocal && l) L = l;
-  return l || !isLocal && L;
-};
+  if (!isLocal && l) L = l
+  return l || (!isLocal && L)
+}
 
 var dayjs = function dayjs(date, c) {
   if (isDayjs(date)) {
-    return date.clone();
+    return date.clone()
   } // eslint-disable-next-line no-nested-ternary
 
+  var cfg = typeof c === 'object' ? c : {}
+  cfg.date = date
+  cfg.args = arguments // eslint-disable-line prefer-rest-params
 
-  var cfg = typeof c === 'object' ? c : {};
-  cfg.date = date;
-  cfg.args = arguments; // eslint-disable-line prefer-rest-params
-
-  return new Dayjs(cfg); // eslint-disable-line no-use-before-define
-};
+  return new Dayjs(cfg) // eslint-disable-line no-use-before-define
+}
 
 var wrapper = function wrapper(date, instance) {
   return dayjs(date, {
@@ -63,480 +63,513 @@ var wrapper = function wrapper(date, instance) {
     utc: instance.$u,
     x: instance.$x,
     $offset: instance.$offset // todo: refactor; do not use this.$offset in you code
+  })
+}
 
-  });
-};
+var Utils = U // for plugin use
 
-var Utils = U; // for plugin use
-
-Utils.l = parseLocale;
-Utils.i = isDayjs;
-Utils.w = wrapper;
+Utils.l = parseLocale
+Utils.i = isDayjs
+Utils.w = wrapper
 
 var parseDate = function parseDate(cfg) {
   var date = cfg.date,
-      utc = cfg.utc;
-  if (date === null) return new Date(NaN); // null is invalid
+    utc = cfg.utc
+  if (date === null) return new Date(NaN) // null is invalid
 
-  if (Utils.u(date)) return new Date(); // today
+  if (Utils.u(date)) return new Date() // today
 
-  if (date instanceof Date) return new Date(date);
+  if (date instanceof Date) return new Date(date)
 
   if (typeof date === 'string' && !/Z$/i.test(date)) {
-    var d = date.match(C.REGEX_PARSE);
+    var d = date.match(C.REGEX_PARSE)
 
     if (d) {
-      var m = d[2] - 1 || 0;
-      var ms = (d[7] || '0').substring(0, 3);
+      var m = d[2] - 1 || 0
+      var ms = (d[7] || '0').substring(0, 3)
 
       if (utc) {
-        return new Date(Date.UTC(d[1], m, d[3] || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms));
+        return new Date(Date.UTC(d[1], m, d[3] || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms))
       }
 
-      return new Date(d[1], m, d[3] || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms);
+      return new Date(d[1], m, d[3] || 1, d[4] || 0, d[5] || 0, d[6] || 0, ms)
     }
   }
 
-  return new Date(date); // everything else
-};
+  return new Date(date) // everything else
+}
 
-var Dayjs = /*#__PURE__*/function () {
+var Dayjs = /*#__PURE__*/ (function () {
   function Dayjs(cfg) {
-    this.$L = parseLocale(cfg.locale, null, true);
-    this.parse(cfg); // for plugin
+    this.$L = parseLocale(cfg.locale, null, true)
+    this.parse(cfg) // for plugin
 
-    this.$x = this.$x || cfg.x || {};
-    this[IS_DAYJS] = true;
+    this.$x = this.$x || cfg.x || {}
+    this[IS_DAYJS] = true
   }
 
-  var _proto = Dayjs.prototype;
+  var _proto = Dayjs.prototype
 
   _proto.parse = function parse(cfg) {
-    this.$d = parseDate(cfg);
-    this.init();
-  };
+    this.$d = parseDate(cfg)
+    this.init()
+  }
 
   _proto.init = function init() {
-    var $d = this.$d;
-    this.$y = $d.getFullYear();
-    this.$M = $d.getMonth();
-    this.$D = $d.getDate();
-    this.$W = $d.getDay();
-    this.$H = $d.getHours();
-    this.$m = $d.getMinutes();
-    this.$s = $d.getSeconds();
-    this.$ms = $d.getMilliseconds();
+    var $d = this.$d
+    this.$y = $d.getFullYear()
+    this.$M = $d.getMonth()
+    this.$D = $d.getDate()
+    this.$W = $d.getDay()
+    this.$H = $d.getHours()
+    this.$m = $d.getMinutes()
+    this.$s = $d.getSeconds()
+    this.$ms = $d.getMilliseconds()
   } // eslint-disable-next-line class-methods-use-this
-  ;
 
   _proto.$utils = function $utils() {
-    return Utils;
-  };
+    return Utils
+  }
 
   _proto.isValid = function isValid() {
-    return !(this.$d.toString() === C.INVALID_DATE_STRING);
-  };
+    return !(this.$d.toString() === C.INVALID_DATE_STRING)
+  }
 
   _proto.isSame = function isSame(that, units) {
-    var other = dayjs(that);
-    return this.startOf(units) <= other && other <= this.endOf(units);
-  };
+    var other = dayjs(that)
+    return this.startOf(units) <= other && other <= this.endOf(units)
+  }
 
   _proto.isAfter = function isAfter(that, units) {
-    return dayjs(that) < this.startOf(units);
-  };
+    return dayjs(that) < this.startOf(units)
+  }
 
   _proto.isBefore = function isBefore(that, units) {
-    return this.endOf(units) < dayjs(that);
-  };
+    return this.endOf(units) < dayjs(that)
+  }
 
   _proto.$g = function $g(input, get, set) {
-    if (Utils.u(input)) return this[get];
-    return this.set(set, input);
-  };
+    if (Utils.u(input)) return this[get]
+    return this.set(set, input)
+  }
 
   _proto.unix = function unix() {
-    return Math.floor(this.valueOf() / 1000);
-  };
+    return Math.floor(this.valueOf() / 1000)
+  }
 
   _proto.valueOf = function valueOf() {
     // timezone(hour) * 60 * 60 * 1000 => ms
-    return this.$d.getTime();
-  };
+    return this.$d.getTime()
+  }
 
   _proto.startOf = function startOf(units, _startOf) {
-    var _this = this;
+    var _this = this
 
     // startOf -> endOf
-    var isStartOf = !Utils.u(_startOf) ? _startOf : true;
-    var unit = Utils.p(units);
+    var isStartOf = !Utils.u(_startOf) ? _startOf : true
+    var unit = Utils.p(units)
 
     var instanceFactory = function instanceFactory(d, m) {
-      var ins = Utils.w(_this.$u ? Date.UTC(_this.$y, m, d) : new Date(_this.$y, m, d), _this);
-      return isStartOf ? ins : ins.endOf(C.D);
-    };
+      var ins = Utils.w(_this.$u ? Date.UTC(_this.$y, m, d) : new Date(_this.$y, m, d), _this)
+      return isStartOf ? ins : ins.endOf(C.D)
+    }
 
     var instanceFactorySet = function instanceFactorySet(method, slice) {
-      var argumentStart = [0, 0, 0, 0];
-      var argumentEnd = [23, 59, 59, 999];
-      return Utils.w(_this.toDate()[method].apply( // eslint-disable-line prefer-spread
-      _this.toDate('s'), (isStartOf ? argumentStart : argumentEnd).slice(slice)), _this);
-    };
+      var argumentStart = [0, 0, 0, 0]
+      var argumentEnd = [23, 59, 59, 999]
+      return Utils.w(
+        _this.toDate()[method].apply(
+          // eslint-disable-line prefer-spread
+          _this.toDate('s'),
+          (isStartOf ? argumentStart : argumentEnd).slice(slice)
+        ),
+        _this
+      )
+    }
 
     var $W = this.$W,
-        $M = this.$M,
-        $D = this.$D;
-    var utcPad = "set" + (this.$u ? 'UTC' : '');
+      $M = this.$M,
+      $D = this.$D
+    var utcPad = 'set' + (this.$u ? 'UTC' : '')
 
     switch (unit) {
       case C.Y:
-        return isStartOf ? instanceFactory(1, 0) : instanceFactory(31, 11);
+        return isStartOf ? instanceFactory(1, 0) : instanceFactory(31, 11)
 
       case C.M:
-        return isStartOf ? instanceFactory(1, $M) : instanceFactory(0, $M + 1);
+        return isStartOf ? instanceFactory(1, $M) : instanceFactory(0, $M + 1)
 
-      case C.W:
-        {
-          var weekStart = this.$locale().weekStart || 0;
-          var gap = ($W < weekStart ? $W + 7 : $W) - weekStart;
-          return instanceFactory(isStartOf ? $D - gap : $D + (6 - gap), $M);
-        }
+      case C.W: {
+        var weekStart = this.$locale().weekStart || 0
+        var gap = ($W < weekStart ? $W + 7 : $W) - weekStart
+        return instanceFactory(isStartOf ? $D - gap : $D + (6 - gap), $M)
+      }
 
       case C.D:
       case C.DATE:
-        return instanceFactorySet(utcPad + "Hours", 0);
+        return instanceFactorySet(utcPad + 'Hours', 0)
 
       case C.H:
-        return instanceFactorySet(utcPad + "Minutes", 1);
+        return instanceFactorySet(utcPad + 'Minutes', 1)
 
       case C.MIN:
-        return instanceFactorySet(utcPad + "Seconds", 2);
+        return instanceFactorySet(utcPad + 'Seconds', 2)
 
       case C.S:
-        return instanceFactorySet(utcPad + "Milliseconds", 3);
+        return instanceFactorySet(utcPad + 'Milliseconds', 3)
 
       default:
-        return this.clone();
+        return this.clone()
     }
-  };
+  }
 
   _proto.endOf = function endOf(arg) {
-    return this.startOf(arg, false);
-  };
+    return this.startOf(arg, false)
+  }
 
   _proto.$set = function $set(units, _int) {
-    var _C$D$C$DATE$C$M$C$Y$C;
+    var _C$D$C$DATE$C$M$C$Y$C
 
     // private set
-    var unit = Utils.p(units);
-    var utcPad = "set" + (this.$u ? 'UTC' : '');
-    var name = (_C$D$C$DATE$C$M$C$Y$C = {}, _C$D$C$DATE$C$M$C$Y$C[C.D] = utcPad + "Date", _C$D$C$DATE$C$M$C$Y$C[C.DATE] = utcPad + "Date", _C$D$C$DATE$C$M$C$Y$C[C.M] = utcPad + "Month", _C$D$C$DATE$C$M$C$Y$C[C.Y] = utcPad + "FullYear", _C$D$C$DATE$C$M$C$Y$C[C.H] = utcPad + "Hours", _C$D$C$DATE$C$M$C$Y$C[C.MIN] = utcPad + "Minutes", _C$D$C$DATE$C$M$C$Y$C[C.S] = utcPad + "Seconds", _C$D$C$DATE$C$M$C$Y$C[C.MS] = utcPad + "Milliseconds", _C$D$C$DATE$C$M$C$Y$C)[unit];
-    var arg = unit === C.D ? this.$D + (_int - this.$W) : _int;
+    var unit = Utils.p(units)
+    var utcPad = 'set' + (this.$u ? 'UTC' : '')
+    var name = ((_C$D$C$DATE$C$M$C$Y$C = {}),
+    (_C$D$C$DATE$C$M$C$Y$C[C.D] = utcPad + 'Date'),
+    (_C$D$C$DATE$C$M$C$Y$C[C.DATE] = utcPad + 'Date'),
+    (_C$D$C$DATE$C$M$C$Y$C[C.M] = utcPad + 'Month'),
+    (_C$D$C$DATE$C$M$C$Y$C[C.Y] = utcPad + 'FullYear'),
+    (_C$D$C$DATE$C$M$C$Y$C[C.H] = utcPad + 'Hours'),
+    (_C$D$C$DATE$C$M$C$Y$C[C.MIN] = utcPad + 'Minutes'),
+    (_C$D$C$DATE$C$M$C$Y$C[C.S] = utcPad + 'Seconds'),
+    (_C$D$C$DATE$C$M$C$Y$C[C.MS] = utcPad + 'Milliseconds'),
+    _C$D$C$DATE$C$M$C$Y$C)[unit]
+    var arg = unit === C.D ? this.$D + (_int - this.$W) : _int
 
     if (unit === C.M || unit === C.Y) {
       // clone is for badMutable plugin
-      var date = this.clone().set(C.DATE, 1);
-      date.$d[name](arg);
-      date.init();
-      this.$d = date.set(C.DATE, Math.min(this.$D, date.daysInMonth())).$d;
-    } else if (name) this.$d[name](arg);
+      var date = this.clone().set(C.DATE, 1)
+      date.$d[name](arg)
+      date.init()
+      this.$d = date.set(C.DATE, Math.min(this.$D, date.daysInMonth())).$d
+    } else if (name) this.$d[name](arg)
 
-    this.init();
-    return this;
-  };
+    this.init()
+    return this
+  }
 
   _proto.set = function set(string, _int2) {
-    return this.clone().$set(string, _int2);
-  };
+    return this.clone().$set(string, _int2)
+  }
 
   _proto.get = function get(unit) {
-    return this[Utils.p(unit)]();
-  };
+    return this[Utils.p(unit)]()
+  }
 
   _proto.add = function add(number, units) {
     var _this2 = this,
-        _C$MIN$C$H$C$S$unit;
+      _C$MIN$C$H$C$S$unit
 
-    number = Number(number); // eslint-disable-line no-param-reassign
+    number = Number(number) // eslint-disable-line no-param-reassign
 
-    var unit = Utils.p(units);
+    var unit = Utils.p(units)
 
     var instanceFactorySet = function instanceFactorySet(n) {
-      var d = dayjs(_this2);
-      return Utils.w(d.date(d.date() + Math.round(n * number)), _this2);
-    };
+      var d = dayjs(_this2)
+      return Utils.w(d.date(d.date() + Math.round(n * number)), _this2)
+    }
 
     if (unit === C.M) {
-      return this.set(C.M, this.$M + number);
+      return this.set(C.M, this.$M + number)
     }
 
     if (unit === C.Y) {
-      return this.set(C.Y, this.$y + number);
+      return this.set(C.Y, this.$y + number)
     }
 
     if (unit === C.D) {
-      return instanceFactorySet(1);
+      return instanceFactorySet(1)
     }
 
     if (unit === C.W) {
-      return instanceFactorySet(7);
+      return instanceFactorySet(7)
     }
 
-    var step = (_C$MIN$C$H$C$S$unit = {}, _C$MIN$C$H$C$S$unit[C.MIN] = C.MILLISECONDS_A_MINUTE, _C$MIN$C$H$C$S$unit[C.H] = C.MILLISECONDS_A_HOUR, _C$MIN$C$H$C$S$unit[C.S] = C.MILLISECONDS_A_SECOND, _C$MIN$C$H$C$S$unit)[unit] || 1; // ms
+    var step =
+      ((_C$MIN$C$H$C$S$unit = {}),
+      (_C$MIN$C$H$C$S$unit[C.MIN] = C.MILLISECONDS_A_MINUTE),
+      (_C$MIN$C$H$C$S$unit[C.H] = C.MILLISECONDS_A_HOUR),
+      (_C$MIN$C$H$C$S$unit[C.S] = C.MILLISECONDS_A_SECOND),
+      _C$MIN$C$H$C$S$unit)[unit] || 1 // ms
 
-    var nextTimeStamp = this.$d.getTime() + number * step;
-    return Utils.w(nextTimeStamp, this);
-  };
+    var nextTimeStamp = this.$d.getTime() + number * step
+    return Utils.w(nextTimeStamp, this)
+  }
 
   _proto.subtract = function subtract(number, string) {
-    return this.add(number * -1, string);
-  };
+    return this.add(number * -1, string)
+  }
 
   _proto.format = function format(formatStr) {
-    var _this3 = this;
+    var _this3 = this
 
-    var locale = this.$locale();
-    if (!this.isValid()) return locale.invalidDate || C.INVALID_DATE_STRING;
-    var str = formatStr || C.FORMAT_DEFAULT;
-    var zoneStr = Utils.z(this);
+    var locale = this.$locale()
+    if (!this.isValid()) return locale.invalidDate || C.INVALID_DATE_STRING
+    var str = formatStr || C.FORMAT_DEFAULT
+    var zoneStr = Utils.z(this)
     var $H = this.$H,
-        $m = this.$m,
-        $M = this.$M;
+      $m = this.$m,
+      $M = this.$M
     var weekdays = locale.weekdays,
-        months = locale.months,
-        meridiem = locale.meridiem;
+      months = locale.months,
+      meridiem = locale.meridiem
 
     var getShort = function getShort(arr, index, full, length) {
-      return arr && (arr[index] || arr(_this3, str)) || full[index].slice(0, length);
-    };
+      return (arr && (arr[index] || arr(_this3, str))) || full[index].slice(0, length)
+    }
 
     var get$H = function get$H(num) {
-      return Utils.s($H % 12 || 12, num, '0');
-    };
+      return Utils.s($H % 12 || 12, num, '0')
+    }
 
-    var meridiemFunc = meridiem || function (hour, minute, isLowercase) {
-      var m = hour < 12 ? 'AM' : 'PM';
-      return isLowercase ? m.toLowerCase() : m;
-    };
+    var meridiemFunc =
+      meridiem ||
+      function (hour, minute, isLowercase) {
+        var m = hour < 12 ? 'AM' : 'PM'
+        return isLowercase ? m.toLowerCase() : m
+      }
 
     var matches = function matches(match) {
       switch (match) {
         case 'YY':
-          return String(_this3.$y).slice(-2);
+          return String(_this3.$y).slice(-2)
 
         case 'YYYY':
-          return Utils.s(_this3.$y, 4, '0');
+          return Utils.s(_this3.$y, 4, '0')
 
         case 'M':
-          return $M + 1;
+          return $M + 1
 
         case 'MM':
-          return Utils.s($M + 1, 2, '0');
+          return Utils.s($M + 1, 2, '0')
 
         case 'MMM':
-          return getShort(locale.monthsShort, $M, months, 3);
+          return getShort(locale.monthsShort, $M, months, 3)
 
         case 'MMMM':
-          return getShort(months, $M);
+          return getShort(months, $M)
 
         case 'D':
-          return _this3.$D;
+          return _this3.$D
 
         case 'DD':
-          return Utils.s(_this3.$D, 2, '0');
+          return Utils.s(_this3.$D, 2, '0')
 
         case 'd':
-          return String(_this3.$W);
+          return String(_this3.$W)
 
         case 'dd':
-          return getShort(locale.weekdaysMin, _this3.$W, weekdays, 2);
+          return getShort(locale.weekdaysMin, _this3.$W, weekdays, 2)
 
         case 'ddd':
-          return getShort(locale.weekdaysShort, _this3.$W, weekdays, 3);
+          return getShort(locale.weekdaysShort, _this3.$W, weekdays, 3)
 
         case 'dddd':
-          return weekdays[_this3.$W];
+          return weekdays[_this3.$W]
 
         case 'H':
-          return String($H);
+          return String($H)
 
         case 'HH':
-          return Utils.s($H, 2, '0');
+          return Utils.s($H, 2, '0')
 
         case 'h':
-          return get$H(1);
+          return get$H(1)
 
         case 'hh':
-          return get$H(2);
+          return get$H(2)
 
         case 'a':
-          return meridiemFunc($H, $m, true);
+          return meridiemFunc($H, $m, true)
 
         case 'A':
-          return meridiemFunc($H, $m, false);
+          return meridiemFunc($H, $m, false)
 
         case 'm':
-          return String($m);
+          return String($m)
 
         case 'mm':
-          return Utils.s($m, 2, '0');
+          return Utils.s($m, 2, '0')
 
         case 's':
-          return String(_this3.$s);
+          return String(_this3.$s)
 
         case 'ss':
-          return Utils.s(_this3.$s, 2, '0');
+          return Utils.s(_this3.$s, 2, '0')
 
         case 'SSS':
-          return Utils.s(_this3.$ms, 3, '0');
+          return Utils.s(_this3.$ms, 3, '0')
 
         case 'Z':
-          return zoneStr;
+          return zoneStr
         // 'ZZ' logic below
 
         default:
-          break;
+          break
       }
 
-      return null;
-    };
+      return null
+    }
 
     return str.replace(C.REGEX_FORMAT, function (match, $1) {
-      return $1 || matches(match) || zoneStr.replace(':', '');
-    }); // 'ZZ'
-  };
+      return $1 || matches(match) || zoneStr.replace(':', '')
+    }) // 'ZZ'
+  }
 
   _proto.utcOffset = function utcOffset() {
     // Because a bug at FF24, we're rounding the timezone offset around 15 minutes
     // https://github.com/moment/moment/pull/1871
-    return -Math.round(this.$d.getTimezoneOffset() / 15) * 15;
-  };
+    return -Math.round(this.$d.getTimezoneOffset() / 15) * 15
+  }
 
   _proto.diff = function diff(input, units, _float) {
-    var _this4 = this;
+    var _this4 = this
 
-    var unit = Utils.p(units);
-    var that = dayjs(input);
-    var zoneDelta = (that.utcOffset() - this.utcOffset()) * C.MILLISECONDS_A_MINUTE;
-    var diff = this - that;
+    var unit = Utils.p(units)
+    var that = dayjs(input)
+    var zoneDelta = (that.utcOffset() - this.utcOffset()) * C.MILLISECONDS_A_MINUTE
+    var diff = this - that
 
     var getMonth = function getMonth() {
-      return Utils.m(_this4, that);
-    };
+      return Utils.m(_this4, that)
+    }
 
-    var result;
+    var result
 
     switch (unit) {
       case C.Y:
-        result = getMonth() / 12;
-        break;
+        result = getMonth() / 12
+        break
 
       case C.M:
-        result = getMonth();
-        break;
+        result = getMonth()
+        break
 
       case C.Q:
-        result = getMonth() / 3;
-        break;
+        result = getMonth() / 3
+        break
 
       case C.W:
-        result = (diff - zoneDelta) / C.MILLISECONDS_A_WEEK;
-        break;
+        result = (diff - zoneDelta) / C.MILLISECONDS_A_WEEK
+        break
 
       case C.D:
-        result = (diff - zoneDelta) / C.MILLISECONDS_A_DAY;
-        break;
+        result = (diff - zoneDelta) / C.MILLISECONDS_A_DAY
+        break
 
       case C.H:
-        result = diff / C.MILLISECONDS_A_HOUR;
-        break;
+        result = diff / C.MILLISECONDS_A_HOUR
+        break
 
       case C.MIN:
-        result = diff / C.MILLISECONDS_A_MINUTE;
-        break;
+        result = diff / C.MILLISECONDS_A_MINUTE
+        break
 
       case C.S:
-        result = diff / C.MILLISECONDS_A_SECOND;
-        break;
+        result = diff / C.MILLISECONDS_A_SECOND
+        break
 
       default:
-        result = diff; // milliseconds
+        result = diff // milliseconds
 
-        break;
+        break
     }
 
-    return _float ? result : Utils.a(result);
-  };
+    return _float ? result : Utils.a(result)
+  }
 
   _proto.daysInMonth = function daysInMonth() {
-    return this.endOf(C.M).$D;
-  };
+    return this.endOf(C.M).$D
+  }
 
   _proto.$locale = function $locale() {
     // get locale object
-    return Ls[this.$L];
-  };
-
+    return Ls[this.$L]
+  }
+  _proto.quarter = function (quarter) {
+    if (!this.$utils().u(quarter)) {
+      return this.month((this.month() % 3) + (quarter - 1) * 3)
+    }
+    return Math.ceil((this.month() + 1) / 3)
+  }
   _proto.locale = function locale(preset, object) {
-    if (!preset) return this.$L;
-    var that = this.clone();
-    var nextLocaleName = parseLocale(preset, object, true);
-    if (nextLocaleName) that.$L = nextLocaleName;
-    return that;
-  };
+    if (!preset) return this.$L
+    var that = this.clone()
+    var nextLocaleName = parseLocale(preset, object, true)
+    if (nextLocaleName) that.$L = nextLocaleName
+    return that
+  }
 
   _proto.clone = function clone() {
-    return Utils.w(this.$d, this);
-  };
+    return Utils.w(this.$d, this)
+  }
 
   _proto.toDate = function toDate() {
-    return new Date(this.valueOf());
-  };
+    return new Date(this.valueOf())
+  }
 
   _proto.toJSON = function toJSON() {
-    return this.isValid() ? this.toISOString() : null;
-  };
+    return this.isValid() ? this.toISOString() : null
+  }
 
   _proto.toISOString = function toISOString() {
     // ie 8 return
     // new Dayjs(this.valueOf() + this.$d.getTimezoneOffset() * 60000)
     // .format('YYYY-MM-DDTHH:mm:ss.SSS[Z]')
-    return this.$d.toISOString();
-  };
+    return this.$d.toISOString()
+  }
 
   _proto.toString = function toString() {
-    return this.$d.toUTCString();
-  };
+    return this.$d.toUTCString()
+  }
 
-  return Dayjs;
-}();
+  return Dayjs
+})()
 
-var proto = Dayjs.prototype;
-dayjs.prototype = proto;
-[['$ms', C.MS], ['$s', C.S], ['$m', C.MIN], ['$H', C.H], ['$W', C.D], ['$M', C.M], ['$y', C.Y], ['$D', C.DATE]].forEach(function (g) {
+var proto = Dayjs.prototype
+dayjs.prototype = proto
+;[
+  ['$ms', C.MS],
+  ['$s', C.S],
+  ['$m', C.MIN],
+  ['$H', C.H],
+  ['$W', C.D],
+  ['$M', C.M],
+  ['$y', C.Y],
+  ['$D', C.DATE]
+].forEach(function (g) {
   proto[g[1]] = function (input) {
-    return this.$g(input, g[0], g[1]);
-  };
-});
+    return this.$g(input, g[0], g[1])
+  }
+})
 
 dayjs.extend = function (plugin, option) {
   if (!plugin.$i) {
     // install plugin only once
-    plugin(option, Dayjs, dayjs);
-    plugin.$i = true;
+    plugin(option, Dayjs, dayjs)
+    plugin.$i = true
   }
 
-  return dayjs;
-};
+  return dayjs
+}
 
-dayjs.locale = parseLocale;
-dayjs.isDayjs = isDayjs;
+dayjs.locale = parseLocale
+dayjs.isDayjs = isDayjs
 
 dayjs.unix = function (timestamp) {
-  return dayjs(timestamp * 1e3);
-};
+  return dayjs(timestamp * 1e3)
+}
 
-dayjs.en = Ls[L];
-dayjs.Ls = Ls;
-dayjs.p = {};
-export default dayjs;
+dayjs.en = Ls[L]
+dayjs.Ls = Ls
+dayjs.p = {}
+export default dayjs

--- a/src/uni_modules/wot-design-uni/locale/lang/ar-SA.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/ar-SA.ts
@@ -5,6 +5,7 @@ export default {
     day: 'يوم',
     week: 'أسبوع',
     month: 'شهر',
+    quarter: 'ربع',
     confirm: 'تأكيد',
     startTime: 'وقت البداية',
     endTime: 'وقت النهاية',
@@ -12,10 +13,13 @@ export default {
     timeFormat: 'YY-MM-DD HH:mm:ss',
     dateFormat: 'YYYY-MM-DD',
     weekFormat: (year: number, week: number) => `${year} الأسبوع ${week}`,
+    quarterFormat: (year: number, quarter: number) => `${year} الربع ${quarter}`,
     startWeek: 'بداية الأسبوع',
     endWeek: 'نهاية الأسبوع',
     startMonth: 'بداية الشهر',
     endMonth: 'نهاية الشهر',
+    startQuarter: 'بداية الربع',
+    endQuarter: 'نهاية الربع',
     monthFormat: 'YYYY-MM'
   },
   calendarView: {

--- a/src/uni_modules/wot-design-uni/locale/lang/de-DE.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/de-DE.ts
@@ -5,6 +5,7 @@ export default {
     day: 'Tag',
     week: 'Woche',
     month: 'Monat',
+    quarter: 'Quartal',
     confirm: 'Bestätigen',
     startTime: 'Startdatum',
     endTime: 'Enddatum',
@@ -12,10 +13,13 @@ export default {
     timeFormat: 'YY-MM-DD HH:mm:ss',
     dateFormat: 'YYYY-MM-DD',
     weekFormat: (year: number, week: number) => `Woche ${week} ${year}`,
+    quarterFormat: (year: number, quarter: number) => `Quartal ${quarter} ${year}`,
     startWeek: 'Startwoche',
     endWeek: 'Endwoche',
     startMonth: 'Startmonat',
     endMonth: 'Endmonat',
+    startQuarter: 'Startquartal',
+    endQuarter: 'Endquartal',
     monthFormat: 'YYYY-MM'
   },
   calendarView: {

--- a/src/uni_modules/wot-design-uni/locale/lang/en-US.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/en-US.ts
@@ -5,6 +5,7 @@ export default {
     day: 'Date',
     week: 'Week',
     month: 'Month',
+    quarter: 'Quarter',
     confirm: 'OK',
     startTime: 'Start Date',
     endTime: 'End Date',
@@ -12,10 +13,13 @@ export default {
     timeFormat: 'YY-MM-DD HH:mm:ss',
     dateFormat: 'YYYY-MM-DD',
     weekFormat: (year: number, week: number) => `${year} W${week}`,
+    quarterFormat: (year: number, quarter: number) => `${year} Q${quarter}`,
     startWeek: 'Start Week',
     endWeek: 'End Week',
     startMonth: 'Start Month',
     endMonth: 'End Month',
+    startQuarter: 'Start Quarter',
+    endQuarter: 'End Quarter',
     monthFormat: 'YYYY-MM'
   },
   calendarView: {

--- a/src/uni_modules/wot-design-uni/locale/lang/es-ES.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/es-ES.ts
@@ -5,6 +5,7 @@ export default {
     day: 'Día',
     week: 'Semana',
     month: 'Mes',
+    quarter: 'Trimestre',
     confirm: 'Confirmar',
     startTime: 'Hora de Inicio',
     endTime: 'Hora de Fin',
@@ -12,10 +13,13 @@ export default {
     timeFormat: 'YY-MM-DD HH:mm:ss',
     dateFormat: 'YYYY-MM-DD',
     weekFormat: (year: number, week: number) => `Semana ${week}, ${year}`,
+    quarterFormat: (year: number, quarter: number) => `Trimestre ${quarter}, ${year}`,
     startWeek: 'Inicio de Semana',
     endWeek: 'Fin de Semana',
     startMonth: 'Inicio de Mes',
     endMonth: 'Fin de Mes',
+    startQuarter: 'Inicio de Trimestre',
+    endQuarter: 'Fin de Trimestre',
     monthFormat: 'YYYY-MM'
   },
   calendarView: {

--- a/src/uni_modules/wot-design-uni/locale/lang/fr-FR.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/fr-FR.ts
@@ -5,6 +5,7 @@ export default {
     day: 'Jour',
     week: 'Semaine',
     month: 'Mois',
+    quarter: 'Trimestre',
     confirm: 'Confirmer',
     startTime: 'Heure de début',
     endTime: 'Heure de fin',
@@ -12,10 +13,13 @@ export default {
     timeFormat: 'YY-MM-DD HH:mm:ss',
     dateFormat: 'YYYY-MM-DD',
     weekFormat: (year: number, week: number) => `Semaine ${week}, ${year}`,
+    quarterFormat: (year: number, quarter: number) => `Trimestre ${quarter}, ${year}`,
     startWeek: 'Début de la semaine',
     endWeek: 'Fin de la semaine',
     startMonth: 'Début du mois',
     endMonth: 'Fin du mois',
+    startQuarter: 'Début du trimestre',
+    endQuarter: 'Fin du trimestre',
     monthFormat: 'YYYY-MM'
   },
   calendarView: {

--- a/src/uni_modules/wot-design-uni/locale/lang/ja-JP.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/ja-JP.ts
@@ -5,6 +5,7 @@ export default {
     day: '日',
     week: '週',
     month: '月',
+    quarter: '四半期',
     confirm: '確認',
     startTime: '開始時間',
     endTime: '終了時間',
@@ -12,10 +13,13 @@ export default {
     timeFormat: 'YY年MM月DD日 HH:mm:ss',
     dateFormat: 'YYYY年MM月DD日',
     weekFormat: (year: number, week: number) => `${year}年 第${week}週`,
+    quarterFormat: (year: number, quarter: number) => `${year}年 第${quarter}四半期`,
     startWeek: '開始週',
     endWeek: '終了週',
     startMonth: '開始月',
     endMonth: '終了月',
+    startQuarter: '開始四半期',
+    endQuarter: '終了四半期',
     monthFormat: 'YYYY年MM月'
   },
   calendarView: {

--- a/src/uni_modules/wot-design-uni/locale/lang/ko-KR.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/ko-KR.ts
@@ -5,6 +5,7 @@ export default {
     day: '일',
     week: '주',
     month: '월',
+    quarter: '분기',
     confirm: '확인',
     startTime: '시작 시간',
     endTime: '종료 시간',
@@ -12,10 +13,13 @@ export default {
     timeFormat: 'YY년 MM월 DD일 HH:mm:ss',
     dateFormat: 'YYYY년 MM월 DD일',
     weekFormat: (year: number, week: number) => `${year}년 ${week}주`,
+    quarterFormat: (year: number, quarter: number) => `${year}년 ${quarter}분기`,
     startWeek: '주 시작',
     endWeek: '주 종료',
     startMonth: '월 시작',
     endMonth: '월 종료',
+    startQuarter: '분기 시작',
+    endQuarter: '분기 종료',
     monthFormat: 'YYYY년 MM월'
   },
   calendarView: {

--- a/src/uni_modules/wot-design-uni/locale/lang/pt-PT.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/pt-PT.ts
@@ -5,6 +5,7 @@ export default {
     day: 'Dia',
     week: 'Semana',
     month: 'Mês',
+    quarter: 'Trimestre',
     confirm: 'Confirmar',
     startTime: 'Hora de início',
     endTime: 'Hora de término',
@@ -12,10 +13,13 @@ export default {
     timeFormat: 'DD/MM/YYYY HH:mm:ss',
     dateFormat: 'DD/MM/YYYY',
     weekFormat: (year: number, week: number) => `${year} Semana ${week}`,
+    quarterFormat: (year: number, quarter: number) => `${year} Trimestre ${quarter}`,
     startWeek: 'Semana de início',
     endWeek: 'Semana de término',
     startMonth: 'Mês de início',
     endMonth: 'Mês de término',
+    startQuarter: 'Trimestre de início',
+    endQuarter: 'Trimestre de término',
     monthFormat: 'MM/YYYY'
   },
   calendarView: {

--- a/src/uni_modules/wot-design-uni/locale/lang/ru-RU.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/ru-RU.ts
@@ -5,6 +5,7 @@ export default {
     day: 'День',
     week: 'Неделя',
     month: 'Месяц',
+    quarter: 'Квартал',
     confirm: 'Ок',
     startTime: 'Начало',
     endTime: 'Конец',
@@ -12,10 +13,13 @@ export default {
     timeFormat: 'DD.MM.YY HH:mm:ss',
     dateFormat: 'DD.MM.YYYY',
     weekFormat: (year: number, week: number) => `${year} Неделя ${week}`,
+    quarterFormat: (year: number, quarter: number) => `${year} Квартал ${quarter}`,
     startWeek: 'Начало недели',
     endWeek: 'Конец недели',
     startMonth: 'Начало месяца',
     endMonth: 'Конец месяца',
+    startQuarter: 'Начало квартала',
+    endQuarter: 'Конец квартала',
     monthFormat: 'MM.YYYY'
   },
   calendarView: {

--- a/src/uni_modules/wot-design-uni/locale/lang/th-TH.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/th-TH.ts
@@ -5,6 +5,7 @@ export default {
     day: 'วันที่',
     week: 'สัปดาห์',
     month: 'เดือน',
+    quarter: 'ไตรมาส',
     confirm: 'ยืนยัน',
     startTime: 'วันที่เริ่มต้น',
     endTime: 'วันที่สิ้นสุด',
@@ -12,10 +13,13 @@ export default {
     timeFormat: 'YY-MM-DD HH:mm:ss',
     dateFormat: 'YYYY-MM-DD',
     weekFormat: (year: number, week: number) => `${year} W${week}`,
+    quarterFormat: (year: number, quarter: number) => `${year} Q${quarter}`,
     startWeek: 'เริ่มต้นสัปดาห์',
     endWeek: 'สิ้นสุดสัปดาห์',
     startMonth: 'เดือนเริ่มต้น',
     endMonth: 'สิ้นเดือน',
+    startQuarter: 'ไตรมาสเริ่มต้น',
+    endQuarter: 'สิ้นสุดไตรมาส',
     monthFormat: 'YYYY-MM'
   },
   calendarView: {

--- a/src/uni_modules/wot-design-uni/locale/lang/tr-TR.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/tr-TR.ts
@@ -10,6 +10,7 @@ export default {
     day: 'Gün',
     week: 'Hafta',
     month: 'Ay',
+    quarter: 'Çeyrek',
     confirm: 'Tamam',
     startTime: 'Başlangıç zamanı',
     endTime: 'Bitiş zamanı',
@@ -17,10 +18,13 @@ export default {
     timeFormat: 'YY-MM-DD HH:mm:ss',
     dateFormat: 'YYYY-MM-DD',
     weekFormat: (year: number, week: number) => `${year} ${week}. Hafta`,
+    quarterFormat: (year: number, quarter: number) => `${year} ${quarter}. Çeyrek`,
     startWeek: 'Başlangıç hafta',
     endWeek: 'Bitiş hafta',
     startMonth: 'Başlangıç ay',
     endMonth: 'Bitiş ay',
+    startQuarter: 'Başlangıç çeyrek',
+    endQuarter: 'Bitiş çeyrek',
     monthFormat: 'YYYY-MM'
   },
   calendarView: {

--- a/src/uni_modules/wot-design-uni/locale/lang/ug-CN.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/ug-CN.ts
@@ -9,6 +9,7 @@ export default {
     day: 'كۈن',
     week: 'ھەپتە',
     month: 'ئاي',
+    quarter: 'چوڭ پەسىل',
     confirm: 'جەزملەش',
     startTime: 'باشلىنىش ۋاقتى',
     endTime: 'ئاخىرلىشىش ۋاقتى',
@@ -16,10 +17,13 @@ export default {
     timeFormat: 'YY-MM-DD HH:mm:ss',
     dateFormat: 'YYYY-MM-DD',
     weekFormat: (year: number, week: number) => `${year}يىلى ${week}ھەپتە`,
+    quarterFormat: (year: number, quarter: number) => `${year}يىلى ${quarter}چوڭ پەسىل`,
     startWeek: 'باشلىنىش ھەپتىسى',
     endWeek: 'ئاخىرلىشىش ھەپتىسى',
     startMonth: 'باشلىنىش ئېيى',
     endMonth: 'ئاخىرلىشىش ئېيى',
+    startQuarter: 'باشلىنىش چوڭ پەسىلى',
+    endQuarter: 'ئاخىرلىشىش چوڭ پەسىلى',
     monthFormat: 'YYYYيىل MMئاي'
   },
   calendarView: {

--- a/src/uni_modules/wot-design-uni/locale/lang/vi-VN.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/vi-VN.ts
@@ -17,6 +17,7 @@ export default {
     day: 'Ngày',
     week: 'Tuần',
     month: 'Tháng',
+    quarter: 'Quý',
     confirm: 'Xác nhận',
     startTime: 'Thời gian bắt đầu',
     endTime: 'Thời gian kết thúc',
@@ -24,10 +25,13 @@ export default {
     timeFormat: 'YY-MM-DD HH:mm:ss',
     dateFormat: 'YYYY-MM-DD',
     weekFormat: (year: number, week: number) => `Tuần thứ ${week} năm ${year}`,
+    quarterFormat: (year: number, quarter: number) => `Quý ${quarter} năm ${year}`,
     startWeek: 'Tuần bắt đầu',
     endWeek: 'Tuần kết thúc',
     startMonth: 'Tháng bắt đầu',
     endMonth: 'Tháng kết thúc',
+    startQuarter: 'Quý bắt đầu',
+    endQuarter: 'Quý kết thúc',
     monthFormat: 'Tháng YYYY MM'
   },
   calendarView: {

--- a/src/uni_modules/wot-design-uni/locale/lang/zh-CN.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/zh-CN.ts
@@ -9,6 +9,7 @@ export default {
     day: '日',
     week: '周',
     month: '月',
+    quarter: '季度',
     confirm: '确定',
     startTime: '开始时间',
     endTime: '结束时间',
@@ -16,10 +17,13 @@ export default {
     timeFormat: 'YY年MM月DD日 HH:mm:ss',
     dateFormat: 'YYYY年MM月DD日',
     weekFormat: (year: number, week: number) => `${year} 第 ${week} 周`,
+    quarterFormat: (year: number, quarter: number) => `${year} 第 ${quarter} 季度`,
     startWeek: '开始周',
     endWeek: '结束周',
     startMonth: '开始月',
     endMonth: '结束月',
+    startQuarter: '开始季度',
+    endQuarter: '结束季度',
     monthFormat: 'YYYY年MM月'
   },
   calendarView: {

--- a/src/uni_modules/wot-design-uni/locale/lang/zh-HK.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/zh-HK.ts
@@ -9,6 +9,7 @@ export default {
     day: '日',
     week: '週',
     month: '月',
+    quarter: '季度',
     confirm: '確定',
     startTime: '開始時間',
     endTime: '結束時間',
@@ -16,10 +17,13 @@ export default {
     timeFormat: 'YY年MM月DD日 HH:mm:ss',
     dateFormat: 'YYYY年MM月DD日',
     weekFormat: (year: number, week: number) => `${year} 第 ${week} 週`,
+    quarterFormat: (year: number, quarter: number) => `${year} 第 ${quarter} 季度`,
     startWeek: '開始週',
     endWeek: '結束週',
     startMonth: '開始月',
     endMonth: '結束月',
+    startQuarter: '開始季度',
+    endQuarter: '結束季度',
     monthFormat: 'YYYY年MM月'
   },
   calendarView: {

--- a/src/uni_modules/wot-design-uni/locale/lang/zh-TW.ts
+++ b/src/uni_modules/wot-design-uni/locale/lang/zh-TW.ts
@@ -13,6 +13,7 @@ export default {
     day: '日',
     week: '週',
     month: '月',
+    quarter: '季度',
     confirm: '確定',
     startTime: '開始時間',
     endTime: '結束時間',
@@ -20,10 +21,13 @@ export default {
     timeFormat: 'YY年MM月DD日 HH:mm:ss',
     dateFormat: 'YYYY年MM月DD日',
     weekFormat: (year: number, week: number) => `${year} 第 ${week} 週`,
+    quarterFormat: (year: number, quarter: number) => `${year} 第 ${quarter} 季度`,
     startWeek: '開始週',
     endWeek: '結束週',
     startMonth: '開始月',
     endMonth: '結束月',
+    startQuarter: '開始季度',
+    endQuarter: '結束季度',
     monthFormat: 'YYYY年MM月'
   },
   calendarView: {


### PR DESCRIPTION
为Calendar和CalendarView增加季度选择

BREAKING CHANGE: 🧨 季度选择器

✅ Closes: #1247

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [x] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
[1247](https://github.com/Moonofweisheng/wot-design-uni/issues/1247)
### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
`<wd-calendar type="quarter" v-model="value" @confirm="handleConfirm" />`


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 日历与日历视图支持“季度/季度范围”选择，并提供新的季度面板与显示格式；示例页新增对应交互。
- 国际化
  - 多语言新增季度相关文案与格式化（包含中英及多语种）。
- 文档
  - 新增“季度选择”章节；范围类型新增 quarterrange；标注 use-default-slot、use-label-slot 为弃用。
- 样式
  - 新增季度视图样式与可配置的季度宽度变量。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->