### PR TITLE
fix(wd-icon): 避免有size参数情况下高度被外部样式影响

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-icon/wd-icon.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-icon/wd-icon.vue
@@ -38,7 +38,9 @@ const rootStyle = computed(() => {
     style['color'] = props.color
   }
   if (props.size) {
-    style['font-size'] = addUnit(props.size)
+    const fontSize = addUnit(props.size)
+    style['font-size'] = fontSize
+    style['line-height'] = fontSize
   }
   return `${objToStyle(style)} ${props.customStyle}`
 })


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

通常传入 `size` 时，图标宽高应该与之一致，且不被外部样式影响，目前高度会被影响


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充