### PR TITLE
feat(wd-search):  支持禁用状态下的点击事件

### DIFF
--- a/docs/component/search.md
+++ b/docs/component/search.md
@@ -70,6 +70,12 @@ function change({ value }) {
 ```html
 <wd-search hide-cancel disabled />
 ```
+可以监听禁用状态下的点击事件。
+
+```html
+<wd-search disabled @click="handleDisabledClick" />
+```
+
 
 ## 自定义左侧插槽
 
@@ -170,6 +176,7 @@ function changeSearchType({ item, index }) {
 | clear    | 监听输入框清空按钮事件     | -           | -        |
 | cancel   | 监听输入框右侧文本点击事件 | `{ value }` | -        |
 | change   | 监听输入框内容变化事件     | `{ value }` | -        |
+| click    | 禁用状态下点击事件         | -           |  $LOWEST_VERSION$       |
 
 ## Slots
 

--- a/docs/en-US/component/search.md
+++ b/docs/en-US/component/search.md
@@ -70,6 +70,11 @@ It can be used in combination with `hide-cancel` to only display the search box 
 ```html
 <wd-search hide-cancel disabled />
 ```
+You can listen to click events in the disabled state.
+
+```html
+<wd-search disabled @click="handleDisabledClick" />
+```
 
 ## Custom Left Slot
 
@@ -169,6 +174,7 @@ Modify the input box placeholder text through the `placeholder` property and the
 | clear | Input box clear button event | - | - |
 | cancel | Input box right text click event | `{ value }` | - |
 | change | Input box content change event | `{ value }` | - |
+| click    | Click event in disabled state | -           |  $LOWEST_VERSION$       |
 
 ## Slots
 

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -675,6 +675,7 @@
   "jin-yong-jin-yong-jin-yong": "Disable, disable, disable",
   "jin-yong-jin-yong-jin-yong-0": "Disable, disable, disable",
   "jin-yong-qie-yin-cang-qu-xiao-an-niu": "Disable and hide the cancel button",
+  "jin-yong-dian-ji": "Disable state click",
   "jin-yong-shu-ru-kuang": "Disable input box",
   "jin-yong-tab": "Disable tab",
   "jin-yong-xuan-xiang": "Disable option",

--- a/src/locale/zh-CN.json
+++ b/src/locale/zh-CN.json
@@ -675,6 +675,7 @@
   "jin-yong-jin-yong-jin-yong": "禁用禁用禁用",
   "jin-yong-jin-yong-jin-yong-0": "禁用禁用禁用",
   "jin-yong-qie-yin-cang-qu-xiao-an-niu": "禁用且隐藏取消按钮",
+  "jin-yong-dian-ji": "禁用状态点击",
   "jin-yong-shu-ru-kuang": "禁用输入框",
   "jin-yong-tab": "禁用tab",
   "jin-yong-xuan-xiang": "禁用选项",

--- a/src/subPages/search/Index.vue
+++ b/src/subPages/search/Index.vue
@@ -15,7 +15,7 @@
       </demo-block>
 
       <demo-block :title="$t('jin-yong-qie-yin-cang-qu-xiao-an-niu')" transparent>
-        <wd-search disabled hide-cancel />
+        <wd-search disabled hide-cancel @click="handleDisabledClick" />
       </demo-block>
 
       <view style="margin: 15px 0; color: #666">
@@ -77,6 +77,10 @@ const menu = computed(() => {
     }
   ]
 })
+
+function handleDisabledClick() {
+  uni.showToast({ title: t('jin-yong-dian-ji') })
+}
 
 function search(e: any) {
   uni.showToast({ title: t('sou-suo') + e.value })

--- a/src/uni_modules/wot-design-uni/components/wd-search/wd-search.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-search/wd-search.vue
@@ -1,6 +1,6 @@
 <template>
   <view :class="rootClass" :style="customStyle">
-    <view class="wd-search__block">
+    <view class="wd-search__block" @click="handleClick">
       <slot name="prefix"></slot>
       <view class="wd-search__field">
         <view v-if="!placeholderLeft" :style="coverStyle" class="wd-search__cover" @click="closeCover">
@@ -55,7 +55,7 @@ import { useTranslate } from '../composables/useTranslate'
 import { searchProps } from './types'
 
 const props = defineProps(searchProps)
-const emit = defineEmits(['update:modelValue', 'change', 'clear', 'search', 'focus', 'blur', 'cancel'])
+const emit = defineEmits(['update:modelValue', 'change', 'clear', 'search', 'focus', 'blur', 'cancel', 'click'])
 
 const { translate } = useTranslate('search')
 
@@ -180,6 +180,12 @@ function handleCancel() {
   emit('cancel', {
     value: inputValue.value
   })
+}
+
+function handleClick() {
+  if (props.disabled) {
+    emit('click')
+  }
 }
 </script>
 <style lang="scss" scoped>


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
- #801

### 💡 需求背景和解决方案

**背景：**
search 组件在 disabled 状态下无法响应点击事件

**解决方案：**
在 `disabled` 状态下补充 `click` 事件的触发能力，用于外层业务感知用户点击行为。
同时补充相关文档说明，并新增禁用态示例 demo 便于理解和使用。

**用法示例：**
```vue
<wd-search disabled @click="handleClick" />
```


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 搜索组件新增 click 事件支持，用户可监听搜索框禁用状态下的点击事件
  * 添加了多语言本地化支持

* **文档**
  * 更新了搜索组件事件文档，新增禁用状态点击事件说明和使用示例

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->