### PR TITLE
feat(wd-fab): 添加自定义位置和偏移量支持，修复关闭拖拽后，菜单弹出方向未更新回来的bug

### DIFF
--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -424,6 +424,8 @@
   "fa-xue-0": "jurisprudence",
   "fab-title": "Fab",
   "fab-xuan-fu-an-niu": "Fab",
+  "fab-zi-ding-yi-wei-zhi": "Custom Position",
+  "fab-pian-yi-liang": "Offset",
   "fade-dong-hua": "Fade animation",
   "fan-hui": "return",
   "fan-hui-shang-ji": "Return to the superior",

--- a/src/locale/zh-CN.json
+++ b/src/locale/zh-CN.json
@@ -424,6 +424,8 @@
   "fa-xue-0": "法学",
   "fab-title": "Fab 悬浮按钮",
   "fab-xuan-fu-an-niu": "Fab 悬浮按钮",
+  "fab-zi-ding-yi-wei-zhi": "自定义位置",
+  "fab-pian-yi-liang": "偏移量",
   "fade-dong-hua": "Fade 动画",
   "fan-hui": "返回",
   "fan-hui-shang-ji": "返回上级",

--- a/src/subPages/fab/Index.vue
+++ b/src/subPages/fab/Index.vue
@@ -21,7 +21,21 @@
           <wd-radio value="bottom-center" custom-class="custom-radio">{{ $t('xia-zhong') }}</wd-radio>
           <wd-radio value="left-bottom" custom-class="custom-radio">{{ $t('zuo-xia') }}</wd-radio>
           <wd-radio value="right-bottom" custom-class="custom-radio">{{ $t('you-xia') }}</wd-radio>
+          <wd-radio value="custom" custom-class="custom-radio">{{ $t('zi-ding-yi') }}</wd-radio>
         </wd-radio-group>
+      </demo-block>
+      <demo-block v-if="position === 'custom'" :title="$t('fab-zi-ding-yi-wei-zhi') + ' ' + $t('fab-pian-yi-liang')">
+        <view class="custom-position-controls">
+          <view class="control-item">
+            <text class="control-label">X {{ $t('fab-pian-yi-liang') }}: {{ offsetX }}</text>
+            <wd-slider v-model="offsetX" :min="0" :max="maxOffsetX" />
+          </view>
+          <view class="control-item">
+            <text class="control-label">Y {{ $t('fab-pian-yi-liang') }}: {{ offsetY }}</text>
+            <wd-slider v-model="offsetY" :min="0" :max="100" />
+          </view>
+        </view>
+        <wd-button @click="reRenderFab">重新渲染</wd-button>
       </demo-block>
       <demo-block :title="$t('cai-dan-dan-chu-fang-xiang')">
         <wd-radio-group v-model="direction" inline shape="dot">
@@ -55,13 +69,17 @@
       </demo-block>
       <wd-fab
         v-if="!useTriggerSlot"
+        :key="fabKey"
         v-model:active="active"
         :disabled="disabled"
         :type="type"
         :position="position"
         :direction="direction"
         :draggable="draggable"
+        :offset-x="position === 'custom' ? offsetX : undefined"
+        :offset-y="position === 'custom' ? offsetY : undefined"
         @click="showToast('我被点了')"
+        custom-class="fab-demo"
       >
         <wd-button @click="showToast('一键三连')" :disabled="disabled" custom-class="custom-button" type="primary" round>
           <wd-icon name="github-filled" size="22px"></wd-icon>
@@ -77,7 +95,6 @@
           <wd-icon name="thumb-up" size="22px"></wd-icon>
         </wd-button>
       </wd-fab>
-
       <wd-fab v-else position="left-bottom" :draggable="draggable" :expandable="false">
         <template #trigger>
           <wd-button @click="handleCustomClick" icon="share" type="error">{{ $t('fen-xiang-gei-peng-you') }}</wd-button>
@@ -94,18 +111,28 @@ const { t } = useI18n()
 const { show: showToast } = useToast()
 const active = ref<boolean>(false)
 const type = ref<'primary' | 'success' | 'info' | 'warning' | 'error' | 'default'>('primary')
-const position = ref<'left-top' | 'right-top' | 'left-bottom' | 'right-bottom' | 'left-center' | 'right-center' | 'top-center' | 'bottom-center'>(
-  'left-bottom'
-)
+const position = ref<
+  'left-top' | 'right-top' | 'left-bottom' | 'right-bottom' | 'left-center' | 'right-center' | 'top-center' | 'bottom-center' | 'custom'
+>('custom')
+
 const direction = ref<'top' | 'right' | 'bottom' | 'left'>('top')
 const disabled = ref<boolean>(false)
 const draggable = ref<boolean>(false)
 const useTriggerSlot = ref<boolean>(false)
 
 const { closeOutside } = useQueue()
-
+const fabKey = ref<number>(0)
+const sysInfo = uni.getSystemInfoSync()
+const offsetX = ref<number>(0)
+const offsetY = ref<number>(0)
+const maxOffsetX = sysInfo.windowWidth
+const maxOffsetY = sysInfo.windowHeight
 function handleCustomClick() {
   showToast(t('fen-xiang-gei-peng-you-0'))
+}
+
+function reRenderFab() {
+  fabKey.value++
 }
 </script>
 <style lang="scss" scoped>
@@ -124,10 +151,12 @@ function handleCustomClick() {
     border-radius: 16px !important;
     margin: 8rpx;
   }
-
   :deep(.custom-radio) {
     height: 32px !important;
     line-height: 32px !important;
   }
+}
+.fab-demo {
+  padding: 60px;
 }
 </style>

--- a/src/subPages/fab/Index.vue
+++ b/src/subPages/fab/Index.vue
@@ -32,7 +32,7 @@
           </view>
           <view class="control-item">
             <text class="control-label">Y {{ $t('fab-pian-yi-liang') }}: {{ offsetY }}</text>
-            <wd-slider v-model="offsetY" :min="0" :max="100" />
+            <wd-slider v-model="offsetY" :min="0" :max="maxOffsetY" />
           </view>
         </view>
         <wd-button @click="reRenderFab">重新渲染</wd-button>

--- a/src/subPages/fab/Index.vue
+++ b/src/subPages/fab/Index.vue
@@ -79,7 +79,6 @@
         :offset-x="position === 'custom' ? offsetX : undefined"
         :offset-y="position === 'custom' ? offsetY : undefined"
         @click="showToast('我被点了')"
-        custom-class="fab-demo"
       >
         <wd-button @click="showToast('一键三连')" :disabled="disabled" custom-class="custom-button" type="primary" round>
           <wd-icon name="github-filled" size="22px"></wd-icon>
@@ -155,8 +154,5 @@ function reRenderFab() {
     height: 32px !important;
     line-height: 32px !important;
   }
-}
-.fab-demo {
-  padding: 60px;
 }
 </style>

--- a/src/uni_modules/wot-design-uni/components/wd-fab/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-fab/types.ts
@@ -3,7 +3,16 @@ import { baseProps, makeBooleanProp, makeNumberProp, makeStringProp } from '../c
 import type { PropType } from 'vue'
 
 export type FabType = 'primary' | 'success' | 'info' | 'warning' | 'error' | 'default'
-export type FabPosition = 'left-top' | 'right-top' | 'left-bottom' | 'right-bottom' | 'left-center' | 'right-center' | 'top-center' | 'bottom-center'
+export type FabPosition =
+  | 'left-top'
+  | 'right-top'
+  | 'left-bottom'
+  | 'right-bottom'
+  | 'left-center'
+  | 'right-center'
+  | 'top-center'
+  | 'bottom-center'
+  | 'custom'
 export type FabDirection = 'top' | 'right' | 'bottom' | 'left'
 export type FabGap = Partial<Record<FabDirection, number>>
 export const fabProps = {
@@ -51,7 +60,15 @@ export const fabProps = {
   /**
    * 用于控制点击时是否展开菜单
    */
-  expandable: makeBooleanProp(true)
+  expandable: makeBooleanProp(true),
+  /**
+   * 悬浮按钮的x偏移量，在position为custom时作为初始x位置，在展开时作为展开方向的x偏移量
+   */
+  offsetX: makeNumberProp(0),
+  /**
+   * 悬浮按钮的y轴偏移量，在position为custom时作为初始y位置，在展开时作为展开方向的y偏移量
+   */
+  offsetY: makeNumberProp(0)
 }
 
 export type FabProps = ExtractPropTypes<typeof fabProps>

--- a/src/uni_modules/wot-design-uni/components/wd-fab/wd-fab.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-fab/wd-fab.vue
@@ -90,6 +90,12 @@ watch(
   () => props.position,
   () => initPosition()
 )
+watch(
+  () => props.draggable,
+  () => {
+    fabDirection.value = props.direction
+  }
+)
 
 const top = ref<number>(0)
 const left = ref<number>(0)
@@ -160,6 +166,14 @@ function initPosition() {
       top.value = maxTop
       left.value = centerX
       break
+    case 'custom': {
+      // 自定义初始化位置逻辑，使用offsetX和offsetY，并判断是否超过边界
+      const customTop = minTop + (props.offsetY || 0)
+      const customLeft = minLeft + (props.offsetX || 0)
+      top.value = Math.max(minTop, Math.min(customTop, maxTop))
+      left.value = Math.max(minLeft, Math.min(customLeft, maxLeft))
+      break
+    }
   }
 }
 


### PR DESCRIPTION
<!--
请务必阅读 `https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md`
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

[wd-fab组件可拖动记忆。 #1310 ](https://github.com/Moonofweisheng/wot-design-uni/issues/1310)
[ Fab 悬浮按钮添加 offset 属性 #811 ](https://github.com/Moonofweisheng/wot-design-uni/issues/811)
[Fab组件支持自定义初始位置 #660 ](https://github.com/Moonofweisheng/wot-design-uni/issues/660)


### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

**需求背景：**
- FAB组件需要支持自定义位置和偏移量，以满足不同场景下的定位需求
- 修复关闭拖拽功能后，菜单弹出方向未正确更新的bug

**解决方案：**
- 新增 `custom` 定位类型，支持通过 `offsetX` 和 `offsetY` 属性自定义FAB组件的初始位置
- 修复 `watch` 监听器，确保 `draggable` 属性变化时正确更新 `fabDirection`

**API变更：**
- 新增 `offsetX`: 自定义X轴偏移量（number类型）
- 新增 `offsetY`: 自定义Y轴偏移量（number类型）

**代码变更：**
- `/d:/code-open/wot-design-uni/src/uni_modules/wot-design-uni/components/wd-fab/wd-fab.vue#L169-176`: 添加自定义位置初始化逻辑
- `/d:/code-open/wot-design-uni/src/uni_modules/wot-design-uni/components/wd-fab/wd-fab.vue#L93-98`: 修复菜单弹出方向更新逻辑

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - FAB 支持“自定义位置”，可通过 offsetX/offsetY 精确定位，并按屏幕尺寸自动限制偏移范围。
  - 新增本地化文案（en-US/zh-CN）：“自定义位置”“偏移量”。

- 文档/示例
  - FAB 示例页新增自定义位置演示与 X/Y 偏移滑块，支持重渲染即时查看效果。

- Bug 修复
  - 修复切换可拖拽状态时方向不同步的问题，现与当前方向设置保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->