### PR TITLE
fix: 🐛 修复 Upload 设置 multiple 无效的问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-upload/wd-upload.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-upload/wd-upload.vue
@@ -69,11 +69,11 @@
     </view>
 
     <block v-if="showUpload">
-      <view :class="['wd-upload__evoke-slot', customEvokeClass]" v-if="$slots.default" @click="handleChoose">
+      <view :class="['wd-upload__evoke-slot', customEvokeClass]" v-if="$slots.default" @click="onEvokeClick">
         <slot></slot>
       </view>
       <!-- 唤起项 -->
-      <view v-else @click="handleChoose" :class="['wd-upload__evoke', disabled ? 'is-disabled' : '', customEvokeClass]">
+      <view v-else @click="onEvokeClick" :class="['wd-upload__evoke', disabled ? 'is-disabled' : '', customEvokeClass]">
         <!-- 唤起项图标 -->
         <wd-icon class="wd-upload__evoke-icon" name="fill-camera"></wd-icon>
         <!-- 有限制个数时确认是否展示限制个数 -->
@@ -408,7 +408,6 @@ function handleProgress(res: UniApp.OnProgressUpdateResult, file: UploadFileItem
  */
 function onChooseFile(currentIndex?: number) {
   const { multiple, maxSize, accept, sizeType, limit, sourceType, compressed, maxDuration, camera, beforeUpload, extension } = props
-
   chooseFile({
     multiple: isDef(currentIndex) ? false : multiple,
     sizeType,
@@ -455,6 +454,13 @@ function onChooseFile(currentIndex?: number) {
     .catch((error) => {
       emit('chooseerror', { error })
     })
+}
+
+/**
+ * @description 处理唤起选择文件的点击事件
+ */
+function onEvokeClick() {
+  handleChoose()
 }
 
 /**


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
https://ext.dcloud.net.cn/plugin?id=13889

大佬上传多选失效了，只能单选。我看了下代码问题大概出现在wd-upload.vue的413行的multiple: isDef(currentIndex) ? false : multiple，isDef(currentIndex) 这里一直返回的是true，所以造成不论我在中的multiple是true还是false。最后multiple所获取到的值一直都是false，所以只能单选不能多选。不知道我说的对不对，大佬有时间看下。
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
@click="handleChoose"，会导致将event传给handleChoose，导致isDef(currentIndex) 始终为true，调整为使用onEvokeClick处理click
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 重构
  - 统一上传组件触发区域的点击事件处理逻辑为单一入口，减少重复并提升一致性与可维护性；不影响现有交互与功能表现。
- 杂务
  - 轻微代码格式调整，不引入任何行为或功能变化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->