### PR TITLE
fix(wd-search): 🐛 修复禁用点击事件失效

### DIFF
--- a/src/subPages/search/Index.vue
+++ b/src/subPages/search/Index.vue
@@ -16,6 +16,7 @@
 
       <demo-block :title="$t('jin-yong-qie-yin-cang-qu-xiao-an-niu')" transparent>
         <wd-search disabled hide-cancel @click="handleDisabledClick" />
+        <wd-search placeholder-left disabled hide-cancel @click="handleDisabledClick" />
       </demo-block>
 
       <view style="margin: 15px 0; color: #666">

--- a/src/uni_modules/wot-design-uni/components/wd-search/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-search/index.scss
@@ -32,11 +32,11 @@
 
     @include when(light) {
       background: $-dark-background4;
-  
+
       .wd-search__block {
         background: $-dark-background7;
       }
-  
+
       .wd-search__cover {
         background: $-dark-background7;
       }
@@ -96,6 +96,16 @@
     justify-content: center;
     align-items: center;
   }
+
+  @include e(disabled-mask) {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+  }
+
   @include edeep(search-icon) {
     margin-right: 8px;
     color: $-search-icon-color;

--- a/src/uni_modules/wot-design-uni/components/wd-search/wd-search.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-search/wd-search.vue
@@ -3,6 +3,7 @@
     <view class="wd-search__block" @click="handleClick">
       <slot name="prefix"></slot>
       <view class="wd-search__field">
+        <view v-if="disabled" class="wd-search__disabled-mask"></view>
         <view v-if="!placeholderLeft" :style="coverStyle" class="wd-search__cover" @click="closeCover">
           <wd-icon name="search" custom-class="wd-search__search-icon"></wd-icon>
           <text :class="`wd-search__placeholder-txt ${placeholderClass}`">{{ placeholder || translate('search') }}</text>


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue


### 💡 需求背景和解决方案
在禁用状态下补充遮罩层来提供禁用状态下点击事件


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 搜索组件在禁用状态下新增遮罩层视觉效果。

* **示例更新**
  * 搜索演示页面新增禁用搜索输入示例。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->