### PR TITLE
修复文档中手机比例高度

### DIFF
--- a/docs/.vitepress/theme/components/VPDoc.vue
+++ b/docs/.vitepress/theme/components/VPDoc.vue
@@ -3,8 +3,8 @@ import { useRoute } from 'vitepress'
 import { computed, ref } from 'vue'
 import VPDocAside from 'vitepress/dist/client/theme-default/components/VPDocAside.vue'
 import VPDocFooter from 'vitepress/dist/client/theme-default/components/VPDocFooter.vue'
-import { useData } from 'vitepress';
-import { useSidebar } from 'vitepress/theme';
+import { useData } from 'vitepress'
+import { useSidebar } from 'vitepress/theme'
 import VPIframe from './VPIframe.vue'
 
 const { theme }: any = useData()
@@ -12,23 +12,18 @@ const { theme }: any = useData()
 const route = useRoute()
 const { hasSidebar, hasAside, leftAside } = useSidebar()
 
-const pageName = computed(() =>
-  route.path.replace(/[./]+/g, '_').replace(/_html$/, '')
-)
-const isComponent = computed(() => 
-  (route.path.startsWith('/component') || route.path.startsWith('/en-US/component')) && !route.path.includes('/use-')
+const pageName = computed(() => route.path.replace(/[./]+/g, '_').replace(/_html$/, ''))
+const isComponent = computed(
+  () => (route.path.startsWith('/component') || route.path.startsWith('/en-US/component')) && !route.path.includes('/use-')
 )
 const expanded = ref(true)
-
 </script>
 
 <template>
-  <div class="VPDoc"
-    :class="{ 'has-sidebar': hasSidebar, 'has-aside': hasAside, 'is-component': isComponent, 'is-expanded': expanded }">
+  <div class="VPDoc" :class="{ 'has-sidebar': hasSidebar, 'has-aside': hasAside, 'is-component': isComponent, 'is-expanded': expanded }">
     <slot name="doc-top" />
     <div class="container">
       <div v-if="hasAside" class="aside" :class="{ 'left-aside': leftAside }">
-        <div class="aside-curtain" />
         <div class="aside-container">
           <div class="aside-content">
             <VPDocAside>
@@ -59,10 +54,7 @@ const expanded = ref(true)
         <div class="content-container">
           <slot name="doc-before" />
           <main class="main">
-            <Content class="vp-doc" :class="[
-              pageName,
-              theme.externalLinkIcon && 'external-link-icon-enabled'
-            ]" />
+            <Content class="vp-doc" :class="[pageName, theme.externalLinkIcon && 'external-link-icon-enabled']" />
             <VPIframe v-if="isComponent" v-model:expanded="expanded" />
           </main>
           <VPDocFooter>
@@ -163,15 +155,6 @@ const expanded = ref(true)
   display: none;
 }
 
-.aside-curtain {
-  position: fixed;
-  bottom: 0;
-  z-index: 10;
-  width: 224px;
-  height: 32px;
-  background: linear-gradient(transparent, var(--vp-c-bg) 70%);
-}
-
 .aside-content {
   display: flex;
   flex-direction: column;
@@ -199,7 +182,6 @@ const expanded = ref(true)
   }
 }
 
-
 @media (min-width: 1280px) {
   .VPDoc.is-component.is-expanded .container {
     padding-right: 358px;
@@ -218,9 +200,7 @@ const expanded = ref(true)
   .VPDoc.is-component:not(.is-expanded) .container {
     padding-right: 64px;
   }
-
 }
-
 
 .content-container {
   margin: 0 auto;

--- a/docs/.vitepress/theme/components/VPIframe.vue
+++ b/docs/.vitepress/theme/components/VPIframe.vue
@@ -1,21 +1,25 @@
 <template>
   <!-- 主容器：根据展开状态和过渡状态添加对应类名 -->
-  <div v-if="href" class="demo-model" :class="{
-    'collapsed': !expanded,
-    'transition-end': transitionEnd
-  }" @transitionend="onTransitionEnd">
+  <div
+    v-if="href"
+    class="demo-model"
+    :class="{
+      collapsed: !expanded,
+      'transition-end': transitionEnd
+    }"
+    @transitionend="onTransitionEnd"
+  >
     <!-- 头部控制栏 -->
     <div class="demo-header">
-      <ExternalLink :href="href" class="demo-link" :style="`${expanded ? '' : 'height:0;width:0;opacity:0'}`">
-      </ExternalLink>
-      <QrCode class="demo-qrcode" :src="qrcode" v-if="expanded&&qrcode"></QrCode>
-      <el-icon class="expand-icon" style="cursor: pointer;" @click="toggleExpand">
+      <ExternalLink :href="href" class="demo-link" :style="`${expanded ? '' : 'height:0;width:0;opacity:0'}`"></ExternalLink>
+      <QrCode class="demo-qrcode" :src="qrcode" v-if="expanded && qrcode"></QrCode>
+      <el-icon class="expand-icon" style="cursor: pointer" @click="toggleExpand">
         <component :is="expanded ? Fold : Expand" />
       </el-icon>
     </div>
     <!-- iframe 容器 -->
     <div class="iframe-container">
-      <iframe v-if="expanded&&transitionEnd" ref="iframe" id="demo" class="iframe" scrolling="auto" frameborder="0" :src="href" />
+      <iframe v-if="expanded && transitionEnd" ref="iframe" id="demo" class="iframe" scrolling="auto" frameborder="0" :src="href" />
     </div>
   </div>
 </template>
@@ -41,8 +45,8 @@ const iframe = ref<HTMLIFrameElement | null>(null)
 const transitionEnd = ref(true)
 
 const emit = defineEmits<{
-  'update:expanded': [boolean]  // 更新展开状态
-  'state-change': [boolean]     // 状态变化通知
+  'update:expanded': [boolean] // 更新展开状态
+  'state-change': [boolean] // 状态变化通知
 }>()
 
 const route = useRoute()
@@ -90,7 +94,6 @@ function toggleExpand() {
 // 过渡结束处理
 function onTransitionEnd() {
   transitionEnd.value = true
-
 }
 
 // iframe 消息通信
@@ -108,9 +111,8 @@ function sendLanguageMessage() {
 }
 
 onMounted(() => {
-  baseUrl.value = process.env.NODE_ENV === 'production'
-    ? `${location.origin}/demo/?timestamp=${new Date().getTime()}#/`
-    : 'http://localhost:5173/demo/#/'
+  baseUrl.value =
+    process.env.NODE_ENV === 'production' ? `${location.origin}/demo/?timestamp=${new Date().getTime()}#/` : 'http://localhost:5173/demo/#/'
 
   // 监听 iframe 加载完成事件
   iframe.value?.addEventListener('load', () => {
@@ -119,16 +121,10 @@ onMounted(() => {
   })
 })
 
-watch(
-  () => vitepressData.isDark.value,
-  sendMessage
-)
+watch(() => vitepressData.isDark.value, sendMessage)
 
 // 监听语言变化
-watch(
-  () => vitepressData.lang.value,
-  sendLanguageMessage
-)
+watch(() => vitepressData.lang.value, sendLanguageMessage)
 </script>
 
 <style scoped>
@@ -202,7 +198,7 @@ watch(
   color: var(--color);
 }
 
-.demo-qrcode{
+.demo-qrcode {
   font-size: 28px !important;
   transition: all 0.3s ease-in-out;
   position: absolute;
@@ -237,8 +233,7 @@ watch(
 .fade-enter,
 .fade-leave-to
 
-/* .fade-leave-active in <2.1.8 */
-  {
+/* .fade-leave-active in <2.1.8 */ {
   opacity: 0;
 }
 
@@ -257,7 +252,7 @@ watch(
 @media screen and (min-width: 1440px) {
   .demo-model {
     width: 360px;
-    height: calc(360px * 143.6 / 70.9 + 56px);
+    height: calc(360px * 143.6 / 70.9 - 56px);
     right: 64px;
   }
 


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

测试显示器尺寸为13.6寸与24寸，分辨率都为2k

<img width="2582" height="1752" alt="461569a665bdb18ce6554bd8adccc2d7" src="https://github.com/user-attachments/assets/bb567d45-158d-4692-8e5d-6243ee0e896e" />

### 💡 需求背景和解决方案
1. 文档模拟手机部分高度过高，导致部分组件显示不完整
2. 当min-width大于1440时，高度减少一部分

<img width="3004" height="1740" alt="image" src="https://github.com/user-attachments/assets/857c6fc1-a193-4de3-8d16-8ea2cb350042" />


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 移除侧边“幕帘”渐变元素及其样式，界面更简洁。
  - 在超大屏（≥1440px）下下调示例面板高度，优化大屏布局与留白。
  - 统一模板与样式的格式化（属性、空白、类绑定），不影响现有行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->