### PR TITLE
feat: wd-upload组件的submit新增promise返回

### DIFF
--- a/docs/component/upload.md
+++ b/docs/component/upload.md
@@ -739,7 +739,7 @@ count 值在 H5 平台的表现基于浏览器本身的规范。目前测试结�
 
 | 方法名称 | 说明         | 参数 | 最低版本         |
 | -------- | ------------ | ---- | ---------------- |
-| submit   | 手动开始上传 | -    | 1.3.8 |
+| submit   | 手动开始上传 | Promise<{ success: boolean; fileList: UploadFile[] }> success 为所有待上传文件均成功, 'fileList' 为上传图片列表 | 1.12.4 |
 
 ## Upload 外部样式类
 

--- a/src/uni_modules/wot-design-uni/components/wd-upload/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-upload/types.ts
@@ -351,7 +351,7 @@ export type UploadExpose = {
   /**
    * 手动触发上传
    */
-  submit: () => void
+  submit: () => Promise<{ success: boolean; fileList: UploadFileItem[] }>
   /**
    * 取消上传
    * @param task 上传任务

--- a/src/uni_modules/wot-design-uni/components/wd-upload/wd-upload.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-upload/wd-upload.vue
@@ -133,7 +133,7 @@ const emit = defineEmits<{
 }>()
 
 defineExpose<UploadExpose>({
-  submit: () => startUploadFiles(),
+  submit: () => startUploadFiles(), // 这里会返回 Promise
   abort: () => abort()
 })
 
@@ -261,54 +261,84 @@ function emitFileList() {
 }
 
 /**
- *  开始上传文件
+ *  开始上传文件，返回 Promise
  */
-function startUploadFiles() {
-  const { buildFormData, formData = {}, statusKey } = props
-  const { action, name, header = {}, accept, successStatus, uploadMethod } = props
-  const statusCode = isDef(successStatus) ? successStatus : 200
+function startUploadFiles(): Promise<{ success: boolean; fileList: UploadFileItem[] }> {
+  return new Promise((resolve) => {
+    const { buildFormData, formData = {}, statusKey } = props
+    const { action, name, header = {}, accept, successStatus, uploadMethod } = props
+    const statusCode = isDef(successStatus) ? successStatus : 200
 
-  for (const uploadFile of uploadFiles.value) {
-    // 仅开始未上传的文件
-    if (uploadFile[statusKey] === UPLOAD_STATUS.PENDING) {
-      if (buildFormData) {
-        buildFormData({
-          file: uploadFile,
-          formData,
-          resolve: (formData: Record<string, any>) => {
-            formData &&
-              startUpload(uploadFile, {
-                action,
-                header,
-                name,
-                formData,
-                fileType: accept as 'image' | 'video' | 'audio',
-                statusCode,
-                statusKey,
-                uploadMethod,
-                onSuccess: handleSuccess,
-                onError: handleError,
-                onProgress: handleProgress
-              })
-          }
+    // 获取所有待上传的文件
+    const pendingFiles = uploadFiles.value.filter(file => file[statusKey] === UPLOAD_STATUS.PENDING)
+    
+    if (pendingFiles.length === 0) {
+      // 如果没有待上传的文件，直接返回成功
+      resolve({ 
+        success: uploadFiles.value.every(file => file[statusKey] === 'success'),
+        fileList: uploadFiles.value 
+      })
+      return
+    }
+
+    let completedCount = 0
+    const totalCount = pendingFiles.length
+
+    const checkCompletion = () => {
+      completedCount++
+      if (completedCount === totalCount) {
+        const allSuccess = uploadFiles.value
+          .filter(file => pendingFiles.includes(file))
+          .every(file => file[statusKey] === 'success')
+        
+        resolve({
+          success: allSuccess,
+          fileList: uploadFiles.value
         })
-      } else {
-        startUpload(uploadFile, {
+      }
+    }
+
+    // 遍历所有待上传的文件
+    for (const uploadFile of pendingFiles) {
+      const uploadSingleFile = (currentFile: UploadFileItem, customFormData?: Record<string, any>) => {
+        const finalFormData = customFormData ?? formData
+        
+        // 调用底层的 startUpload 方法，传入当前文件对象
+        startUpload(currentFile, {
           action,
           header,
           name,
-          formData,
+          formData: finalFormData,
           fileType: accept as 'image' | 'video' | 'audio',
           statusCode,
           statusKey,
           uploadMethod,
-          onSuccess: handleSuccess,
-          onError: handleError,
+          onSuccess: (res, file, formData) => {
+            handleSuccess(res, file, formData)
+            checkCompletion()
+          },
+          onError: (err, file, formData) => {
+            handleError(err, file, formData)
+            checkCompletion()
+          },
           onProgress: handleProgress
         })
       }
+
+      // 判断是否需要构建自定义表单数据
+      if (buildFormData) {
+        buildFormData({
+          file: uploadFile,
+          formData,
+          resolve: (customFormData?: Record<string, any>) => {
+            uploadSingleFile(uploadFile, customFormData)
+          }
+        })
+      } else {
+        uploadSingleFile(uploadFile)
+      }
     }
-  }
+  })
 }
 
 /**

--- a/tests/components/wd-upload.test.ts
+++ b/tests/components/wd-upload.test.ts
@@ -123,15 +123,39 @@ describe('WdUpload', () => {
     expect((wrapper.vm as any).autoUpload).toBe(true)
   })
 
-  test('手动上传功能', () => {
-    // 直接测试手动上传功能，不依赖组件实例
-    const startUploadFilesSpy = vi.fn()
+  test('手动上传功能', async () => {
+    const wrapper = mount(WdUpload, {
+      props: {
+        autoUpload: false, // 关闭自动上传，便于测试手动上传
+        fileList: [
+          {
+            url: 'https://example.com/image1.jpg',
+            name: 'image1.jpg',
+            status: 'pending' // 有待上传的文件
+          }
+        ],
+        action: 'https://example.com/upload'
+      }
+    })
 
-    // 直接调用函数
-    startUploadFilesSpy()
-
-    // 验证是否被调用
-    expect(startUploadFilesSpy).toHaveBeenCalled()
+    // 调用组件暴露的submit方法
+    const resultPromise = wrapper.vm.submit()
+    
+    // 验证返回的是Promise
+    expect(resultPromise).toBeInstanceOf(Promise)
+    
+    // 等待Promise完成并验证结果结构
+    const result = await resultPromise
+    
+    // 断言返回对象的结构和内容
+    expect(result).toEqual({
+      success: expect.any(Boolean), // 可能是true或false，但必须有这个字段
+      fileList: expect.any(Array) // 必须有fileList数组
+    })
+    
+    // 可以进一步验证fileList的内容
+    expect(result.fileList).toHaveLength(1)
+    expect(result.fileList[0]).toHaveProperty('url', 'https://example.com/image1.jpg')
   })
 
   test('文件上传前钩子', async () => {


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

目前在业务中无法判断图片是否上传完成，所以在业务中提交表单时调用submit无法等待图片上传完成再提交表单


<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充