### PR TITLE
feat: 日期支持点击回调、自定义样式、自定义元数据

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-calendar-view/month/month.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-calendar-view/month/month.vue
@@ -11,12 +11,12 @@
             :class="`wd-month__day ${item.disabled ? 'is-disabled' : ''} ${item.isLastRow ? 'is-last-row' : ''} ${
               item.type ? dayTypeClass(item.type) : ''
             }`"
-            :style="index === 0 ? firstDayStyle : ''"
+            :style="[index === 0 ? firstDayStyle : '', item.customStyle]"
             @click="handleDateClick(index)"
           >
-            <view class="wd-month__day-container">
+            <view class="wd-month__day-container" :class="item.customDayClass">
               <view class="wd-month__day-top">{{ item.topInfo }}</view>
-              <view class="wd-month__day-text">
+              <view class="wd-month__day-text" :class="item.customTextClass">
                 {{ item.text }}
               </view>
               <view class="wd-month__day-bottom">{{ item.bottomInfo }}</view>
@@ -60,7 +60,8 @@ import type { CalendarDayItem, CalendarDayType } from '../types'
 import { monthProps } from './types'
 
 const props = defineProps(monthProps)
-const emit = defineEmits(['change'])
+
+const emit = defineEmits(['change', 'date-click'])
 
 const { translate } = useTranslate('calendar-view')
 
@@ -237,6 +238,12 @@ function getWeekValue() {
 }
 function handleDateClick(index: number) {
   const date = days.value[index]
+
+  if (date.clickAble) {
+    emit('date-click', date)
+    return
+  }
+
   switch (props.type) {
     case 'date':
     case 'datetime':

--- a/src/uni_modules/wot-design-uni/components/wd-calendar-view/monthPanel/month-panel.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-calendar-view/monthPanel/month-panel.vue
@@ -28,6 +28,7 @@
           :default-time="defaultTime"
           :showTitle="index !== 0"
           @change="handleDateChange"
+          @date-click="handleDateClick"
         />
       </view>
     </scroll-view>
@@ -69,10 +70,10 @@ import { compareMonth, formatMonthTitle, getMonthEndDay, getMonths, getTimeData,
 import Month from '../month/month.vue'
 import { monthPanelProps, type MonthInfo, type MonthPanelTimeType, type MonthPanelExpose } from './types'
 import { useTranslate } from '../../composables/useTranslate'
-import type { CalendarItem } from '../types'
+import type { CalendarDayItem, CalendarItem } from '../types'
 
 const props = defineProps(monthPanelProps)
-const emit = defineEmits(['change', 'pickstart', 'pickend'])
+const emit = defineEmits(['change', 'date-click', 'pickstart', 'pickend'])
 
 const { translate } = useTranslate('calendar-view')
 
@@ -290,6 +291,9 @@ function setTime(value: number | (number | null)[], type?: MonthPanelTimeType) {
   }
   timeType.value = type || ''
   timeValue.value = getTimeValue(value, type || '')
+}
+function handleDateClick(obj: CalendarDayItem) {
+  emit('date-click', obj)
 }
 function handleDateChange({ value, type }: { value: number | (number | null)[]; type?: MonthPanelTimeType }) {
   if (!isEqual(value, props.value)) {

--- a/src/uni_modules/wot-design-uni/components/wd-calendar-view/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-calendar-view/types.ts
@@ -73,6 +73,14 @@ export type CalendarViewProps = ExtractPropTypes<typeof calendarViewProps>
 export type CalendarDayType = '' | 'start' | 'middle' | 'end' | 'selected' | 'same' | 'current' | 'multiple-middle' | 'multiple-selected'
 
 export type CalendarDayItem = {
+  meta?: {
+    [k: string]: any
+  } | null
+  clickAble?: boolean
+  color?: string
+  customStyle?: string
+  customDayClass?: string
+  customTextClass?: string
   date: number
   text?: number | string
   topInfo?: string

--- a/src/uni_modules/wot-design-uni/components/wd-calendar-view/wd-calendar-view.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-calendar-view/wd-calendar-view.vue
@@ -12,7 +12,7 @@
       :range-prompt="rangePrompt"
       :allow-same-day="allowSameDay"
       :show-panel-title="showPanelTitle"
-      :default-time="formatDefauleTime"
+      :default-time="formatDefaultTime"
       :panel-height="panelHeight"
       @change="handleChange"
     />
@@ -29,12 +29,13 @@
       :range-prompt="rangePrompt"
       :allow-same-day="allowSameDay"
       :show-panel-title="showPanelTitle"
-      :default-time="formatDefauleTime"
+      :default-time="formatDefaultTime"
       :panel-height="panelHeight"
       :immediate-change="immediateChange"
       :time-filter="timeFilter"
       :hide-second="hideSecond"
       @change="handleChange"
+      @date-click="handleDateClick"
       @pickstart="handlePickStart"
       @pickend="handlePickEnd"
     />
@@ -57,10 +58,11 @@ import { getDefaultTime } from './utils'
 import yearPanel from './yearPanel/year-panel.vue'
 import MonthPanel from './monthPanel/month-panel.vue'
 import { calendarViewProps, type CalendarViewExpose } from './types'
+import type { CalendarDayItem } from './types'
 
 const props = defineProps(calendarViewProps)
-const emit = defineEmits(['change', 'update:modelValue', 'pickstart', 'pickend'])
-const formatDefauleTime = ref<number[][]>([])
+const emit = defineEmits(['change', 'date-click', 'update:modelValue', 'pickstart', 'pickend'])
+const formatDefaultTime = ref<number[][]>([])
 
 const yearPanelRef = ref()
 const monthPanelRef = ref()
@@ -68,7 +70,7 @@ const monthPanelRef = ref()
 watch(
   () => props.defaultTime,
   (newValue) => {
-    formatDefauleTime.value = getDefaultTime(newValue)
+    formatDefaultTime.value = getDefaultTime(newValue)
   },
   {
     deep: true,
@@ -86,6 +88,10 @@ function scrollIntoView() {
 
 function getPanel() {
   return props.type.indexOf('month') > -1 ? yearPanelRef.value : monthPanelRef.value
+}
+
+function handleDateClick(obj: CalendarDayItem) {
+  emit('date-click', obj)
 }
 
 function handleChange({ value }: { value: number | number[] | null }) {


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

1. 解决了日历仅作为数据回显时无法进行交互的问题
2. 使用方法
`<wd-calendar-view :formatter="dayFormatter" @date-click="你的逻辑" />
`
在 `dayFormatter` 中处理数据结构
3. 效果
<img width="399" height="629" alt="image" src="https://github.com/user-attachments/assets/777d81f3-fd0b-45bb-8776-9434b43eef42" />


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新功能
  * 新增 date-click 事件：点击可点击的日期即触发，事件从月视图透传至月面板与日历组件，便于自定义交互。
  * 月视图增强：支持为单个日期设置自定义样式与类名（日期容器与文字），可实现高亮、标记、着色等效果。
  * 日期项能力增强：支持可点击、颜色与自定义样式/类名及元数据等扩展属性，呈现与控制更灵活。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->