### PR TITLE
feat: wd-picker-view组件内itemHeight由props传入

### DIFF
--- a/docs/component/datetime-picker-view.md
+++ b/docs/component/datetime-picker-view.md
@@ -144,6 +144,7 @@ const filter = (type, values) => {
 | loading | 加载中 | boolean | - | false | - |
 | loading-color | 加载的颜色，只能使用十六进制的色值写法，且不能使用缩写 | string | - | #4D80F0 | - |
 | columns-height | picker内部滚筒高 | number | - | 231 | - |
+| item-height | picker item的高度 | number | - | 35 | - |
 | formatter | 自定义弹出层选项文案的格式化函数，返回一个字符串 | function | - | - | - |
 | filter | 自定义过滤选项的函数，返回列的选项数组 | function | - | - | - |
 | minDate | 最小日期，13 位的时间戳    | `timestamp` | - | 当前日期 - 10年 | - |

--- a/docs/component/datetime-picker.md
+++ b/docs/component/datetime-picker.md
@@ -289,6 +289,7 @@ const displayFormatTabLabel = (items) => {
 | loading | 加载中 | boolean | - | false | - |
 | loading-color | 加载的颜色，只能使用十六进制的色值写法，且不能使用缩写 | string | - | #4D80F0 | - |
 | columns-height | picker内部滚筒高 | number | - | 231 | - |
+| item-height | picker item的高度 | number | - | 35 | - |
 | title | 弹出层标题 | string | - | - | - |
 | cancel-button-text | 取消按钮文案 | string | - | 取消 | - |
 | confirm-button-text | 确认按钮文案 | string | - | 完成 | - |

--- a/src/uni_modules/wot-design-uni/components/wd-datetime-picker-view/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-datetime-picker-view/types.ts
@@ -22,6 +22,10 @@ export const datetimePickerViewProps = {
    */
   columnsHeight: makeNumberProp(217),
   /**
+   * picker item的高度
+   */
+  itemHeight: makeNumberProp(35),
+  /**
    * 选项的key
    */
   valueKey: makeStringProp('value'),

--- a/src/uni_modules/wot-design-uni/components/wd-datetime-picker-view/wd-datetime-picker-view.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-datetime-picker-view/wd-datetime-picker-view.vue
@@ -7,6 +7,7 @@
     v-model="pickerValue"
     :columns="columns"
     :columns-height="columnsHeight"
+    :item-height="itemHeight"
     :columnChange="columnChange"
     :loading="loading"
     :loading-color="loadingColor"

--- a/src/uni_modules/wot-design-uni/components/wd-picker-view/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-picker-view/types.ts
@@ -31,6 +31,10 @@ export const pickerViewProps = {
    */
   columnsHeight: makeNumberProp(217),
   /**
+   * picker item的高度
+   */
+  itemHeight: makeNumberProp(35),
+  /**
    * 选项对象中，value对应的 key
    */
   valueKey: makeStringProp('value'),

--- a/src/uni_modules/wot-design-uni/components/wd-picker-view/wd-picker-view.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-picker-view/wd-picker-view.vue
@@ -52,7 +52,6 @@ const props = defineProps(pickerViewProps)
 const emit = defineEmits(['change', 'pickstart', 'pickend', 'update:modelValue'])
 
 const formatColumns = ref<ColumnItem[][]>([]) // 格式化后的列数据
-const itemHeight = ref<number>(35)
 const selectedIndex = ref<Array<number>>([]) // 格式化之后，每列选中的下标集合
 
 watch(


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
https://github.com/Moonofweisheng/wot-design-uni/issues/1273
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
wd-picker-view 支持 props 传入 itemHeight，itemHeight原来在代码里写死了 35
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - DatetimePicker 与 DatetimePickerView 新增 item-height 属性，支持自定义选择器单项高度（默认 35），便于根据屏幕与视觉需求调整显示密度。

- 文档
  - 更新 DatetimePicker 与 DatetimePickerView 文档，在属性表中补充 item-height 的说明与默认值，完善使用指引。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->