### PR TITLE
style(button): 🎨 删除重复的 outline: none 声明

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-button/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-button/index.scss
@@ -47,7 +47,6 @@
   display: inline-block;
   outline: none;
   -webkit-appearance: none;
-  outline: none;
   background: transparent;
   box-sizing: border-box;
   border: none;


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [x] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

#1361

### 💡 需求背景和解决方案

1.  **问题描述**  
   在 `src/uni_modules/wot-design-uni/components/wd-button/wd-button.scss` 第 15-16 行存在**完全重复**的代码：
   ```scss
   outline: none;
   -webkit-appearance: none;
   outline: none;  // ← 多余重复

2.  **解决方案**
删除多余的一行，最终样式为：
outline: none;
-webkit-appearance: none;
减少 1 行无用代码
零副作用：不影响任何平台（H5、微信、支付宝、暗黑模式等）的显示和交互

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **样式优化**
  * 优化按钮默认样式，使焦点轮廓和浏览器原生样式显示更加清晰，改善用户交互体验和无障碍访问。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->