### PR TITLE
feat: ✨ Tabs 组件添加 show-scrollbar 属性用于控制展示滚动条

### DIFF
--- a/docs/component/tabs.md
+++ b/docs/component/tabs.md
@@ -270,6 +270,7 @@ function handlePopupShow() {
 | animated      | 是否开启切换标签内容时的转场动画                                                         | boolean         | -        | false  | -        |
 | duration      | 切换动画过渡时间，单位毫秒                                                               | number          | -        | 300    | -        |
 | slidable      | 是否开启滚动导航                                                                         | TabsSlidable    | `always` | `auto` | 1.4.0    |
+| showScrollbar | 标签可滑动时是否显示滚动条                                                               | boolean         | -        | false  | $LOWEST_VERSION$ |
 | badge-props   | 自定义徽标的属性，传入的对象会被透传给 [Badge 组件的 props](/component/badge#attributes) | BadgeProps      | -        | -      | 1.4.0    |
 
 ## Tab Attributes

--- a/docs/en-US/component/tabs.md
+++ b/docs/en-US/component/tabs.md
@@ -200,3 +200,58 @@ When `slidable` is set to `always`, all tabs will be aligned to the left and can
   </block>
 </wd-tabs>
 ```
+
+## Tabs Attributes
+
+| Parameter      | Description                                                                        | Type            | Options      | Default | Version |
+| -------------- | ---------------------------------------------------------------------------------- | --------------- | ------------ | ------- | ------- |
+| v-model        | Binding value                                                                      | string / number | -            | -       | -       |
+| slidable-num   | Threshold count of tabs to enable scrolling when `slidable` is `auto`              | number          | -            | `6`     | -       |
+| map-num        | Threshold count of tabs to show navigation map                                     | number          | -            | `10`    | -       |
+| map-title      | Title of the navigation map                                                        | string          | -            | -       | 1.4.0   |
+| sticky         | Enable sticky layout                                                               | boolean         | -            | `false` | -       |
+| offset-top     | Distance from the top when sticky                                                  | number          | -            | `0`     | -       |
+| swipeable      | Enable gesture swipe                                                               | boolean         | -            | `false` | -       |
+| autoLineWidth  | Bottom line width follows text; invalid when `lineWidth` is specified              | boolean         | -            | `false` | 1.4.0   |
+| lineWidth      | Bottom line width, unit px                                                         | number          | -            | `19`    | -       |
+| lineHeight     | Bottom line height, unit px                                                        | number          | -            | `3`     | -       |
+| color          | Text color                                                                         | string          | -            | -       | -       |
+| inactiveColor  | Text color of inactive tabs                                                        | string          | -            | -       | -       |
+| animated       | Enable transition animation when switching tab content                             | boolean         | -            | `false` | -       |
+| duration       | Transition duration in ms                                                          | number          | -            | `300`   | -       |
+| slidable       | Enable scrollable navigation                                                       | TabsSlidable    | `always`     | `auto`  | 1.4.0   |
+| showScrollbar  | Whether to show scrollbar when tabs are slidable (nav)                             | boolean         | -            | `false` | $LOWEST_VERSION$ |
+| badge-props    | Props passed to [Badge component props](/component/badge#attributes)               | BadgeProps      | -            | -       | 1.4.0   |
+
+## Tab Attributes
+
+| Parameter | Description                                                     | Type    | Options | Default | Version |
+| --------- | --------------------------------------------------------------- | ------- | ------- | ------- | ------- |
+| name      | Tab name                                                        | string  | -       | -       | -       |
+| title     | Title                                                           | string  | -       | -       | -       |
+| disabled  | Disable                                                         | boolean | -       | `false` | -       |
+| lazy      | Lazy render; when `animated` is enabled this is always `false`  | boolean | -       | `true`  | 1.4.0   |
+
+## Tabs Events
+
+| Event Name | Description             | Parameters                                                     | Version |
+| ---------- | ----------------------- | --------------------------------------------------------------- | ------- |
+| change     | Triggered when value changes | `event = { index, name }`                                   | -       |
+| click      | Triggered when title is clicked | `event = { index, name }`                               | -       |
+| disabled   | Triggered when clicking a disabled title | `event = { index, name }`                            | -       |
+
+## Methods
+
+Exposed methods
+
+| Method           | Description                                                                                   | Signature                                                              | Version |
+| ---------------- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ------- |
+| setActive        | Set active tab; params: `value` active value, `init` initialized, `setScroll` set scroll-view | `(value: number \| string, init: boolean, setScroll: boolean) => void` | -       |
+| scrollIntoView   | Scroll the selected tab into view                                                             | `() => void`                                                           | -       |
+| updateLineStyle  | Update active underline style; `animation` determines whether to animate, default enabled     | `(animation?: boolean) => void`                                        | -       |
+
+## External Classes
+
+| Class Name   | Description      | Version |
+| ------------ | ---------------- | ------- |
+| custom-class | Root node style  | -       |

--- a/src/uni_modules/wot-design-uni/components/wd-tabs/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/index.scss
@@ -66,6 +66,14 @@
   background: #fff;
   width: 100%;
 
+  @include when(hide-scrollbar) {
+    ::-webkit-scrollbar {
+      width: 0;
+      height: 0;
+      -webkit-appearance: none;
+    }
+  }
+
   @include e(nav) {
     left: 0;
     right: 0;
@@ -115,7 +123,7 @@
     @include lineEllipsis();
   }
 
-  @include edeep(nav-item-badge){
+  @include edeep(nav-item-badge) {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/uni_modules/wot-design-uni/components/wd-tabs/types.ts
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/types.ts
@@ -80,7 +80,11 @@ export const tabsProps = {
    * 可选值：'auto' | 'always'
    * @default auto
    */
-  slidable: makeStringProp<TabsSlidable>('auto')
+  slidable: makeStringProp<TabsSlidable>('auto'),
+  /**
+   * 标签可滑动时是否显示滚动条
+   */
+  showScrollbar: makeBooleanProp(false)
 }
 
 export type TabsExpose = {

--- a/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-tabs/wd-tabs.vue
@@ -2,7 +2,9 @@
   <template v-if="sticky">
     <wd-sticky-box>
       <view
-        :class="`wd-tabs ${customClass} ${innerSlidable ? 'is-slide' : ''} ${mapNum < children.length && mapNum !== 0 ? 'is-map' : ''}`"
+        :class="`wd-tabs ${customClass} ${innerSlidable ? 'is-slide' : ''} ${mapNum < children.length && mapNum !== 0 ? 'is-map' : ''} ${
+          !showScrollbar ? 'is-hide-scrollbar' : ''
+        }`"
         :style="customStyle"
       >
         <wd-sticky :offset-top="offsetTop">
@@ -75,7 +77,11 @@
   </template>
 
   <template v-else>
-    <view :class="`wd-tabs ${customClass} ${innerSlidable ? 'is-slide' : ''} ${mapNum < children.length && mapNum !== 0 ? 'is-map' : ''}`">
+    <view
+      :class="`wd-tabs ${customClass} ${innerSlidable ? 'is-slide' : ''} ${mapNum < children.length && mapNum !== 0 ? 'is-map' : ''} ${
+        !showScrollbar ? 'is-hide-scrollbar' : ''
+      }`"
+    >
       <view class="wd-tabs__nav">
         <view class="wd-tabs__nav--wrap">
           <scroll-view :scroll-x="innerSlidable" scroll-with-animation :scroll-left="state.scrollLeft">


### PR DESCRIPTION
✅ Closes: #643

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
Tabs 组件添加 show-scrollbar 属性用于控制展示滚动条
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * Tabs 组件新增 `showScrollbar` 属性，允许控制可滚动标签页时是否显示滚动条（默认关闭）。

* **文档**
  * 新增完整的 Tabs 组件文档，包括属性、事件、方法等详细说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->