### PR TITLE
fix: 🐛 修复 Rate 组件在禁用和只读状态下可以触摸拖动调整的问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-rate/wd-rate.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-rate/wd-rate.vue
@@ -156,6 +156,7 @@ function updateValue(value: number) {
 }
 
 async function onTouchMove(event: TouchEvent) {
+  if (props.readonly || props.disabled) return
   const { clientX } = event.touches[0]
   const rateItems = await getRect('.wd-rate__item', true, proxy)
   const targetIndex = Array.from(rateItems).findIndex((rect) => {


### PR DESCRIPTION
✅ Closes: #1404

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
#1404
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
禁用和只读状态下 Rate仍可以通过触摸调整。
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- 修复评分组件在禁用或只读状态下仍响应触摸操作的问题。当组件处于禁用或只读状态时，触摸操作将不再影响评分值，提升用户体验的一致性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->