### PR TITLE
feat: ✨ Cell 新增 icon-size 属性用于指定左侧图标大小

### DIFF
--- a/docs/component/cell.md
+++ b/docs/component/cell.md
@@ -251,6 +251,7 @@ function handleSwitchChange({ value }) {
 | title       | 标题                           | string  | -      | -      | -        |
 | value       | 右侧内容                       | string  | -      | -      | -        |
 | icon        | 图标类名                       | string  | -      | -      | -        |
+| icon-size   | 图标大小                       | string \| number  | -      | -      | $LOWEST_VERSION$ |
 | label       | 描述信息                       | string  | -      | -      | -        |
 | is-link     | 是否为跳转链接                 | boolean | -      | false  | -        |
 | to          | 跳转地址                       | string  | -      | -      | -        |

--- a/docs/component/icon.md
+++ b/docs/component/icon.md
@@ -70,7 +70,7 @@
 |-----|------|-----|-------|-------|---------|
 | name | 图标名称或图片链接 |	string | - | - | - |
 | color	| 图标的颜色 | string |	- |	inherit | - |
-| size | 图标的字体大小 | string | - | inherit | - |
+| size | 图标的字体大小 | string \| number | - | inherit | - |
 | classPrefix | 类名前缀，用于使用自定义图标 | string | - | 'wd-icon' | 0.1.27 |
 | custom-style | 根节点样式 | string | - | - | - |
 

--- a/docs/en-US/component/cell.md
+++ b/docs/en-US/component/cell.md
@@ -105,6 +105,7 @@ The `center` attribute sets whether the left and right content of the cell is ve
 | title | Left title | string | - | - |
 | value | Right content | string | - | - |
 | icon | Left icon class name, see Icon component for optional values | string | - | - |
+| icon-size | Icon size | string \| number | - | $LOWEST_VERSION$ |
 | icon-prefix | Icon class name prefix, same as Icon component | string | 'wd-icon' | - |
 | label | Description below the title | string | - | - |
 | is-link | Whether to show the right arrow and click effect | boolean | false | - |

--- a/docs/en-US/component/icon.md
+++ b/docs/en-US/component/icon.md
@@ -54,7 +54,7 @@ Set the `name` attribute to an image URL to use image icons. The component autom
 | ------------ | ------------------------ | ------ | ------- | ------- |
 | name         | Icon name or image URL   | string | -       | -       |
 | color        | Icon color               | string | -       | -       |
-| size         | Icon size                | string | -       | -       |
+| size         | Icon size                | string \| number | -       | -       |
 | class-prefix | Custom icon class prefix | string | wd-icon | -       |
 | custom-style | Custom root node style   | string | -       | -       |
 

--- a/src/uni_modules/wot-design-uni/components/wd-cell/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-cell/types.ts
@@ -1,5 +1,5 @@
 import type { ExtractPropTypes } from 'vue'
-import { baseProps, makeArrayProp, makeBooleanProp, makeStringProp, makeNumericProp } from '../common/props'
+import { baseProps, makeArrayProp, makeBooleanProp, makeStringProp, makeNumericProp, numericProp } from '../common/props'
 
 import { type FormItemRule } from '../wd-form/types'
 
@@ -17,6 +17,10 @@ export const cellProps = {
    * 图标类名
    */
   icon: String,
+  /**
+   * 图标大小
+   */
+  iconSize: numericProp,
   /**
    * 描述信息
    */

--- a/src/uni_modules/wot-design-uni/components/wd-cell/wd-cell.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-cell/wd-cell.vue
@@ -11,7 +11,7 @@
         <text v-if="isRequired && markerSide === 'before'" class="wd-cell__required wd-cell__required--left">*</text>
         <!--左侧icon部位-->
         <slot name="icon">
-          <wd-icon v-if="icon" :name="icon" :custom-class="`wd-cell__icon  ${customIconClass}`"></wd-icon>
+          <wd-icon v-if="icon" :name="icon" :size="iconSize" :custom-class="`wd-cell__icon  ${customIconClass}`"></wd-icon>
         </slot>
 
         <view class="wd-cell__title">

--- a/src/uni_modules/wot-design-uni/components/wd-datetime-picker/wd-datetime-picker.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-datetime-picker/wd-datetime-picker.vue
@@ -167,6 +167,7 @@ export default {
 import wdPopup from '../wd-popup/wd-popup.vue'
 import wdDatetimePickerView from '../wd-datetime-picker-view/wd-datetime-picker-view.vue'
 import wdCell from '../wd-cell/wd-cell.vue'
+import wdIcon from '../wd-icon/wd-icon.vue'
 import { computed, getCurrentInstance, nextTick, onBeforeMount, onMounted, ref, watch } from 'vue'
 import { deepClone, isArray, isDef, isEqual, isFunction, padZero } from '../common/util'
 import { type DatetimePickerViewInstance, type DatetimePickerViewColumnType, type DatetimePickerViewExpose } from '../wd-datetime-picker-view/types'


### PR DESCRIPTION
✅ Closes: #1088

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
#1088
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
 Cell 新增 icon-size 属性用于指定左侧图标大小
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新增功能
  * Cell 组件新增 icon-size 属性，支持自定义左侧图标大小，接受字符串或数值。
* 文档
  * 更新 Cell 与 Icon 文档，明确 icon-size/size 支持 string | number，并补充版本信息与属性说明。
* 杂务
  * 优化图标组件的本地引入以确保正常解析与使用，不影响对外接口与行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->