### PR TITLE
fix: 🐛 修复 Segmented 选项点击时无论是否改变选中值都会触发 change 的问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-segmented/wd-segmented.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-segmented/wd-segmented.vue
@@ -32,7 +32,7 @@ export default {
 
 <script setup lang="ts">
 import { computed, getCurrentInstance, onMounted, reactive, watch } from 'vue'
-import { getRect, isObj, objToStyle, addUnit, pause } from '../common/util'
+import { getRect, isObj, objToStyle, addUnit, pause, isEqual } from '../common/util'
 import type { CSSProperties } from 'vue'
 import { segmentedProps, type SegmentedExpose, type SegmentedOption } from './types'
 const $item = '.wd-segmented__item'
@@ -95,19 +95,28 @@ function updateActiveStyle(animation: boolean = true) {
 }
 
 /**
+ * 更新值
+ */
+function updateValue(newValue: string | number, option: string | number | SegmentedOption) {
+  if (!isEqual(newValue, props.value)) {
+    emit('update:value', newValue)
+    emit('change', isObj(option) ? option : { value: newValue })
+  }
+}
+
+/**
  * 更新当前下标
  */
 function updateCurrentIndex() {
   const index = props.options.findIndex((option: string | number | SegmentedOption) => {
     const value = isObj(option) ? option.value : option
-    return value == props.value
+    return isEqual(value, props.value)
   })
   if (index >= 0) {
     state.activeIndex = index
   } else {
     const value = isObj(props.options[0]) ? props.options[0].value : props.options[0]
-    emit('update:value', value)
-    emit('change', isObj(props.options[0]) ? props.options[0] : { value })
+    updateValue(value, props.options[0])
   }
 }
 
@@ -117,10 +126,10 @@ function handleClick(option: string | number | SegmentedOption, index: number) {
     return
   }
   const value = isObj(option) ? option.value : option
+
   state.activeIndex = index
   updateActiveStyle()
-  emit('update:value', value)
-  emit('change', isObj(option) ? option : { value })
+  updateValue(value, option)
   emit('click', isObj(option) ? option : { value })
 }
 


### PR DESCRIPTION
✅ Closes: #1323

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
#1323
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充