### PR TITLE
修复wd-tour组件h5引入useLockScroll报错，swiper默认插槽标签补齐

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-swiper/wd-swiper.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-swiper/wd-swiper.vue
@@ -40,6 +40,7 @@
               objectFit="cover"
               @click="handleClick(index, item)"
             />
+            <slot name="default" :current="currentValue" :item="item" v-else-if="$slots.default"></slot>
             <image
               v-else
               :src="isObj(item) ? item[valueKey] : item"

--- a/src/uni_modules/wot-design-uni/components/wd-tour/wd-tour.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-tour/wd-tour.vue
@@ -61,7 +61,7 @@ export default {
 import { ref, computed, watch, nextTick } from 'vue'
 import { tourProps } from './types'
 // #ifdef H5
-import useLockScroll from '../composables/useLockScroll'
+import { useLockScroll } from '../composables/useLockScroll'
 // #endif
 
 interface ElementRect {


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能

* 轮播组件（Swiper）现已支持通过默认插槽自定义每个轮播项的内容展示。用户可以根据需要灵活地覆盖默认的图片或视频渲染方式，提升组件的灵活性和适用场景。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->