### PR TITLE
fix: 🐛 修复 Fab 悬浮按钮组件 Icon 垂直居中异常的问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-icon/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-icon/index.scss
@@ -28,7 +28,6 @@
   font-weight: normal;
   font-variant: normal;
   text-transform: none;
-  line-height: 1;
   /* Better Font Rendering =========== */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
修复 Fab 悬浮按钮组件 Icon 垂直居中异常的问题，取消 icon 组件默认的行高。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 样式
  - 调整 wd-icon 基础样式：移除固定行高，改为使用默认/继承值。此变更可能影响图标与文本在同一行内的垂直对齐与间距效果，具体表现取决于所在容器与外层样式。在不同页面或主题下，图标的行内位置可能出现轻微变化；如需保持既有视觉一致性，可在项目中按需为相关位置补充行高或对齐样式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->