### PR TITLE
wd-select-picker 组件添加附加数据功能，关联 issue #1401

### DIFF
--- a/docs/component/select-picker.md
+++ b/docs/component/select-picker.md
@@ -320,6 +320,41 @@ function handleConfirm({ value, selectedItems }) {
 }
 ```
 
+## 附加数据
+
+通过插槽在显示选项的附加数据。在这个例子中，显示 additional 的数据
+
+```javascript
+const columns3 = ref<Record<string, any>[]>([
+  {
+    value: '101',
+    label: '男装',
+    additional: {
+      mobile: 13800138000,
+      position: 'manager'
+    }
+  },
+  ...
+])
+```
+
+```vue
+<wd-select-picker
+  :label="$t('fu-jia-shu-ju')"
+  type="radio"
+  :show-confirm="false"
+  v-model="value20"
+  :columns="columns3"
+  @confirm="handleConfirm2"
+>
+  <template #addition="{ item }">
+    <wd-tag type="primary" round>{{ item.additional.position }}</wd-tag>
+    <wd-tag icon="phone" type="success" round>{{ item.additional.mobile }}</wd-tag>
+  </template>
+</wd-select-picker>
+
+```
+
 ## Attributes
 
 | 参数 | 说明 | 类型 | 可选值 | 默认值 | 最低版本 |

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -462,6 +462,7 @@
   "form-demo4-title": "Validation Prompt Method",
   "form-title": "Form",
   "fu-gai-shang-chuan": "Overlay upload",
+  "fu-jia-shu-ju": "Additional data",
   "fu-shun": "Fushun",
   "fu-tian-qu": "Futian District",
   "fu-xin": "Fuxin",

--- a/src/locale/zh-CN.json
+++ b/src/locale/zh-CN.json
@@ -463,6 +463,7 @@
   "form-demo4-title": "校验提示方式",
   "form-title": "Form 表单",
   "fu-gai-shang-chuan": "覆盖上传",
+  "fu-jia-shu-ju": "附加数据",
   "fu-shun": "抚顺",
   "fu-tian-qu": "福田区",
   "fu-xin": "阜新",

--- a/src/subPages/selectPicker/Index.vue
+++ b/src/subPages/selectPicker/Index.vue
@@ -54,6 +54,19 @@
           :columns="columns1"
           @confirm="handleConfirm2"
         />
+        <wd-select-picker
+          :label="$t('fu-jia-shu-ju')"
+          type="radio"
+          :show-confirm="false"
+          v-model="value20"
+          :columns="columns3"
+          @confirm="handleConfirm2"
+        >
+          <template #addition="{ item }">
+            <wd-tag type="primary" round>{{ item.additional.position }}</wd-tag>
+            <wd-tag icon="phone" type="success" round>{{ item.additional.mobile }}</wd-tag>
+          </template>
+        </wd-select-picker>
       </wd-cell-group>
     </view>
     <demo-block :title="$t('label-bu-chuan')" transparent>
@@ -147,6 +160,104 @@ const columns2 = ref<Record<string, any>[]>([
   {
     value: '103',
     label: t('nv-zhuang-0')
+  }
+])
+const columns3 = ref<Record<string, any>[]>([
+  {
+    value: '101',
+    label: t('nan-zhuang'),
+    additional: {
+      mobile: 13800138000,
+      position: 'manager'
+    }
+  },
+  {
+    value: '102',
+    label: t('she-chi-pin'),
+    additional: {
+      mobile: 10000,
+      position: 'telecom'
+    }
+  },
+  {
+    value: '103',
+    label: t('nv-zhuang'),
+    additional: {
+      mobile: 10010,
+      position: 'unicom'
+    }
+  },
+  {
+    value: '104',
+    label: t('xie-xue'),
+    additional: {
+      mobile: 10086,
+      position: 'mobile'
+    }
+  },
+  {
+    value: '105',
+    label: t('nei-yi-pei-shi'),
+    additional: {
+      mobile: 110,
+      position: 'police'
+    }
+  },
+  {
+    value: '106',
+    label: t('xiang-bao'),
+    additional: {
+      mobile: 120,
+      position: 'ambulance'
+    }
+  },
+  {
+    value: '107',
+    label: t('mei-zhuang-hu-fu'),
+    additional: {
+      mobile: 510000,
+      position: 'postcode'
+    }
+  },
+  {
+    value: '108',
+    label: t('ge-xing-qing-jie'),
+    additional: {
+      mobile: 13800138000,
+      position: 'staff'
+    }
+  },
+  {
+    value: '109',
+    label: t('zhong-biao-zhu-bao'),
+    additional: {
+      mobile: 13800138000,
+      position: 'manager'
+    }
+  },
+  {
+    value: '110',
+    label: t('shou-ji'),
+    additional: {
+      mobile: 13800138000,
+      position: 'manager'
+    }
+  },
+  {
+    value: '111',
+    label: t('shu-ma'),
+    additional: {
+      mobile: 13800138000,
+      position: 'manager'
+    }
+  },
+  {
+    value: '112',
+    label: t('dian-nao-ban-gong'),
+    additional: {
+      mobile: 13800138000,
+      position: 'manager'
+    }
   }
 ])
 const value1 = ref<string[]>(['101'])

--- a/src/uni_modules/wot-design-uni/components/wd-select-picker/index.scss
+++ b/src/uni_modules/wot-design-uni/components/wd-select-picker/index.scss
@@ -18,6 +18,14 @@
 }
 
 @include b(select-picker) {
+  :deep(.addition) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5em;
+    padding: 0 0.5em;
+    box-sizing: border-box;
+  }
    @include edeep(cell) {
     @include when(disabled) {
       .wd-cell__value {

--- a/src/uni_modules/wot-design-uni/components/wd-select-picker/wd-select-picker.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-select-picker/wd-select-picker.vue
@@ -74,6 +74,9 @@
                 <block v-else>
                   {{ item[labelKey] }}
                 </block>
+                <view class="addition">
+                  <slot name="addition" :item="item" />
+                </view>
               </wd-checkbox>
             </view>
           </wd-checkbox-group>
@@ -91,6 +94,9 @@
                 <block v-else>
                   {{ item[labelKey] }}
                 </block>
+                <view class="addition">
+                  <slot name="addition" :item="item" />
+                </view>
               </wd-radio>
             </view>
           </wd-radio-group>


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [x] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

[[新功能需求] wd-select-picker新增一个插槽，可以自定义列表样式](https://github.com/Moonofweisheng/wot-design-uni/issues/1401)

### 💡 需求背景和解决方案

使用wd-select-picker进行人员选择时，除了显示label以外，还需要显示人员的部门、手机号等信息，通过插槽自定义可以做出自己想要的效果。


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * Select-picker 组件新增 `addition` 插槽功能，支持为选项渲染额外信息。用户现在可以通过该插槽在每个选项中显示自定义附加数据。

* **文档**
  * 新增文档说明 select-picker 组件的附加数据使用方法，包含完整的代码示例。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->