### PR TITLE
feat(rate): 支持清空评分，评分支持滑动为0

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-rate/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-rate/types.ts
@@ -92,5 +92,12 @@ export const rateProps = {
    * 类型: boolean
    * 默认值: false
    */
-  allowHalf: makeBooleanProp(false)
+  allowHalf: makeBooleanProp(false),
+
+  /**
+   * 是否允许评分为0
+   * 类型: boolean
+   * 默认值: false
+   */
+  allowZero: makeBooleanProp(false)
 }

--- a/src/uni_modules/wot-design-uni/components/wd-rate/wd-rate.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-rate/wd-rate.vue
@@ -142,7 +142,9 @@ async function onTouchMove(event: TouchEvent) {
   const { clientX } = event.touches[0]
   const rateItems = await getRect('.wd-rate__item', true, proxy)
   if (rateItems.length && clientX < rateItems[0].left!) {
-    changeRate(-1, false)
+    if (props.allowZero) {
+      changeRate(-1, false)
+    }
     return
   }
 


### PR DESCRIPTION
- 在 changeRate 函数中增加判断，当 index 为 -1 时设置 value 为 0
- 在 onTouchMove 函数中，当 clientX 小于第一个评分项的 left 时，调用 changeRate(-1, false)

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/Moonofweisheng/wot-design-uni/issues/1293

### 💡 需求背景和解决方案

取消评分的情况


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 新增允许评分为 0 的配置项，支持按需开启 0 分评分行为。

* **Bug Fixes**
  * 修复在左滑超出首个星时未重置为 0 分的问题，现会正确归零。
  * 修复触摸滑动在只读或禁用状态下仍响应的问题，交互现已被忽略。
  * 优化边界与半星计算，避免出现负值或异常评分，提升交互稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->