### PR TITLE
Feature/add show-menu-by-longpress prop

### DIFF
--- a/docs/component/curtain.md
+++ b/docs/component/curtain.md
@@ -96,6 +96,7 @@ function handleClick() {
 | hide-when-close      | 是否当关闭时将弹出层隐藏（display: none）          | boolean | -                                                                        | true   | -        |
 | z-index              | 设置层级                                           | number  | -                                                                        | 10     | 1.4.0    |
 | root-portal          | 是否从页面中脱离出来，用于解决各种 fixed 失效问题 | boolean | -                                                                        | false  | 1.11.0 |
+| show-menu-by-longpress          | 开启长按图片显示识别小程序码菜单，仅微信小程序支持 | boolean | -                                                                        | false  | $LOWEST_VERSION$ |
 
 ## Events
 

--- a/docs/en-US/component/curtain.md
+++ b/docs/en-US/component/curtain.md
@@ -96,6 +96,7 @@ function handleClick() {
 | hide-when-close     | Hide popup layer when closed (display: none)                 | boolean | -                                                                         | true    | -        |
 | z-index             | Set layer level                                              | number  | -                                                                         | 10      | 1.4.0    |
 | root-portal         | Whether to detach from the page, used to solve various fixed positioning issues | boolean | -                                                                         | false   | 1.11.0 |
+| show-menu-by-longpress         | Enable long press image to show Mini Program code recognition menu, only supported in WeChat Mini Program | boolean | -                                                                         | false   | $LOWEST_VERSION$ |
 
 ## Events
 

--- a/src/uni_modules/wot-design-uni/components/wd-curtain/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-curtain/types.ts
@@ -68,7 +68,11 @@ export const curtainProps = {
   /**
    * 是否从页面中脱离出来，用于解决各种 fixed 失效问题 (H5: teleport, APP: renderjs, 小程序: root-portal)
    */
-  rootPortal: makeBooleanProp(false)
+  rootPortal: makeBooleanProp(false),
+  /**
+   * 开启长按图片显示识别小程序码菜单，仅在微信小程序平台有效
+   */
+  showMenuByLongpress: makeBooleanProp(false)
 }
 
 export type CurtainProps = ExtractPropTypes<typeof curtainProps>

--- a/src/uni_modules/wot-design-uni/components/wd-curtain/wd-curtain.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-curtain/wd-curtain.vue
@@ -20,7 +20,15 @@
       :custom-style="customStyle"
     >
       <view class="wd-curtain__content">
-        <image :src="src" class="wd-curtain__content-img" :style="imgStyle" @click="clickImage" @error="imgErr" @load="imgLoad"></image>
+        <image
+          :src="src"
+          class="wd-curtain__content-img"
+          :style="imgStyle"
+          :show-menu-by-longpress="showMenuByLongpress"
+          @click="clickImage"
+          @error="imgErr"
+          @load="imgLoad"
+        ></image>
         <slot name="close">
           <wd-icon
             name="close-outline"


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
[https://github.com/Moonofweisheng/wot-design-uni/issues/1279](url)
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
新增show-menu-by-longpress属性
`<wd-curtain show-menu-by-longpress />`
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充