### PR TITLE
docs: 修复 starter 地址错误

### DIFF
--- a/docs/.vitepress/locales/en-US.ts
+++ b/docs/.vitepress/locales/en-US.ts
@@ -84,7 +84,7 @@ export default defineConfig({
       { text: 'Blog', link: 'https://blog.wot-ui.cn/' },
       {
         text: 'Templates', items: [
-          { text: 'Quick Start Template wot-starter', link: 'https://start.wot-ui.cn/' },
+          { text: 'Quick Start Template wot-starter', link: 'https://starter.wot-ui.cn/' },
           { text: 'vitesse-uni-app', link: 'https://vitesse-docs.netlify.app/' },
           { text: 'wot-starter-retail', link: 'https://github.com/wot-ui/wot-starter-retail' },
           { text: 'unibest', link: 'https://unibest.tech/' },
@@ -92,7 +92,7 @@ export default defineConfig({
       },
       {
         text: 'Resources', items: [
-          { text: 'Quick Start Template', link: 'https://start.wot-ui.cn/' },
+          { text: 'Quick Start Template', link: 'https://starter.wot-ui.cn/' },
           { text: 'Vue3 uni-app Router', link: 'https://moonofweisheng.github.io/uni-mini-router/' },
           { text: 'Mini Program CI Tool', link: 'https://github.com/Moonofweisheng/uni-mini-ci' },
           { text: 'Uni Helper', link: 'https://uni-helper.js.org/' },

--- a/docs/.vitepress/locales/zh-CN.ts
+++ b/docs/.vitepress/locales/zh-CN.ts
@@ -88,7 +88,7 @@ export default defineConfig({
       { text: '博客', link: 'https://blog.wot-ui.cn/' },
       {
         text: '模板', items: [
-          { text: '快速上手模板 wot-starter', link: 'https://start.wot-ui.cn/' },
+          { text: '快速上手模板 wot-starter', link: 'https://starter.wot-ui.cn/' },
           { text: 'vitesse-uni-app', link: 'https://vitesse-docs.netlify.app/' },
           { text: 'wot-starter-retail', link: 'https://github.com/wot-ui/wot-starter-retail' },
           { text: 'unibest', link: 'https://unibest.tech/' },
@@ -96,7 +96,7 @@ export default defineConfig({
       },
       {
         text: '资源', items: [
-          { text: '快速上手模板', link: 'https://start.wot-ui.cn/' },
+          { text: '快速上手模板', link: 'https://starter.wot-ui.cn/' },
           { text: 'Vue3 uni-app路由库', link: 'https://moonofweisheng.github.io/uni-mini-router/' },
           { text: '多平台小程序CI工具', link: 'https://github.com/Moonofweisheng/uni-mini-ci' },
           { text: 'Uni Helper', link: 'https://uni-helper.js.org/' },


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 文档
  * 将中英文站点导航中“快速上手模板”的链接统一更新为 https://starter.wot-ui.cn/（原为 https://start.wot-ui.cn/），覆盖“模板”和“资源”分组。
* 其他
  * 无功能或结构性变化，纯链接修正以提升可用性与准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->