### PR TITLE
fix: 修复父组件修改值后 wd-input 显示不更新

### DIFF
--- a/src/uni_modules/wot-design-uni/components/wd-input/wd-input.vue
+++ b/src/uni_modules/wot-design-uni/components/wd-input/wd-input.vue
@@ -89,7 +89,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import { computed, ref, watch, useSlots, type Slots } from 'vue'
+import { computed, ref, watch, useSlots, type Slots, nextTick } from 'vue'
 import wdIcon from '../wd-icon/wd-icon.vue'
 import { isDef, objToStyle, pause, isEqual } from '../common/util'
 import { useCell } from '../composables/useCell'
@@ -272,6 +272,15 @@ function handleFocus({ detail }: any) {
 function handleInput({ detail }: any) {
   emit('update:modelValue', inputValue.value)
   emit('input', detail)
+
+  // 等待父组件处理完毕
+  nextTick(() => {
+    // 检查父组件是否修改了值（例如限制小数位、格式化等）
+    const newVal = isDef(props.modelValue) ? String(props.modelValue) : ''
+    if (newVal !== inputValue.value) {
+      inputValue.value = newVal
+    }
+  })
 }
 function handleKeyboardheightchange({ detail }: any) {
   emit('keyboardheightchange', detail)


### PR DESCRIPTION
# Fix: 修复父组件修改值后 wd-input 显示不更新

## 🐛 问题描述

修复 `wd-input` 组件在被二次封装时，当父组件在 `input` 事件中修改值，且修改后的值与之前的 `modelValue` 相同时，输入框显示不更新的问题。

**相关 Issue**: #1458

## 📋 问题原因

当用户输入触发父组件修改值时的执行流程：

1. `wd-input` 的 `v-model` 更新内部 `inputValue` 为用户输入的值
2. 父组件在 `@input` 事件中处理后 `emit` 新值（例如限制小数位）
3. 如果新值与 `props.modelValue` 相同（无变化）
4. `wd-input` 的 `watch` 不会触发（Vue 的 watch 只在值变化时触发）
5. 导致内部 `inputValue` 与 `props.modelValue` 不一致
6. 输入框显示错误的值

**示例场景**：
- 用户输入 `123.456`
- 父组件限制小数位为 2 位，emit `123.45`
- 但 `props.modelValue` 之前就是 `123.45`（无变化）
- `watch` 不触发，输入框仍显示 `123.456`

## 🔧 修改内容

### 1. 添加必要的导入

```typescript
import { computed, ref, watch, useSlots, type Slots, nextTick } from 'vue'
```

### 2. 修改 handleInput 函数（核心修复）

**修改前**：
```typescript
function handleInput({ detail }: any) {
  emit('update:modelValue', inputValue.value)
  emit('input', detail)
}
```

**修改后**：
```typescript
function handleInput({ detail }: any) {
  emit('update:modelValue', inputValue.value)
  emit('input', detail)

  // 等待父组件处理完毕
  nextTick(() => {
    // 检查父组件是否修改了值（例如限制小数位、格式化等）
    const newVal = isDef(props.modelValue) ? String(props.modelValue) : ''
    if (newVal !== inputValue.value) {
      inputValue.value = newVal
    }
  })
}
```

## 💡 技术实现

### 为什么需要 `nextTick`？

`nextTick` 确保在父组件处理完 `update:modelValue` 事件并更新 `props.modelValue` 后再执行检查。这样可以获取到父组件处理后的最新值。

### 为什么不使用 `watch`？

`watch` 只在值变化时触发。当父组件修改后的值与之前的 `modelValue` 相同时，`watch` 不会触发，无法同步 `inputValue`。

### 性能影响

- ✅ 每次 `input` 事件会执行一次 `nextTick`（微任务，性能开销极小）
- ✅ 只有当父组件修改了值时才会更新 `inputValue`
- ✅ 对正常输入场景无影响（不修改值时不执行额外操作）

## 🧪 测试方法

### 测试场景 1: 限制小数位数

```vue
<script setup>
import { ref } from 'vue'

const value = ref('')

function handleInput(e) {
  let val = e.detail.value.replace(/[^\d.]/g, '')
  if (val.includes('.')) {
    const [int, dec] = val.split('.')
    val = dec ? `${int}.${dec.slice(0, 2)}` : `${int}.`
  }
  value.value = val
}
</script>

<template>
  <wd-input v-model="value" @input="handleInput" label="限制2位小数" />
  <view>当前值: {{ value }}</view>
</template>
```

**测试步骤**:
1. 输入 `123.45`
2. 继续输入 `6`，变成 `123.456`
3. 观察输入框显示

**预期结果**: 输入框显示 `123.45`（修复前会显示 `123.456`）

### 测试场景 2: 千分位格式化

**测试步骤**:
1. 输入 `1234`
2. 继续输入 `5`，变成 `12345`
3. 观察输入框显示

**预期结果**: 输入框正确显示格式化后的值

### 测试场景 3: 限制输入范围

**测试步骤**:
1. 设置最大值为 100
2. 输入 `99`
3. 继续输入 `9`，变成 `999`
4. 观察输入框显示

**预期结果**: 输入框显示 `100`（最大值）

### 测试场景 4: 正常输入（无修改）

**测试步骤**:
1. 正常输入任意内容
2. 观察输入框显示

**预期结果**: 输入框显示与输入内容一致（无影响）

## 📊 影响范围

### 受益场景

所有需要在 `input` 事件中对值进行处理的二次封装场景：
- ✅ 限制小数位数
- ✅ 数字格式化（千分位、货币等）
- ✅ 限制输入范围
- ✅ 自定义输入规则
- ✅ 实时校验和修正

### 兼容性

- ✅ 不影响现有的正常使用场景
- ✅ 不影响性能
- ✅ 向后兼容
- ✅ 跨平台兼容（H5、微信小程序、APP）
- ✅ 纯响应式实现，无平台特定代码

## ✅ 检查清单

- [x] 代码已通过 ESLint 检查
- [x] 已在 H5 平台测试
- [x] 已在微信小程序平台测试
- [x] 已在 APP 平台测试

## 🔗 相关链接

- **Issue**: #1458
- **复现 Demo**: https://github.com/Gitzzr/wot-input-bug-demo-clean

## 📝 备注

此修复采用纯响应式方案，通过 `nextTick` 等待父组件处理完毕后同步内部状态，无需直接操作 DOM，确保跨平台兼容性。

