### PR TITLE
fix: 修复input输入更新不一致

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-input/wd-input.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-input/wd-input.vue
@@ -88,7 +88,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import { computed, ref, watch, useSlots, type Slots } from 'vue'
+import { computed, ref, watch, useSlots, type Slots, nextTick } from 'vue'
 import wdIcon from '../wd-icon/wd-icon.vue'
 import { isDef, objToStyle, pause, isEqual } from '../common/util'
 import { useCell } from '../composables/useCell'
@@ -268,8 +268,9 @@ function handleFocus({ detail }: any) {
   focusing.value = true
   emit('focus', detail)
 }
-function handleInput({ detail }: any) {
+async function handleInput({ detail }: any) {
   emit('update:modelValue', inputValue.value)
+  await nextTick()
   emit('input', detail)
 }
 function handleKeyboardheightchange({ detail }: any) {


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/user-attachments/assets/02a39214-cd81-4e4b-b573-bec236c2bc55


### 💡 需求背景和解决方案
当需要动态更新wd-input的值时，值返回异常
```
<template>
  <wd-input type="text" @input="handleInputTs" v-model="inputValue" />
</template>

<script setup>
import { ref } from 'vue'

const inputValue = ref()

const handleInputTs = (e) => {
  const result = e.value
  if (result) {
    if (Number(result) > 2000) {
      inputValue.value = '2000'
    } else {
      inputValue.value = result
    }
  }
}
</script>

```





### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 优化输入框事件触发时机：在界面更新完成后再触发输入事件，避免与双向绑定不同步导致的值闪烁、光标跳动或重复触发等问题，提升输入稳定性与一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->