### PR TITLE
feat(message-box): 添加显示关闭按钮功能

### DIFF
--- a/docs/component/message-box.md
+++ b/docs/component/message-box.md
@@ -43,6 +43,25 @@ function alert() {
 }
 ```
 
+显示关闭按钮的 alert 弹框。
+
+```html
+<wd-message-box />
+<wd-button @click="showClose">showClose</wd-button>
+```
+
+```typescript
+import { useMessage } from '@/uni_modules/wot-design-uni'
+const message = useMessage()
+
+function showClose() {
+  message.alert({
+    title: '显示关闭按钮',
+    showClose: true
+  })
+}
+```
+
 如果内容文案过长，弹框高度不再增加，而是展示滚动条。
 
 ```html
@@ -259,6 +278,7 @@ MessageBox.prompt(options)
 | title                | 标题                                                                            | string          | -                        | -                | -                |
 | msg                  | 消息文案                                                                        | string          | -                        | -                | -                |
 | type                 | 弹框类型                                                                        | string          | alert / confirm / prompt | alert            | -                |
+| showClose            | 是否展示关闭按钮                                                                | boolean         | -                        | false            | -                |
 | closeOnClickModal    | 是否支持点击蒙层进行关闭，点击蒙层回调传入的 action 为'modal'                   | boolean         | -                        | true             | -                |
 | inputType            | 当 type 为 prompt 时，输入框类型                                                | string          | -                        | text             | -                |
 | inputValue           | 当 type 为 prompt 时，输入框初始值                                              | string / number | -                        | -                | -                |

--- a/docs/component/use-message.md
+++ b/docs/component/use-message.md
@@ -96,6 +96,7 @@ function prompt() {
 | title | 标题 | string | - | - |
 | msg | 消息文案 | string | - | - |
 | type | 弹框类型 | string | alert / confirm / prompt | alert |
+| showClose | 是否展示关闭按钮 | boolean | - | false |
 | closeOnClickModal | 是否支持点击蒙层进行关闭 | boolean | - | true |
 | inputType | 当type为prompt时，输入框类型 | string | - | text |
 | inputValue | 当type为prompt时，输入框初始值 | string / number | - | - |

--- a/src/subPages/messageBox/Index.vue
+++ b/src/subPages/messageBox/Index.vue
@@ -13,6 +13,10 @@
         <wd-button @click="alertWithTitle">alert</wd-button>
       </demo-block>
 
+      <demo-block :title="$t('xian-shi-guan-bi-an-niu')">
+        <wd-button @click="showClose">showClose</wd-button>
+      </demo-block>
+
       <demo-block title="confirm">
         <wd-button @click="confirm">confirm</wd-button>
       </demo-block>
@@ -59,6 +63,12 @@ function alertWithTitle() {
   message.alert({
     msg: t('ti-shi-wen-an'),
     title: t('biaoTi-0')
+  })
+}
+function showClose() {
+  message.alert({
+    title: t('xian-shi-guan-bi-an-niu'),
+    showClose: true
   })
 }
 function confirm() {

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/index.scss
@@ -18,6 +18,14 @@
         background: $-dark-border-color;
       }
     }
+    
+    @include e(close) {
+      color: $-dark-color3;
+
+      &:hover {
+        color: $-dark-color;
+      }
+    }
   }
 }
 
@@ -29,6 +37,7 @@
 @include b(message-box) {
   border-radius: $-message-box-radius;
   overflow: hidden;
+  position: relative;
 
   @include e(container) {
     width: $-message-box-width;
@@ -41,6 +50,19 @@
 
     @include when(no-title) {
       padding: 25px 24px 0px;
+    }
+  }
+
+  @include e(close) {
+    position: absolute;
+    top: 14px;
+    right: 14px;
+    color: #666;
+    cursor: pointer;
+    z-index: 1;
+    transition: all 0.2s ease;
+    &:hover {
+      color: #333;
     }
   }
 

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
@@ -191,6 +191,11 @@ function toggleModal(action: 'confirm' | 'cancel' | 'modal' | 'close') {
         action: action
       })
       break
+    case 'close':
+      handleCancel({
+        action: 'close'
+      })
+      break
     default:
       handleCancel({
         action: 'modal'

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
@@ -286,7 +286,7 @@ function reset(option: MessageOptionsWithCallBack) {
     messageState.lazyRender = option.lazyRender
     messageState.confirmButtonProps = option.confirmButtonProps
     messageState.cancelButtonProps = option.cancelButtonProps
-    messageState.showClose = option.showClose
+    messageState.showClose = isDef(option.showClose) ? option.showClose : false
   }
 }
 </script>

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
@@ -12,7 +12,9 @@
       :root-portal="rootPortal"
     >
       <view :class="rootClass">
-        <view class="wd-message-box__close" v-if="messageState.showClose" @click="toggleModal('close')"><wd-icon name="close" size="14px"></wd-icon></view>
+        <view class="wd-message-box__close" v-if="messageState.showClose" @click="toggleModal('close')">
+          <wd-icon name="close" size="14px"></wd-icon>
+        </view>
         <view :class="bodyClass">
           <view v-if="messageState.title" class="wd-message-box__title">
             {{ messageState.title }}

--- a/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-message-box/wd-message-box.vue
@@ -12,6 +12,7 @@
       :root-portal="rootPortal"
     >
       <view :class="rootClass">
+        <view class="wd-message-box__close" v-if="messageState.showClose" @click="toggleModal('close')"><wd-icon name="close" size="14px"></wd-icon></view>
         <view :class="bodyClass">
           <view v-if="messageState.title" class="wd-message-box__title">
             {{ messageState.title }}
@@ -96,7 +97,8 @@ const messageState = reactive<MessageOptionsWithCallBack>({
   inputError: '', // 输入框错误提示文案
   showErr: false, // 是否显示错误提示
   zIndex: 99, // 弹窗层级
-  lazyRender: true // 弹层内容懒渲染
+  lazyRender: true, // 弹层内容懒渲染
+  showClose: false // 是否展示关闭按钮
 })
 
 /**
@@ -155,7 +157,7 @@ watch(
  * 点击操作
  * @param action
  */
-function toggleModal(action: 'confirm' | 'cancel' | 'modal') {
+function toggleModal(action: 'confirm' | 'cancel' | 'modal' | 'close') {
   if (action === 'modal' && !messageState.closeOnClickModal) {
     return
   }
@@ -282,6 +284,7 @@ function reset(option: MessageOptionsWithCallBack) {
     messageState.lazyRender = option.lazyRender
     messageState.confirmButtonProps = option.confirmButtonProps
     messageState.cancelButtonProps = option.cancelButtonProps
+    messageState.showClose = option.showClose
   }
 }
 </script>


### PR DESCRIPTION
新增 showClose 参数控制是否显示关闭按钮，并添加相关样式和文档说明

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ x ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
https://github.com/Moonofweisheng/wot-design-uni/issues/1338

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
<img width="391" height="307" alt="image" src="https://github.com/user-attachments/assets/8617be1d-95db-4048-b542-01e4f10f317e" />


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [ x ] 文档已补充或无须补充
- [ x ] 代码演示已提供或无须提供
- [ x ] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * MessageBox 新增 showClose 选项（默认 false），可在对话框上显示可点击的关闭按钮，用户可启用以直接关闭弹窗。

* **文档**
  * 更新 MessageBox 与 useMessage 文档，补充 showClose 选项说明与示例；示例页新增“showClose”演示按钮。

* **样式**
  * 为关闭按钮添加样式与定位，保证浅色/深色主题下显示与交互一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->