### PR TITLE
fix: 🐛 修复collapse查看更多模式下，初始状态为展开时，无法收起的问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-collapse/wd-collapse.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-collapse/wd-collapse.vue
@@ -83,8 +83,8 @@ watch(
 )
 
 onBeforeMount(() => {
-  const { lineNum, viewmore, modelValue } = props
-  contentLineNum.value = viewmore && !modelValue ? lineNum : 0
+  const { lineNum, viewmore } = props
+  contentLineNum.value = viewmore ? lineNum : 0
 })
 
 function updateChange(activeNames: string | string[] | boolean) {


### PR DESCRIPTION
<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

### 1. 复现
```vue
<template>
  <wd-collapse viewmore v-model="value4">
    这是一条简单的示例文字。这是一条简单的示例文字。这是一条简单的示例文字。这是一条简单的示例文字。这是一条简单的示例文字。这是一条简单的示例文字。这是一条简单的示例文字。这是一条简单的示例文字。
  </wd-collapse>
</template>

<script lang="ts" setup>
import { ref } from 'vue'
const value4 = ref(true)  // 初始展开状态下无法收起
</script>
```
### 2. 解决方案

初始化时不判断 `modelValue`状态，保证初始展开状态下仍可正常进行收起操作。



### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 优化了折叠组件在"查看更多"模式下的内容行数计算逻辑，改进了内容截断行为的准确性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->