### PR TITLE
docs: ✏️ 修复 swiper 文档中 default 参数类型定义的格式问题

### DIFF
--- a/docs/component/swiper.md
+++ b/docs/component/swiper.md
@@ -405,7 +405,7 @@ const isLoop = ref(false)
 | name      | 说明         | 参数                                 | 最低版本 |
 | --------- | ------------ | ------------------------------------ | -------- |
 | indicator | 自定义指示器 | `{ current: number, total: number }` | 1.13.0   |
-| default   | item展示内容 | `{ item: string | SwiperList, index: number }`       | 1.13.0   |
+| default   | item展示内容 | `{ item: string \| SwiperList, index: number }`       | 1.13.0   |
 
 
 ## 外部样式类

--- a/docs/en-US/component/swiper.md
+++ b/docs/en-US/component/swiper.md
@@ -398,7 +398,7 @@ Carousel item list configuration, including image or video address `value`, vide
 | name      | Description         | Parameters                           | Minimum Version |
 | --------- | ------------------- | ------------------------------------ | --------------- |
 | indicator | Custom indicator    | `{ current: number, total: number }` | 1.13.0          |
-| default   | Item display content | `{ item: string | SwiperList, index: number }`       | 1.13.0          |
+| default   | Item display content | `{ item: string \| SwiperList, index: number }`       | 1.13.0          |
 
 ## External Style Classes
 


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [x] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue


### 💡 需求背景和解决方案


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 修复了文档中类型说明的格式显示问题。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->