### PR TITLE
fix(picker): 修复第一次modalValue值为空，打开面板后直接点击确认按钮，beforeConfirm回调中value参数为空的问题

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-picker/wd-picker.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-picker/wd-picker.vue
@@ -325,8 +325,10 @@ function onConfirm() {
 
   const { beforeConfirm } = props
   if (beforeConfirm && isFunction(beforeConfirm)) {
+    // 获取pickerView中当前最新的值，防止在第一次modelValue值为undefined的时候，用户打开面板不滑动pickerView，直接点击确认按，拿到的pickerValue.value为空
+    const values = pickerViewWd.value!.getValues()
     beforeConfirm(
-      pickerValue.value,
+      values,
       (isPass: boolean) => {
         isPass && handleConfirm()
       },


### PR DESCRIPTION
…为空串的问题

<!--
请务必阅读[贡献指南](https://github.com/Moonofweisheng/wot-design-uni/blob/master/.github/CONTRIBUTING.md)
-->

<!-- (将"[ ]"更新为"[x]"以勾选一个框) -->

### 🤔 这个 PR 的性质是？(至少选择一个)

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] CI/CD 改进
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
### bug复现示例代码
```vue
<script setup lang="ts">
import { ref } from 'vue'

const animalList = ref([
  { label: '狗', value: 'dog' },
  { label: '猫', value: 'cat' },
  { label: '鸟', value: 'bird' },
])
const selectedAnimal = ref()

const beforeConfirm = (value, resolve) => {
  // 这里取不到值
  console.log('beforeConfirm', value)
  resolve(true)
}

const confirm = ({ value, selectedItem }) => {
  // 这里能取到值
  console.log('confirm', value, selectedItem)
}
</script>

<template>
  <view class="root-container">
    <wd-picker
        :before-confirm="beforeConfirm"
        v-model="selectedAnimal"
        :columns="animalList"
        @confirm="confirm"
    />
  </view>
</template>

<style scoped>
.root-container {
  padding: 5rem 2.5rem;
  text-align: center;
}
</style>
```

### bug示例效果

https://github.com/user-attachments/assets/eae25aea-cde0-4220-b9ad-245b2a477513
<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->


### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug修复
* 改进选择器确认逻辑，确保在使用确认前钩子时，能正确获取并传递当前的选择值，修复了初始值未定义场景下的状态同步问题

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->