### PR TITLE
feat(wd-keyboard): 增加车牌键盘语言切换功能，支持受控和非受控模式

### DIFF
--- a/docs/component/keyboard.md
+++ b/docs/component/keyboard.md
@@ -1,6 +1,7 @@
 ---
 version: 1.3.10
 ---
+
 # Keyboard 虚拟键盘
 
 虚拟数字键盘，用于输入数字、密码、身份证或车牌号等场景。
@@ -87,6 +88,42 @@ const visible = ref<boolean>(false)
 
 function showKeyBoard() {
   visible.value = true
+}
+
+const onInput = (value) => showToast(`${value}`)
+const onDelete = () => showToast('删除')
+```
+
+## 车牌号键盘语言控制
+
+通过 `car-lang` 属性可以控制车牌键盘的语言模式，支持中文省份（`zh`）和英文字母（`en`）。通过 `auto-switch-lang` 属性可以控制是否自动切换语言。
+
+```html
+<!-- 受控模式：手动控制语言切换 -->
+<wd-cell title="车牌号键盘（受控）" :value="value" is-link @click="showKeyBoard" />
+
+<wd-keyboard v-model="value" v-model:visible="visible" v-model:car-lang="lang" mode="car" @input="onInput" @delete="onDelete"></wd-keyboard>
+
+<!-- 非受控模式：禁用自动切换 -->
+<wd-cell title="车牌号键盘（非自动切换）" :value="value2" is-link @click="showKeyBoard2" />
+
+<wd-keyboard v-model="value2" v-model:visible="visible2" mode="car" :auto-switch-lang="false" @input="onInput" @delete="onDelete"></wd-keyboard>
+```
+
+```ts
+const { show: showToast } = useToast()
+const visible = ref<boolean>(false)
+const visible2 = ref<boolean>(false)
+const value = ref<string>('')
+const value2 = ref<string>('')
+const lang = ref<'zh' | 'en'>('zh')
+
+function showKeyBoard() {
+  visible.value = true
+}
+
+function showKeyBoard2() {
+  visible2.value = true
 }
 
 const onInput = (value) => showToast(`${value}`)
@@ -242,25 +279,27 @@ const onDelete = () => showToast('删除')
 
 ## Attributes
 
-| 参数                | 说明                     | 类型                  | 可选值                     | 默认值     | 最低版本         |
-| ------------------- | ------------------------ | --------------------- | -------------------------- | ---------- | ---------------- |
-| v-model:visible     | 是否展开                 | `boolean`             | -                          | `false`    | 1.3.10           |
-| v-model             | 绑定的值                 | `string`              | -                          | -          | 1.3.10           |
-| title               | 标题                     | `string`              | -                          | -          | 1.3.10           |
-| mode                | 键盘模式                 | `string`              | `default`, `car`, `custom` | `default`  | 1.3.10 |
-| zIndex              | 层级                     | `number`              | -                          | `100`      | 1.3.10           |
-| maxlength           | 最大长度                 | `number`              | -                          | `Infinity` | 1.3.10           |
-| showDeleteKey       | 是否显示删除键           | `boolean`             | -                          | `true`     | 1.3.10           |
-| randomKeyOrder      | 是否随机键盘按键顺序     | `boolean`             | -                          | `false`    | 1.3.10           |
-| closeText           | 确认按钮文本             | `string`              | -                          | -          | 1.3.10           |
-| deleteText          | 删除按钮文本             | `string`              | -                          | -          | 1.3.10           |
-| closeButtonLoading  | 关闭按钮是否显示加载状态 | `boolean`             | -                          | `false`    | 1.3.10           |
-| modal               | 是否显示蒙层遮罩         | `boolean`             | -                          | `false`    | 1.3.10           |
-| hideOnClickOutside  | 是否在点击外部时收起键盘 | `boolean`             | -                          | `true`     | 1.3.10           |
-| lockScroll          | 是否锁定背景滚动，锁定时蒙层里的内容也将无法滚动 | `boolean`             | -                          | `true`     | 1.3.10           |
-| safeAreaInsetBottom | 是否在底部安全区域内     | `boolean`             | -                          | `true`     | 1.3.10           |
-| extraKey            | 额外按键                 | `string` / `string[]` | -                          | -          | 1.3.10           |
-| root-portal         | 是否从页面中脱离出来，用于解决各种 fixed 失效问题 | `boolean`             | -                          | `false`    | 1.11.0 |
+| 参数                | 说明                                                                 | 类型                  | 可选值                     | 默认值     | 最低版本 |
+| ------------------- | -------------------------------------------------------------------- | --------------------- | -------------------------- | ---------- | -------- |
+| v-model:visible     | 是否展开                                                             | `boolean`             | -                          | `false`    | 1.3.10   |
+| v-model             | 绑定的值                                                             | `string`              | -                          | -          | 1.3.10   |
+| title               | 标题                                                                 | `string`              | -                          | -          | 1.3.10   |
+| mode                | 键盘模式                                                             | `string`              | `default`, `car`, `custom` | `default`  | 1.3.10   |
+| zIndex              | 层级                                                                 | `number`              | -                          | `100`      | 1.3.10   |
+| maxlength           | 最大长度                                                             | `number`              | -                          | `Infinity` | 1.3.10   |
+| showDeleteKey       | 是否显示删除键                                                       | `boolean`             | -                          | `true`     | 1.3.10   |
+| randomKeyOrder      | 是否随机键盘按键顺序                                                 | `boolean`             | -                          | `false`    | 1.3.10   |
+| closeText           | 确认按钮文本                                                         | `string`              | -                          | -          | 1.3.10   |
+| deleteText          | 删除按钮文本                                                         | `string`              | -                          | -          | 1.3.10   |
+| closeButtonLoading  | 关闭按钮是否显示加载状态                                             | `boolean`             | -                          | `false`    | 1.3.10   |
+| modal               | 是否显示蒙层遮罩                                                     | `boolean`             | -                          | `false`    | 1.3.10   |
+| hideOnClickOutside  | 是否在点击外部时收起键盘                                             | `boolean`             | -                          | `true`     | 1.3.10   |
+| lockScroll          | 是否锁定背景滚动，锁定时蒙层里的内容也将无法滚动                     | `boolean`             | -                          | `true`     | 1.3.10   |
+| safeAreaInsetBottom | 是否在底部安全区域内                                                 | `boolean`             | -                          | `true`     | 1.3.10   |
+| extraKey            | 额外按键                                                             | `string` / `string[]` | -                          | -          | 1.3.10   |
+| root-portal         | 是否从页面中脱离出来，用于解决各种 fixed 失效问题                    | `boolean`             | -                          | `false`    | 1.11.0   |
+| v-model:carLang    | 车牌键盘语言模式，当 mode=car 时生效                                 | `string`              | `zh`, `en`                 | -          | 1.12.4   |
+| autoSwitchLang    | 是否自动切换车牌键盘语言，当 mode=car 且 car-lang 是非受控状态时生效 | `boolean`             | -                          | `false`    | 1.12.4   |
 
 ## Slot
 

--- a/docs/en-US/component/keyboard.md
+++ b/docs/en-US/component/keyboard.md
@@ -1,6 +1,7 @@
 ---
 version: 1.3.10
 ---
+
 # Keyboard
 
 Virtual keyboard for inputting numbers, passwords, ID cards, or license plate numbers.
@@ -87,6 +88,42 @@ const visible = ref<boolean>(false)
 
 function showKeyBoard() {
   visible.value = true
+}
+
+const onInput = (value) => showToast(`${value}`)
+const onDelete = () => showToast('Delete')
+```
+
+## License Plate Keyboard Language Control
+
+You can control the language mode of the license plate keyboard through the `car-lang` property, supporting Chinese provinces (`zh`) and English letters (`en`). Use the `auto-switch-lang` property to control whether to automatically switch languages.
+
+```html
+<!-- Controlled mode: Manual language switching -->
+<wd-cell title="License Plate Keyboard (Controlled)" :value="value" is-link @click="showKeyBoard" />
+
+<wd-keyboard v-model="value" v-model:visible="visible" v-model:car-lang="lang" mode="car" @input="onInput" @delete="onDelete"></wd-keyboard>
+
+<!-- Uncontrolled mode: Disable auto-switching -->
+<wd-cell title="License Plate Keyboard (No Auto-switch)" :value="value2" is-link @click="showKeyBoard2" />
+
+<wd-keyboard v-model="value2" v-model:visible="visible2" mode="car" :auto-switch-lang="false" @input="onInput" @delete="onDelete"></wd-keyboard>
+```
+
+```ts
+const { show: showToast } = useToast()
+const visible = ref<boolean>(false)
+const visible2 = ref<boolean>(false)
+const value = ref<string>('')
+const value2 = ref<string>('')
+const lang = ref<'zh' | 'en'>('zh')
+
+function showKeyBoard() {
+  visible.value = true
+}
+
+function showKeyBoard2() {
+  visible2.value = true
 }
 
 const onInput = (value) => showToast(`${value}`)
@@ -201,33 +238,86 @@ You can bind the keyboard's current input value through `v-model` and limit the 
 ></wd-keyboard>
 ```
 
+```ts
+const { show: showToast } = useToast()
+const visible = ref<boolean>(false)
+const value1 = ref<string>('')
+
+function showKeyBoard() {
+  visible.value = true
+}
+
+const onInput = (value) => showToast(`${value}`)
+const onDelete = () => showToast('Delete')
+```
+
+## Display Modal Overlay
+
+`hideOnClickOutside` controls whether the keyboard popup has an overlay, and `modal` controls whether the overlay is transparent.
+
+::: tip
+Currently `modal` only controls whether the overlay is transparent, `hideOnClickOutside` controls whether the popup has an overlay. When there is an overlay, clicking the overlay can close the keyboard, but when the keyboard is open, you must click the overlay to close the current keyboard before you can click other buttons. You can also disable `hideOnClickOutside` and manually control whether the keyboard is displayed to implement closing the keyboard when clicking outside, which is more flexible.
+:::
+
+```html
+<wd-cell title="Two-way Binding" :value="value1" is-link @click="showKeyBoard" />
+<wd-keyboard :modal="true" :hide-on-click-outside="true" v-model:visible="visible" @input="onInput" @delete="onDelete" />
+```
+
+```ts
+const { show: showToast } = useToast()
+const visible = ref<boolean>(false)
+const value1 = ref<string>('')
+
+function showKeyBoard() {
+  visible.value = true
+}
+
+const onInput = (value) => showToast(`${value}`)
+const onDelete = () => showToast('Delete')
+```
+
 ## Attributes
 
-| Attribute | Description | Type | Default | Version |
-|---------|-------------|------|---------|------|
-| v-model:visible | Whether to display keyboard | boolean | false | - |
-| v-model | Keyboard input value | string | - | - |
-| maxlength | Maximum input length | number | - | - |
-| title | Keyboard title | string | - | - |
-| mode | Keyboard mode, can be set to `custom` or `car` | string | - | - |
-| close-text | Text of close button | string | - | - |
-| extra-key | Content of extra key | string / string[] | - | - |
-| random-key-order | Whether to randomly arrange number keys | boolean | false | - |
-| show-close-button | Whether to show close button | boolean | true | - |
-| safe-area-inset-bottom | Whether to enable bottom safe area adaptation | boolean | true | - |
-| z-index | Keyboard z-index | number | 100 | - |
-| root-portal | Whether to detach from the page, used to solve various fixed positioning issues | boolean | false | 1.11.0 |
+| Parameter           | Description                                                                                                           | Type                  | Options                    | Default    | Version |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------- | -------------------------- | ---------- | ------- |
+| v-model:visible     | Whether to display                                                                                                    | `boolean`             | -                          | `false`    | 1.3.10  |
+| v-model             | Bound value                                                                                                           | `string`              | -                          | -          | 1.3.10  |
+| title               | Title                                                                                                                 | `string`              | -                          | -          | 1.3.10  |
+| mode                | Keyboard mode                                                                                                         | `string`              | `default`, `car`, `custom` | `default`  | 1.3.10  |
+| zIndex              | Z-index                                                                                                               | `number`              | -                          | `100`      | 1.3.10  |
+| maxlength           | Maximum length                                                                                                        | `number`              | -                          | `Infinity` | 1.3.10  |
+| showDeleteKey       | Whether to show delete key                                                                                            | `boolean`             | -                          | `true`     | 1.3.10  |
+| randomKeyOrder      | Whether to randomize keyboard key order                                                                               | `boolean`             | -                          | `false`    | 1.3.10  |
+| closeText           | Confirm button text                                                                                                   | `string`              | -                          | -          | 1.3.10  |
+| deleteText          | Delete button text                                                                                                    | `string`              | -                          | -          | 1.3.10  |
+| closeButtonLoading  | Whether close button shows loading state                                                                              | `boolean`             | -                          | `false`    | 1.3.10  |
+| modal               | Whether to show modal overlay                                                                                         | `boolean`             | -                          | `false`    | 1.3.10  |
+| hideOnClickOutside  | Whether to close keyboard when clicking outside                                                                       | `boolean`             | -                          | `true`     | 1.3.10  |
+| lockScroll          | Whether to lock background scroll, when locked, content in the overlay will also not scroll                           | `boolean`             | -                          | `true`     | 1.3.10  |
+| safeAreaInsetBottom | Whether to enable bottom safe area                                                                                    | `boolean`             | -                          | `true`     | 1.3.10  |
+| extraKey            | Extra key                                                                                                             | `string` / `string[]` | -                          | -          | 1.3.10  |
+| root-portal         | Whether to detach from the page, used to solve various fixed positioning issues                                       | `boolean`             | -                          | `false`    | 1.11.0  |
+| v-model:carLang     | License plate keyboard language mode, effective when mode=car                                                         | `string`              | `zh`, `en`                 | -          | 1.12.4  |
+| autoSwitchLang      | Whether to automatically switch license plate keyboard language, effective when mode=car and car-lang is uncontrolled | `boolean`             | -                          | `false`    | 1.12.4  |
+
+## Slot
+
+| name  | Description | Type | Version |
+| ----- | ----------- | ---- | ------- |
+| title | Title       | -    | 1.2.12  |
 
 ## Events
 
-| Event | Description | Parameters |
-|-------|-------------|------------|
-| input | Triggered when a key is pressed | key: The pressed key |
-| delete | Triggered when delete key is pressed | - |
-| close | Triggered when keyboard is closed | - |
+| Event Name | Description                                       | Parameters  | Version |
+| ---------- | ------------------------------------------------- | ----------- | ------- |
+| input      | Triggered when a key is pressed                   | key: string | -       |
+| delete     | Triggered when delete key is pressed              | -           | -       |
+| close      | Triggered when close button or outside is clicked | -           | -       |
 
-## Slots
+## External Style Classes
 
-| Name | Description |
-|------|-------------|
-| title | Custom title content |
+| Class Name   | Description           | Version |
+| ------------ | --------------------- | ------- |
+| custom-class | Root node style class | 1.3.10  |
+| custom-style | Root node style       | 1.3.10  |

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -235,6 +235,8 @@
   "chao-zhou": "Chaozhou",
   "che-hui": "withdraw",
   "che-pai-hao-jian-pan": "License plate number keyboard",
+  "che-pai-hao-jian-pan-fei-shou-kong": "License plate keyboard (Uncontrolled)",
+  "che-pai-hao-jian-pan-shou-kong": "License plate keyboard (Controlled)",
   "checkbox-fu-xuan-kuang": "Checkbox",
   "checkbox-title": "Checkbox",
   "chen-zhou": "Chenzhou",

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -234,7 +234,6 @@
   "chao-hu": "Chaohu Lake",
   "chao-zhou": "Chaozhou",
   "che-hui": "withdraw",
-  "che-pai-hao-jian-pan": "License plate number keyboard",
   "che-pai-hao-jian-pan-fei-shou-kong": "License plate keyboard (Uncontrolled)",
   "che-pai-hao-jian-pan-shou-kong": "License plate keyboard (Controlled)",
   "checkbox-fu-xuan-kuang": "Checkbox",

--- a/src/locale/zh-CN.json
+++ b/src/locale/zh-CN.json
@@ -234,7 +234,6 @@
   "chao-hu": "巢湖",
   "chao-zhou": "潮州",
   "che-hui": "撤回",
-  "che-pai-hao-jian-pan": "车牌号键盘",
   "che-pai-hao-jian-pan-fei-shou-kong": "车牌号键盘(非受控)",
   "che-pai-hao-jian-pan-shou-kong": "车牌号键盘(受控)",
   "checkbox-fu-xuan-kuang": "Checkbox 复选框",

--- a/src/locale/zh-CN.json
+++ b/src/locale/zh-CN.json
@@ -235,6 +235,8 @@
   "chao-zhou": "潮州",
   "che-hui": "撤回",
   "che-pai-hao-jian-pan": "车牌号键盘",
+  "che-pai-hao-jian-pan-fei-shou-kong": "车牌号键盘(非受控)",
+  "che-pai-hao-jian-pan-shou-kong": "车牌号键盘(受控)",
   "checkbox-fu-xuan-kuang": "Checkbox 复选框",
   "checkbox-title": "Checkbox 复选框",
   "chen-zhou": "郴州",

--- a/src/subPages/keyboard/Index.vue
+++ b/src/subPages/keyboard/Index.vue
@@ -66,7 +66,7 @@
 
     <wd-keyboard :modal="true" v-model:visible="visible8" @input="onInput" @delete="onDelete" />
 
-    <wd-keyboard v-model="value10" v-model:visible="visible10" mode="car" @input="onInput" @delete="onDelete" />
+    <wd-keyboard v-model="value10" v-model:visible="visible10" mode="car" @input="onInput" @delete="onDelete" :autoSwitchLang="false" />
     <wd-keyboard v-model="value11" v-model:visible="visible11" v-model:lang="lang" mode="car" @input="onInput" @delete="onDelete" />
   </page-wraper>
 </template>

--- a/src/subPages/keyboard/Index.vue
+++ b/src/subPages/keyboard/Index.vue
@@ -11,7 +11,8 @@
         <wd-cell :title="$t('slot-zi-ding-yi-biao-ti')" is-link @click="showKeyBoard(9)" />
         <wd-cell :title="$t('duo-geewai-an-jian')" is-link @click="showKeyBoard(5)" />
         <wd-cell :title="$t('sui-ji-shu-zi-jian-pan')" is-link @click="showKeyBoard(6)" />
-        <wd-cell :title="$t('che-pai-hao-jian-pan')" is-link @click="showKeyBoard(10)" />
+        <wd-cell :title="$t('che-pai-hao-jian-pan-fei-shou-kong')" :value="value10" is-link @click="showKeyBoard(10)" />
+        <wd-cell :title="$t('che-pai-hao-jian-pan-shou-kong')" :value="value11" is-link @click="showKeyBoard(11)" />
         <wd-cell :title="$t('shuang-xiang-bang-ding')" clickable :value="value1" @click="showKeyBoard(7)" />
         <wd-cell :title="$t('zhan-shi-meng-ceng')" clickable @click="showKeyBoard(8)" />
       </wd-cell-group>
@@ -65,7 +66,8 @@
 
     <wd-keyboard :modal="true" v-model:visible="visible8" @input="onInput" @delete="onDelete" />
 
-    <wd-keyboard v-model:visible="visible10" mode="car" @input="onInput" @delete="onDelete" />
+    <wd-keyboard v-model="value10" v-model:visible="visible10" mode="car" @input="onInput" @delete="onDelete" />
+    <wd-keyboard v-model="value11" v-model:visible="visible11" v-model:lang="lang" mode="car" @input="onInput" @delete="onDelete" />
   </page-wraper>
 </template>
 <script lang="ts" setup>
@@ -84,11 +86,14 @@ const visible7 = ref<boolean>(false)
 const visible8 = ref<boolean>(false)
 const visible9 = ref<boolean>(false)
 const visible10 = ref<boolean>(false)
+const visible11 = ref<boolean>(false)
 
-const visibleArr = [visible1, visible2, visible3, visible4, visible5, visible6, visible7, visible8, visible9, visible10]
+const visibleArr = [visible1, visible2, visible3, visible4, visible5, visible6, visible7, visible8, visible9, visible10, visible11]
 
 const value1 = ref<string>('')
-
+const value10 = ref<string>('')
+const value11 = ref<string>('')
+const lang = ref<'zh' | 'en'>('zh')
 function showKeyBoard(index: number) {
   visibleArr.forEach((item, i) => (i === index - 1 ? (item.value = true) : (item.value = false)))
 }

--- a/src/subPages/keyboard/Index.vue
+++ b/src/subPages/keyboard/Index.vue
@@ -67,7 +67,7 @@
     <wd-keyboard :modal="true" v-model:visible="visible8" @input="onInput" @delete="onDelete" />
 
     <wd-keyboard v-model="value10" v-model:visible="visible10" mode="car" @input="onInput" @delete="onDelete" :autoSwitchLang="false" />
-    <wd-keyboard v-model="value11" v-model:visible="visible11" v-model:lang="lang" mode="car" @input="onInput" @delete="onDelete" />
+    <wd-keyboard v-model="value11" v-model:visible="visible11" v-model:carLang="carLang" mode="car" @input="onInput" @delete="onDelete" />
   </page-wraper>
 </template>
 <script lang="ts" setup>
@@ -93,7 +93,7 @@ const visibleArr = [visible1, visible2, visible3, visible4, visible5, visible6, 
 const value1 = ref<string>('')
 const value10 = ref<string>('')
 const value11 = ref<string>('')
-const lang = ref<'zh' | 'en'>('zh')
+const carLang = ref<'zh' | 'en'>('zh')
 function showKeyBoard(index: number) {
   visibleArr.forEach((item, i) => (i === index - 1 ? (item.value = true) : (item.value = false)))
 }

--- a/src/uni_modules/wot-design-uni/components/wd-keyboard/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-keyboard/types.ts
@@ -3,6 +3,7 @@ import { baseProps, makeBooleanProp, makeNumberProp, makeStringProp } from '../c
 
 export type KeyboardMode = 'default' | 'custom' | 'car'
 export type KeyType = '' | 'delete' | 'extra' | 'close'
+export type KeyboardLang = 'zh' | 'en' | ''
 
 export interface Key {
   text?: number | string // key文本
@@ -79,5 +80,9 @@ export const keyboardProps = {
   /**
    * 是否从页面中脱离出来，用于解决各种 fixed 失效问题 (H5: teleport, APP: renderjs, 小程序: root-portal)
    */
-  rootPortal: makeBooleanProp(false)
+  rootPortal: makeBooleanProp(false),
+  /**
+   * 车牌键盘语言模式
+   */
+  lang: makeStringProp<KeyboardLang>('')
 }

--- a/src/uni_modules/wot-design-uni/components/wd-keyboard/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-keyboard/types.ts
@@ -3,7 +3,7 @@ import { baseProps, makeBooleanProp, makeNumberProp, makeStringProp } from '../c
 
 export type KeyboardMode = 'default' | 'custom' | 'car'
 export type KeyType = '' | 'delete' | 'extra' | 'close'
-export type KeyboardLang = 'zh' | 'en'
+export type CarKeyboardLang = 'zh' | 'en'
 
 export interface Key {
   text?: number | string // key文本
@@ -82,7 +82,11 @@ export const keyboardProps = {
    */
   rootPortal: makeBooleanProp(false),
   /**
-   * 车牌键盘语言模式
+   * 车牌键盘语言模式 当mode=car时生效
    */
-  lang: String as PropType<KeyboardLang>
+  carLang: String as PropType<CarKeyboardLang>,
+  /**
+   * 是否自动切换车牌键盘语言 当mode=car且carLang是非受控状态时生效
+   */
+  autoSwitchLang: makeBooleanProp(false)
 }

--- a/src/uni_modules/wot-design-uni/components/wd-keyboard/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-keyboard/types.ts
@@ -3,7 +3,7 @@ import { baseProps, makeBooleanProp, makeNumberProp, makeStringProp } from '../c
 
 export type KeyboardMode = 'default' | 'custom' | 'car'
 export type KeyType = '' | 'delete' | 'extra' | 'close'
-export type KeyboardLang = 'zh' | 'en' | ''
+export type KeyboardLang = 'zh' | 'en'
 
 export interface Key {
   text?: number | string // key文本
@@ -84,5 +84,5 @@ export const keyboardProps = {
   /**
    * 车牌键盘语言模式
    */
-  lang: makeStringProp<KeyboardLang>('')
+  lang: String as PropType<KeyboardLang>
 }

--- a/src/uni_modules/wot-design-uni/components/wd-keyboard/wd-keyboard.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-keyboard/wd-keyboard.vue
@@ -60,7 +60,7 @@ import type { NumberKeyType } from './key/types'
 import { CAR_KEYBOARD_AREAS, CAR_KEYBOARD_KEYS } from './constants'
 
 const props = defineProps(keyboardProps)
-const emit = defineEmits(['update:visible', 'input', 'close', 'delete', 'update:modelValue', 'update:lang'])
+const emit = defineEmits(['update:visible', 'input', 'close', 'delete', 'update:modelValue', 'update:carLang'])
 const slots = useSlots()
 
 const show = ref(props.visible)
@@ -171,7 +171,7 @@ const handlePress = (text: string, type: NumberKeyType) => {
     } else if (text === 'ABC' || text === '省份') {
       const newLang = carKeyboardLang.value === 'zh' ? 'en' : 'zh'
       if (props.carLang) {
-        emit('update:lang', newLang)
+        emit('update:carLang', newLang)
       } else {
         carKeyboardLang.value = newLang
       }

--- a/src/uni_modules/wot-design-uni/components/wd-keyboard/wd-keyboard.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-keyboard/wd-keyboard.vue
@@ -55,7 +55,7 @@ export default {
 import { computed, ref, watch, useSlots } from 'vue'
 import wdPopup from '../wd-popup/wd-popup.vue'
 import WdKey from './key/index.vue'
-import { keyboardProps, type Key, type KeyboardLang } from './types'
+import { keyboardProps, type Key, type CarKeyboardLang } from './types'
 import type { NumberKeyType } from './key/types'
 import { CAR_KEYBOARD_AREAS, CAR_KEYBOARD_KEYS } from './constants'
 
@@ -71,11 +71,11 @@ watch(
   }
 )
 
-const internalLang = ref<KeyboardLang>('zh')
+const carLang = ref<CarKeyboardLang>('zh')
 const carKeyboardLang = computed({
-  get: () => (props.lang ? props.lang : internalLang.value),
-  set: (value: KeyboardLang) => {
-    internalLang.value = value
+  get: () => (props.carLang ? props.carLang : carLang.value),
+  set: (value: CarKeyboardLang) => {
+    carLang.value = value
   }
 })
 
@@ -148,7 +148,7 @@ function genCarKeys(): Array<Key> {
   const [keys, remainKeys] = splitCarKeys()
   return [
     ...keys,
-    { text: carKeyboardLang.value === 'zh' ? 'ABC' : '返回', type: 'extra', wider: true },
+    { text: carKeyboardLang.value === 'zh' ? 'ABC' : '省份', type: 'extra', wider: true },
     ...remainKeys,
     { text: props.deleteText, type: 'delete', wider: true }
   ]
@@ -168,9 +168,9 @@ const handlePress = (text: string, type: NumberKeyType) => {
   if (type === 'extra') {
     if (text === '') {
       return handleClose()
-    } else if (text === 'ABC' || text === '返回') {
+    } else if (text === 'ABC' || text === '省份') {
       const newLang = carKeyboardLang.value === 'zh' ? 'en' : 'zh'
-      if (props.lang) {
+      if (props.carLang) {
         emit('update:lang', newLang)
       } else {
         carKeyboardLang.value = newLang
@@ -184,7 +184,7 @@ const handlePress = (text: string, type: NumberKeyType) => {
     emit('delete')
     const newValue = value.slice(0, value.length - 1)
     emit('update:modelValue', newValue)
-    if (props.mode === 'car' && newValue.length === 0) {
+    if (props.mode === 'car' && newValue.length === 0 && props.autoSwitchLang) {
       carKeyboardLang.value = 'zh'
     }
   } else if (type === 'close') {
@@ -193,7 +193,7 @@ const handlePress = (text: string, type: NumberKeyType) => {
     emit('input', text)
     const newValue = value + text
     emit('update:modelValue', newValue)
-    if (props.mode === 'car' && newValue.length === 1) {
+    if (props.mode === 'car' && newValue.length === 1 && props.autoSwitchLang) {
       // 输入第一位（省份）后，自动切换到英文
       carKeyboardLang.value = 'en'
     }

--- a/src/uni_modules/wot-design-uni/components/wd-keyboard/wd-keyboard.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-keyboard/wd-keyboard.vue
@@ -71,7 +71,7 @@ watch(
   }
 )
 
-const internalLang = ref<KeyboardLang>(props.lang ? props.lang : 'zh')
+const internalLang = ref<KeyboardLang>('zh')
 const carKeyboardLang = computed({
   get: () => (props.lang ? props.lang : internalLang.value),
   set: (value: KeyboardLang) => {
@@ -184,11 +184,8 @@ const handlePress = (text: string, type: NumberKeyType) => {
     emit('delete')
     const newValue = value.slice(0, value.length - 1)
     emit('update:modelValue', newValue)
-
-    if (props.mode === 'car') {
-      if (newValue.length === 0) {
-        carKeyboardLang.value = 'zh'
-      }
+    if (props.mode === 'car' && newValue.length === 0) {
+      carKeyboardLang.value = 'zh'
     }
   } else if (type === 'close') {
     handleClose()
@@ -196,12 +193,9 @@ const handlePress = (text: string, type: NumberKeyType) => {
     emit('input', text)
     const newValue = value + text
     emit('update:modelValue', newValue)
-
-    if (props.mode === 'car') {
-      if (newValue.length === 1) {
-        // 输入第一位（省份）后，自动切换到英文
-        carKeyboardLang.value = 'en'
-      }
+    if (props.mode === 'car' && newValue.length === 1) {
+      // 输入第一位（省份）后，自动切换到英文
+      carKeyboardLang.value = 'en'
     }
   }
 }


### PR DESCRIPTION
- 新增 KeyboardLang 类型，用于定义键盘语言
- 在 keyboardProps 中添加 lang 属性，用于设置初始语言
- 实现车牌键盘在中文和英文之间切换的功能
- 优化车牌键盘的使用体验：
  - 输入第一位（省份）后，自动切换到英文键盘
  - 删除所有输入后，切换回中文键盘
- 当 lang 属性存在时，通过 emit 触发 update:lang 事件来同步语言状态

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [x] 站点、文档改进
- [x] 演示代码改进
- [ ] 组件样式/交互改进
- [x] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [x] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/Moonofweisheng/wot-design-uni/issues/1275

### 💡 需求背景和解决方案

在输入车牌时，输入完第一个汉语字符后，自动切换到英语键盘，不需要用户手动切换；
当用户点击车牌输入框的第一个输入框切换到汉语键盘，非第一个输入框切换到英语键盘；
也可以由用户自由切换英汉键盘

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 新增第二个车牌键盘，可分别输入并独立控制两段车牌信息（受控/非受控均支持）。
  - 车牌键盘支持语言模式（zh/en），可由外部受控或内部自动切换；新增语言双向同步事件。
  - 支持可选的数字键随机排序以增强输入安全性。
- 文案
  - 中/英文文案细化，区分“车牌键盘（非受控）”与“车牌键盘（受控）”，并在文档中新增受控模式示例与属性说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->